### PR TITLE
C3d: Where clauses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ qd
 tests/unit/*
 !tests/unit/Makefile
 **/out
+.*.swp

--- a/c3d/src/C3d.cpp
+++ b/c3d/src/C3d.cpp
@@ -685,7 +685,7 @@ public:
             switch (State) {
                 case Mid:
                     Out << " && ";
-                    // fall through!
+                    [[fallthrough]];
 
                 case First:
                     Out << "(" << W->getAnnotation().slice(shift, W->getAnnotation().size()) << ")";

--- a/c3d/src/C3d.cpp
+++ b/c3d/src/C3d.cpp
@@ -413,7 +413,7 @@ public:
         State = SeenType;
         return AttributeApplied;
 
-      case SeenType:
+      case SeenType: {
         Expr *ArgExpr = Attr.getArgAsExpr(0);
 
         std::string Str = "c3d_parameter:";
@@ -432,6 +432,11 @@ public:
 
         State = SeenExpr;
         return AttributeApplied;
+     }
+
+     default:
+        LLVM_DEBUG(llvm::dbgs() << "c3d: WARNING default case in handleDeclAttribute\n");
+        return NotHandled;
     }
   }
 };

--- a/c3d/src/C3d.cpp
+++ b/c3d/src/C3d.cpp
@@ -435,9 +435,11 @@ public:
         return AttributeApplied;
      }
 
-     default:
+     default: {
+        /* Silences a GCC warning */
         LLVM_DEBUG(llvm::dbgs() << "c3d: WARNING default case in handleDeclAttribute\n");
         return NotHandled;
+     }
     }
   }
 };

--- a/c3d/src/C3d.cpp
+++ b/c3d/src/C3d.cpp
@@ -214,7 +214,7 @@ public:
     // which case no need to add this field to the scope
     // TODO: this did not work out. Why?
     // LookupResult LR(P->getActions(), D->getIdentifier(), D->getBeginLoc(), Sema::LookupAnyName);
-    // if (LR.getResultKind() != LookupResult::Found) {
+    // if (LR.getResultKind() != LookupResult::Found) { ... }
     Sema &S = P->getActions();
     bool InScope = false;
     // TODO: figure out how to use specific_decl_iterator

--- a/c3d/src/C3d.cpp
+++ b/c3d/src/C3d.cpp
@@ -549,15 +549,16 @@ public:
     // Printing parameters
     enum { BeforeLParen, InArgs } State = BeforeLParen;
     for (const auto& A: Parameters) {
+      const int shift = strlen("c3d_parameter:");
       switch (State) {
         case BeforeLParen:
           Out << " (";
-          Out << A->getAnnotation().slice(14, A->getAnnotation().size());
+          Out << A->getAnnotation().slice(shift, A->getAnnotation().size());
           State = InArgs;
           break;
         case InArgs:
           Out << ", ";
-          Out << A->getAnnotation().slice(14, A->getAnnotation().size());
+          Out << A->getAnnotation().slice(shift, A->getAnnotation().size());
           break;
       }
     }

--- a/c3d/src/Makefile
+++ b/c3d/src/Makefile
@@ -1,0 +1,10 @@
+.PHONY: test
+
+ifeq (${CLANG_BUILD},)
+$(error "Please define $$CLANG_BUILD, it should point to your clang build directory")
+endif
+
+test:
+	make -C out/
+	${CLANG_BUILD}/bin/clang -mllvm -debug-only=c3d -std=c2x -fplugin=./out/C3d.so ../tests/basic0.h
+	cat ../tests/basic0.3d

--- a/c3d/src/Makefile
+++ b/c3d/src/Makefile
@@ -19,10 +19,11 @@ endif
 OURCLANG=${CLANG_BUILD}/bin/clang
 
 # This is the compiler that will be used to compile the plugin
-# itself. It doesn't have to be clang: you can use gcc too, others
-# compiler *may* work too, but we support only clang. You *could*
+# itself. It doesn't have to be clang: you can use gcc too, other
+# compilers *may* work too, but we support only clang. You *could*
 # also point this to ${OURCLANG}, but might be terribly slow if
-# you compiled OURCLANG with debugging enabled.
+# you compiled OURCLANG with debugging enabled. On changing this
+# you should delete out/.
 CC = clang
 
 test: out

--- a/c3d/src/Makefile
+++ b/c3d/src/Makefile
@@ -1,10 +1,26 @@
 .PHONY: test
 
+TESTFILE=../tests/basic0.h
+
 ifeq (${CLANG_BUILD},)
 $(error "Please define $$CLANG_BUILD, it should point to your clang build directory")
 endif
 
