### PR TITLE
Fixes for FStarLang/FStar#1905

### DIFF
--- a/src/lowparse/LowParse.Repr.fst
+++ b/src/lowparse/LowParse.Repr.fst
@@ -542,7 +542,7 @@ let recall_stable_region_repr_ptr #t (r:ST.drgn) (p:stable_region_repr_ptr r t)
 
 private
 let ralloc_and_blit (r:ST.drgn) (src:C.const_buffer LP.byte) (len:U32.t)
-  : ST (b:C.const_buffer LP.byte)
+  : ST (C.const_buffer LP.byte)
     (requires fun h0 ->
       HS.live_region h0 (ST.rid_of_drgn r) /\
       U32.v len == C.length src /\

--- a/src/lowparse/LowParse.Spec.BitSum.fst
+++ b/src/lowparse/LowParse.Spec.BitSum.fst
@@ -1237,7 +1237,7 @@ let if_combinator_weak
 = (cond: bool) ->
   (sv_true: (cond_true cond -> Tot t)) ->
   (sv_false: (cond_false cond -> Tot t)) ->
-  Tot (y: t)
+  Tot t
 
 inline_for_extraction
 noextract

--- a/src/lowparse/LowParse.Spec.DER.fst
+++ b/src/lowparse/LowParse.Spec.DER.fst
@@ -469,7 +469,7 @@ let synth_der_length_129_recip
 let synth_be_int_recip
   (len: nat)
   (x: lint len)
-: GTot (b: Seq.lseq byte len)
+: GTot (Seq.lseq byte len)
 = E.n_to_be len x
 
 let synth_be_int_inverse


### PR DESCRIPTION
This PR fixes spurious uses of names, as described in FStarLang/FStar#1905. F* will reject these names with a syntax error once the fix is merged (waiting on this PR and one in miTLS).