### PR TITLE
Make the RewriteBuf work... location computations still approximate, that'll do for now

### DIFF
--- a/c3d/src/C3d.cpp
+++ b/c3d/src/C3d.cpp
@@ -388,12 +388,12 @@ public:
     //
     // TODO: submit a patch to clang to allow a plugin-managed opaque_ptr in the
     // storage area of the ParsedAttr
-    Attrs.addNewTypeAttr(AttrName, SourceRange(AttrNameLoc, RParen), ScopeName, ScopeLoc,
+    Attrs.addNewTypeAttr(AttrName, SourceRange(ScopeLoc, RParen), ScopeName, ScopeLoc,
                  PT, ParsedAttr::AS_C2x);
 
     ArgsVector ArgExprs;
     ArgExprs.push_back(ER.get());
-    Attrs.addNew(AttrName, SourceRange(AttrNameLoc, RParen), ScopeName, ScopeLoc,
+    Attrs.addNew(AttrName, SourceRange(ScopeLoc, RParen), ScopeName, ScopeLoc,
                  ArgExprs.data(), ArgExprs.size(), ParsedAttr::AS_C2x);
 
     return AttributeApplied;
@@ -527,7 +527,7 @@ public:
     // We are done: register the ParsedAttr so that we see it later on.
     ArgsVector ArgExprs;
     ArgExprs.push_back(E.get());
-    Attrs.addNew(AttrName, SourceRange(AttrNameLoc, RParen), ScopeName, ScopeLoc,
+    Attrs.addNew(AttrName, SourceRange(ScopeLoc, RParen), ScopeName, ScopeLoc,
                  ArgExprs.data(), ArgExprs.size(), ParsedAttr::AS_C2x);
 
     return AttributeApplied;


### PR DESCRIPTION
See comments. Figured out how to use the Rewrite API to strategically insert comments to disable attribute blocks in the preprocessed header. This solves a bunch of issues in #30, there's of course some things to polish but that should be enough for now.