-test:
+ifeq ($(OS),Windows_NT)
+	SO = dll
+else
+ifeq ($(uname -s),Darwin)
+	SO = dylib
+else
+	SO = so
+endif
+endif
+
+test: out
 	make -C out/
-	${CLANG_BUILD}/bin/clang -mllvm -debug-only=c3d -std=c2x -fplugin=./out/C3d.so ../tests/basic0.h
-	cat ../tests/basic0.3d
+	${CLANG_BUILD}/bin/clang -mllvm -debug-only=c3d -std=c2x -fplugin=./out/C3d.so ${TESTFILE}
+	cat $(patsubst %.h,%.3d,${TESTFILE})
+
+out:
+	mkdir -p out
+	cd out/ && cmake -D LLVM_BUILD_ROOT=${CLANG_BUILD} ../

--- a/c3d/src/Makefile
+++ b/c3d/src/Makefile
@@ -16,11 +16,23 @@ else
 endif
 endif
 
+OURCLANG=${CLANG_BUILD}/bin/clang
+
+# This is the compiler that will be used to compile the plugin
+# itself. It doesn't have to be clang: you can use gcc too, others
+# compiler *may* work too, but we support only clang. You *could*
+# also point this to ${OURCLANG}, but might be terribly slow if
+# you compiled OURCLANG with debugging enabled.
+CC = clang
+
 test: out
 	make -C out/
-	${CLANG_BUILD}/bin/clang -mllvm -debug-only=c3d -std=c2x -fplugin=./out/C3d.so ${TESTFILE}
+	${OURCLANG} -mllvm -debug-only=c3d -std=c2x -fplugin=./out/C3d.so ${TESTFILE}
 	cat $(patsubst %.h,%.3d,${TESTFILE})
 
 out:
 	mkdir -p out
-	cd out/ && cmake -D LLVM_BUILD_ROOT=${CLANG_BUILD} ../
+	cd out/ && cmake -D LLVM_BUILD_ROOT=${CLANG_BUILD}	\
+		-D CMAKE_C_COMPILER=${CC}			\
+		-D CMAKE_CXX_COMPILER=${CC}			\
+		../

--- a/c3d/tests/basic0.h
+++ b/c3d/tests/basic0.h
@@ -1,9 +1,9 @@
 #include <stdint.h>
 
-typedef uint32_t RNDIS_REQUEST_ID;
+typedef uint32_t FOO_ID;
 
-#define RNDIS_MAJOR_VERSION 0
-#define RNDIS_MINOR_VERSION 0
+#define FOO_MAJOR_VERSION 0
+#define FOO_MINOR_VERSION 0
 
 typedef struct
 [[
@@ -12,13 +12,13 @@ typedef struct
   everparse::parameter(uint32_t MessageBodyLength),
   everparse::where(MessageBodyLength == sizeof(this))
 ]]
-_RNDIS_INITIALIZE_REQUEST {
-  RNDIS_REQUEST_ID RequestId;
+_FOO {
+  FOO_ID RequestId;
   uint32_t MajorVersion
-      [[everparse::constraint(MajorVersion == RNDIS_MAJOR_VERSION && MajorVersion == 0)]];
+      [[everparse::constraint(MajorVersion == FOO_MAJOR_VERSION && MajorVersion == 0)]];
   uint32_t MinorVersion
       [[everparse::constraint(MinorVersion == MajorVersion),
         everparse::constraint(MinorVersion == 1)]];
   uint32_t MaxTransferSize
       [[everparse::constraint(MaxTransferSize <= MessageBodyLength)]];
-} RNDIS_INITIALIZE_REQUEST, *PRNDIS_INITIALIZE_REQUEST;
+} FOO, *PFOO;

--- a/c3d/tests/basic1.h
+++ b/c3d/tests/basic1.h
@@ -5,19 +5,19 @@
 // We start with some auxiliary type definitions.
 typedef int uint32_t;
 
-typedef uint32_t RNDIS_REQUEST_ID;
+typedef uint32_t FOO_ID;
 
 // Note here how the attribute is strategically located after the "struct"
 // keyword to make sure it gets attached to the struct, not to the typedef.
 typedef struct
 [[ everparse::process, everparse::entrypoint ]]
