### PR TITLE
RFC: C3d: rework scoping via an internal static vector of variables

### DIFF
--- a/c3d/src/C3d.cpp
+++ b/c3d/src/C3d.cpp
@@ -226,6 +226,10 @@ public:
     NumArgs = 1;
   }
 
+  // TODO: diagAppertainsToDecl ? It is not inherited from C3dDiagOnStruct,
+  // since C3dDiagOnStruct does not inherit from ParsedAttrInfo. It's default
+  // to true, which is fine for now.
+
   AttrHandling parseAttributePayload(Parser *P,
                                      ParsedAttributes &Attrs,
                                      Declarator *D,

--- a/c3d/src/C3d.cpp
+++ b/c3d/src/C3d.cpp
@@ -261,11 +261,12 @@ public:
 
     if (P->getCurToken().getKind() != tok::r_paren)
       return consumeUntilClosingParenAndError(P);
+    SourceLocation RParen = P->getCurToken().getLocation();
     P->SkipUntil(tok::r_paren);
 
     ArgsVector ArgExprs;
     ArgExprs.push_back(E.get());
-    Attrs.addNew(AttrName, AttrNameLoc, ScopeName, ScopeLoc,
+    Attrs.addNew(AttrName, SourceRange(ScopeLoc, RParen), ScopeName, ScopeLoc,
                  ArgExprs.data(), ArgExprs.size(), ParsedAttr::AS_C2x);
 
     return AttributeApplied;

--- a/c3d/tests/basic0.h
+++ b/c3d/tests/basic0.h
@@ -1,17 +1,19 @@
 #include <stdint.h>
 
 typedef uint32_t FOO_ID;
+typedef uint16_t BAR_ID;
 
 #define FOO_MAJOR_VERSION 0
 #define FOO_MINOR_VERSION 0
 
+#define BAR_MAJOR_VERSION 123
+#define BAR_MINOR_VERSION 42
+
 typedef struct
-[[
-  everparse::entrypoint,
-  everparse::process,
-  everparse::parameter(uint32_t MessageBodyLength),
-  everparse::where(MessageBodyLength == sizeof(this))
-]]
+  [[everparse::process(1)]]
+  [[everparse::entrypoint]]
+  [[everparse::parameter(uint32_t MessageBodyLength)]]
+  [[everparse::where(MessageBodyLength == sizeof(this))]]
 _FOO {
   FOO_ID RequestId;
   uint32_t MajorVersion
@@ -22,3 +24,21 @@ _FOO {
   uint32_t MaxTransferSize
       [[everparse::constraint(MaxTransferSize <= MessageBodyLength)]];
 } FOO, *PFOO;
+
+typedef struct
+[[
+  everparse::process(1),
+  everparse::entrypoint,
+  everparse::parameter(uint32_t MessageBodyLength),
+  everparse::where(MessageBodyLength == sizeof(this)),
+]]
+_BAR {
+  BAR_ID RequestId;
+  uint32_t MajorVersion
+      [[everparse::constraint(MajorVersion == BAR_MAJOR_VERSION && MajorVersion == 0)]];
+  uint32_t MinorVersion
+      [[everparse::constraint(MinorVersion == MajorVersion),
+	everparse::constraint(MinorVersion == 1)]];
+  uint32_t MaxTransferSize
+      [[everparse::constraint(MaxTransferSize <= MessageBodyLength)]];
+} BAR, *PBAR;


### PR DESCRIPTION
Hi @msprotz, here's a first attempt at fixing the scoping, but with some issues. Here's the commit message:

--------

The vector just keeps information to create a VarDecl at the time when
we wish to enter the C3d scope. For now, we ony use it in C3dParseExpr
which pushes the C3d scope, parses an expression, and pops the scope.
This fixes the leakage of parameters and field names into the rest of
the program.

Further, note that was actually dangerous since resolution of `sizeof`
happens at this stage. Previously, this struct:

    typedef struct
    [[
      everparse::entrypoint,
      everparse::process,
      everparse::parameter(uint32_t len)
    ]]
    _FOO {
      int arr[sizeof len];
    } FOO;

Was actually outputting:

    typedef struct
    [[
      everparse::entrypoint,
      everparse::process,
      everparse::parameter(uint32_t len)
    ]]
    _FOO {
      int arr[4];
    } FOO;

Which is perfectly valid C, but not what intended: the `len` parameter
should only be visible in everparse:: attributes. Now, we get an unbound
identifier error for `len` in the array size.

Note: this still will not put all struct fields in the scope,
only those with an everparse::constraint attribute. One can use
everparse::constraint(1) as a workaround.

About resetting:
================

We need to clear the scope when switching to process a different struct.
I see two ways to do this:

 1) When *parsing* an everparse::process attribute, we clear the scope.
    Note that doing it at handling time would be too late.

 2) Store a static pointer to the last struct we were handling,
    and detect when a change happened. In that case, clear the scope.

My first try was 1), but then I realized there is not callback into the
plugin for attributes without arguments. I suppose we could add a callback
here, similar to parseAttributePayload, but simpler, to just notify that
it has been parsed. That's another Clang patch of course.

I then attempted 2) but couldn't really make it work. I could not find a
way to get the (partial) declaration that's being parsed. Maybe I missed
it?

So... I went with 1) again after adding an argument to
everparse::process, so I can do the reset on parseAttributePayload. The
argument is totally ignored for now, but could potentially be an on/off
flag. We do have to parse it and register it though, so we see it later
when traversing the AST, which is suboptimal.

See tests/basic0.h too.

Any opinions? I think the extra "heads up" callback might be the way to
go here.
