### PR TITLE
C3d: supporting unions and enums

### DIFF
--- a/c3d/src/C3d.cpp
+++ b/c3d/src/C3d.cpp
@@ -226,6 +226,10 @@ public:
     NumArgs = 1;
   }
 
+  // TODO: diagAppertainsToDecl ? It is not inherited from C3dDiagOnStruct,
+  // since C3dDiagOnStruct does not inherit from ParsedAttrInfo. It's default
+  // to true, which is fine for now.
+
   AttrHandling parseAttributePayload(Parser *P,
                                      ParsedAttributes &Attrs,
                                      Declarator *D,

--- a/c3d/src/C3d.cpp
+++ b/c3d/src/C3d.cpp
@@ -261,11 +261,12 @@ public:
 
     if (P->getCurToken().getKind() != tok::r_paren)
       return consumeUntilClosingParenAndError(P);
+    SourceLocation RParen = P->getCurToken().getLocation();
     P->SkipUntil(tok::r_paren);
 
     ArgsVector ArgExprs;
     ArgExprs.push_back(E.get());
-    Attrs.addNew(AttrName, AttrNameLoc, ScopeName, ScopeLoc,
+    Attrs.addNew(AttrName, SourceRange(ScopeLoc, RParen), ScopeName, ScopeLoc,
                  ArgExprs.data(), ArgExprs.size(), ParsedAttr::AS_C2x);
 
     return AttributeApplied;

--- a/c3d/tests/basic0.h
+++ b/c3d/tests/basic0.h
@@ -1,17 +1,19 @@
 #include <stdint.h>
 
 typedef uint32_t FOO_ID;
+typedef uint16_t BAR_ID;
 
 #define FOO_MAJOR_VERSION 0
 #define FOO_MINOR_VERSION 0
 
+#define BAR_MAJOR_VERSION 123
+#define BAR_MINOR_VERSION 42
+
 typedef struct
-[[
-  everparse::entrypoint,
-  everparse::process,
-  everparse::parameter(uint32_t MessageBodyLength),
-  everparse::where(MessageBodyLength == sizeof(this))
-]]
+  [[everparse::process(1)]]
+  [[everparse::entrypoint]]
+  [[everparse::parameter(uint32_t MessageBodyLength)]]
+  [[everparse::where(MessageBodyLength == sizeof(this))]]
 _FOO {
   FOO_ID RequestId;
   uint32_t MajorVersion
@@ -22,3 +24,21 @@ _FOO {
   uint32_t MaxTransferSize
       [[everparse::constraint(MaxTransferSize <= MessageBodyLength)]];
 } FOO, *PFOO;
+
+typedef struct
+[[
+  everparse::process(1),
+  everparse::entrypoint,
+  everparse::parameter(uint32_t MessageBodyLength),
+  everparse::where(MessageBodyLength == sizeof(this)),
+]]
+_BAR {
+  BAR_ID RequestId;
+  uint32_t MajorVersion
+      [[everparse::constraint(MajorVersion == BAR_MAJOR_VERSION && MajorVersion == 0)]];
+  uint32_t MinorVersion
+      [[everparse::constraint(MinorVersion == MajorVersion),
+	everparse::constraint(MinorVersion == 1)]];
+  uint32_t MaxTransferSize
+      [[everparse::constraint(MaxTransferSize <= MessageBodyLength)]];
+} BAR, *PBAR;

--- a/c3d/tests/case.h
+++ b/c3d/tests/case.h
@@ -1,0 +1,33 @@
+#include <stdint.h>
+
+enum
+  [[everparse::process(1)]]
+{
+	KIND_INT = 1,
+};
+
+enum
+  [[everparse::process(1)]]
+{
+	KIND_CHAR = 2,
+};
+
+enum
+  [[everparse::process(1)]]
+Enum8 {
+	  Enum8_1 = 0,
+	  Enum8_2,
+	  Enum8_3,
+	  Enum8_100 = 0x64,
+	  Enum8_101 = 101,
+	  Enum8_103,
+	  Enum8_104,
+};
+union
+  [[everparse::process(1)]]
+  [[everparse::entrypoint]]
+  [[everparse::switch(uint32_t kind)]]
+sum {
+	uint32_t i [[everparse::case(KIND_INT)]];
+	uint8_t c [[everparse::case(KIND_CHAR)]];
+};


### PR DESCRIPTION
Here's a first implementation of enums and unions in C3d. Basic idea is:

1- `enum`s with an `everparse::process` attribute get translated, there are no other knobs for them. The 3d source gets all initializers fully spelled out, but that can be disabled (I left an `if (true)` in the source).

2- C unions marked with a `process` **must** have a **single** `everparse::switch` attribute which has a declaration argument (i.e. type + var name). Then, the cases **must** have an `everparse::case` attribute, which has an expression argument representing the label of the casetype branching.

This is based over your RewriteBuf PR and over my scoping PR too. Those two already look good to me,