-_RNDIS_INITIALIZE_REQUEST {
+_FOO {
   uint32_t MessageBodyLength
       [[ everparse::ghost_parameter, everparse::constraint(MessageBodyLength == sizeof(this)) ]];
-  RNDIS_REQUEST_ID RequestId;
+  FOO_ID RequestId;
   uint32_t MajorVersion
-      [[ everparse::constraint(MajorVersion == RNDIS_MAJOR_VERSION) ]];
+      [[ everparse::constraint(MajorVersion == FOO_MAJOR_VERSION) ]];
   uint32_t MinorVersion
-      [[ everparse::constraint(MinorVersion == RNDIS_MINOR_VERSION) ]];
+      [[ everparse::constraint(MinorVersion == FOO_MINOR_VERSION) ]];
   uint32_t MaxTransferSize;
-} RNDIS_INITIALIZE_REQUEST, *PRNDIS_INITIALIZE_REQUEST;
+} FOO, *PFOO;

--- a/c3d/tests/basic2.h
+++ b/c3d/tests/basic2.h
@@ -5,7 +5,7 @@
 // We start with some auxiliary type definitions.
 typedef int uint32_t;
 
-typedef uint32_t RNDIS_REQUEST_ID;
+typedef uint32_t FOO_ID;
 
 void f(void) __attribute__((availability(macos,introduced=10.4,deprecated=10.6,obsoleted=10.7)));
 
@@ -13,13 +13,13 @@ void f(void) __attribute__((availability(macos,introduced=10.4,deprecated=10.6,o
 // keyword to make sure it gets attached to the struct, not to the typedef.
 typedef struct
 [[ everparse::process, everparse::entrypoint ]]
-_RNDIS_INITIALIZE_REQUEST {
+_FOO {
   uint32_t MessageBodyLength
       __attribute__(( everparse_constraint(MessageBodyLength == sizeof(this)) ));
-  RNDIS_REQUEST_ID RequestId;
+  FOO_ID RequestId;
   uint32_t MajorVersion
-      [[ everparse::constraint(MajorVersion == RNDIS_MAJOR_VERSION) ]];
+      [[ everparse::constraint(MajorVersion == FOO_MAJOR_VERSION) ]];
   uint32_t MinorVersion
-      [[ everparse::constraint(MinorVersion == RNDIS_MINOR_VERSION) ]];
+      [[ everparse::constraint(MinorVersion == FOO_MINOR_VERSION) ]];
   uint32_t MaxTransferSize;
-} RNDIS_INITIALIZE_REQUEST, *PRNDIS_INITIALIZE_REQUEST;
+} FOO, *PFOO;

--- a/src/3d/ocaml/.gitignore
+++ b/src/3d/ocaml/.gitignore
@@ -1,0 +1,8 @@
+_build/
+Main.native
+**/*.ml
+
+!Batch.ml
+!Hashtable.ml
+!OS.ml
+!ParserDriver.ml


### PR DESCRIPTION
Hi @msprotz, mostly posting this for review. I added support for where clauses mostly mimicking your existing code for parameters. The tricky bit was adding `this` into the parsing context, which I think came out OK (details in commit messages + comments). I haven't yet refactored anything, wanted to check whether the logic seems OK.

For constraints and their scope, I was thinking we could do a similar trick for the scoping: push a new scope before parsing the constraint, push all the previously-parsed fields, and then parse the constraint. That would make the scopes clean, and seems implementable, but would be quadratic--- are we expecting big (~100 field) structures? Ideally we would carry the "ghost" scope while parsing, but seems like that would require clang surgery.

As an example, our good old `basic0.h`:
```cpp
typedef struct
[[
  everparse::entrypoint,
  everparse::process,
  everparse::parameter(uint32_t MessageBodyLength),
  everparse::where(MessageBodyLength == sizeof(this))
]]
_FOO {
  FOO_ID RequestId;
  uint32_t MajorVersion
      [[everparse::constraint(MajorVersion == FOO_MAJOR_VERSION && MajorVersion == 0)]];
  uint32_t MinorVersion
      [[everparse::constraint(MinorVersion == MajorVersion),
        everparse::constraint(MinorVersion == 1)]];
  uint32_t MaxTransferSize
      [[everparse::constraint(MaxTransferSize <= MessageBodyLength)]];
} FOO, *PFOO;
```
Now turns into
```
entrypoint
typedef struct _FOO (uint32_t MessageBodyLength)
where (MessageBodyLength == sizeof (this))
 { 
  FOO_ID RequestId;
  uint32_t MajorVersion { MajorVersion == 0 && MajorVersion == 0 } ;
  uint32_t MinorVersion { (MinorVersion == MajorVersion) && (MinorVersion == 1) } ;
  uint32_t MaxTransferSize { MaxTransferSize <= MessageBodyLength } ;
}
```
The where clause is still interpreted as a string, and printed as-is.