### PR TITLE
Standalone build of c3d as a separate executable

### DIFF
--- a/c3d/CMakeLists.txt
+++ b/c3d/CMakeLists.txt
@@ -1,0 +1,51 @@
+# General configuration
+# ---------------------
+#
+# Some bits taken from https://github.com/nsumner/clang-plugins-demo/blob/master/CMakeLists.txt
+# The overall idea is that LLVM provides some reusable CMake packages in its
+# build directory, so we just need to include those and we get the benefits of
+# all the proper definitions, etc.
+
+project(c3d)
+cmake_minimum_required(VERSION 3.16)
+
+# TODO: couldn't find how to reuse the flags as picked by the build of LLVM
+# itself
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++14 -fno-rtti -fno-omit-frame-pointer")
+
+# Reusing the LLVM CMake stuff
+# ----------------------------
+#
+# Note: we expect users to invoke cmake -DLLVM_BUILD_DIR=path/to/llvm-project/out
+
+set(CLANG_DIR "${LLVM_BUILD_ROOT}/lib/cmake/clang")
+set(LLVM_DIR "${LLVM_BUILD_ROOT}/lib/cmake/llvm")
+
+list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${CLANG_DIR}")
+
+find_package(LLVM REQUIRED CONFIG HINTS ${LLVM_DIR})
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+find_package(Clang REQUIRED CONFIG HINTS ${CLANG_DIR})
+message(STATUS "Using Clang.cmake in: ${CLANG_DIR}")
+
+# Relies on properly appending the LLVM_DIR to CMAKE_MODULE_PATH!
+include(AddLLVM)
+
+message("LLVM STATUS:
+  Definitions ${LLVM_DEFINITIONS}
+  Includes    ${LLVM_INCLUDE_DIRS}
+              ${CLANG_INCLUDE_DIRS}
+  Libraries   ${LLVM_LIBRARY_DIRS}")
+
+include_directories(SYSTEM ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
+link_directories(${LLVM_LIBRARY_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
+
+set(LLVM_LINK_COMPONENTS Support)
+set(CMAKE_EXPORT_COMPILE_COMMANDS true)
+
+add_subdirectory(src)
+add_subdirectory(driver)

--- a/c3d/driver/CMakeLists.txt
+++ b/c3d/driver/CMakeLists.txt
@@ -7,8 +7,68 @@ add_executable(clang-c3d
   main.cpp)
 
 target_link_libraries(clang-c3d
-  PUBLIC
+  PRIVATE
   C3dCore
+  clangAST
+  clangBasic
+  clangDriver
+  clangFrontend
+  clangIndex
+  clangLex
+  clangSema
+  clangSerialization
   clangTooling
+  clangARCMigrate
+  LLVMX86CodeGen
+  LLVMX86AsmParser
+  LLVMX86Desc
+  LLVMX86Disassembler
+  LLVMX86Info
+  LLVMCore
   LLVMSupport
+  clangFormat
+  clangToolingInclusions
+  clangToolingCore
+  clangFrontend
+  clangDriver
+  LLVMOption
+  clangParse
+  clangSerialization
+  clangSema
+  clangEdit
+  clangRewrite
+  clangAnalysis
+  clangASTMatchers
+  clangAST
+  clangLex
+  clangBasic
+  LLVMFrontendOpenMP
+  LLVMAsmPrinter
+  LLVMDebugInfoDWARF
+  LLVMCFGuard
+  LLVMGlobalISel
+  LLVMSelectionDAG
+  LLVMCodeGen
+  LLVMBitWriter
+  LLVMScalarOpts
+  LLVMAggressiveInstCombine
+  LLVMInstCombine
+  LLVMTransformUtils
+  LLVMTarget
+  LLVMAnalysis
+  LLVMProfileData
+  LLVMObject
+  LLVMBitReader
+  LLVMCore
+  LLVMRemarks
+  LLVMBitstreamReader
+  LLVMTextAPI
+  LLVMMCParser
+  LLVMMCDisassembler
+  LLVMMC
+  LLVMBinaryFormat
+  LLVMDebugInfoCodeView
+  LLVMDebugInfoMSF
+  LLVMSupport
+  LLVMDemangle
 )

--- a/c3d/driver/CMakeLists.txt
+++ b/c3d/driver/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Standalone
+# ----------
+
+include_directories(../src)
+
+add_executable(clang-c3d
+  main.cpp)
+
+target_link_libraries(clang-c3d
+  PUBLIC
+  C3dCore
+  clangTooling
+  LLVMSupport
+)

--- a/c3d/driver/main.cpp
+++ b/c3d/driver/main.cpp
@@ -1,0 +1,33 @@
+#include "clang/Tooling/Tooling.h"
+#include "clang/Frontend/FrontendActions.h"
+#include "clang/Tooling/CommonOptionsParser.h"
+
+#include "C3d.h"
+
+using namespace clang;
+using namespace clang::tooling;
+using namespace c3d;
+
+// A driver for compiling c3d as a standalone tool; good context at
+// https://github.com/eliben/llvm-clang-samples/blob/master/src_clang/tooling_sample.cpp
+class C3dFrontendAction : public ASTFrontendAction {
+public:
+  C3dFrontendAction() {}
+
+  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
+                                                 StringRef file) override {
+    return std::make_unique<C3dASTConsumer>(&CI);
+  }
+};
+
+int main(int argc, const char **argv) {
+  CommonOptionsParser op(argc, argv, llvm::cl::GeneralCategory);
+  ClangTool Tool(op.getCompilations(), op.getSourcePathList());
+
+  // ClangTool::run accepts a FrontendActionFactory, which is then used to
+  // create new objects implementing the FrontendAction interface. Here we use
+  // the helper newFrontendActionFactory to create a default factory that will
+  // return a new MyFrontendAction object every time.
+  // To further customize this, we could create our own factory class.
+  return Tool.run(newFrontendActionFactory<C3dFrontendAction>().get());
+}

--- a/c3d/src/C3d.h
+++ b/c3d/src/C3d.h
@@ -1,0 +1,32 @@
+//===- C3d.h --------------------------------------------------------------===//
+//
+// c3d is a clang plugin that parses everparse annotations as C2x attributes and
+// generates corresponding .3d files, along with a header file stripped of the
+// everparse attributes, which enables further processing by a
+// non-C2x-attributes aware tool.
+//
+// In order to use c3d, invoke clang with -std=c2x
+// -fplugin=path/to/thisplugin.{so,dll,dylib}
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/AST/ASTConsumer.h"
+#include "clang/Frontend/CompilerInstance.h"
+
+using namespace clang;
+
+namespace c3d {
+
+class C3dASTConsumer : public ASTConsumer {
+private:
+  CompilerInstance *CI;
+
+public:
+  explicit C3dASTConsumer(CompilerInstance *CI_)
+    : CI(CI_)
+    { }
+
+  void HandleTranslationUnit(ASTContext &Context) override;
+};
+
+}

--- a/c3d/src/CMakeLists.txt
+++ b/c3d/src/CMakeLists.txt
@@ -5,11 +5,72 @@ add_library(C3dCore C3d.cpp)
 
 add_llvm_library(C3d MODULE C3d.cpp PLUGIN_TOOL clang)
 
-# TODO: I don't understand why, but this causes a segfault on Linux where some
-# global initializer seems to be called twice; try switching PRIVATE for PUBLIC?
+# Library order obtained by running VERBOSE=1 make in LLVM's build directory,
+# then skimming the log to obtain the linker's invocation for
+# libclang.$(SO)
 if(APPLE)
   target_link_libraries(C3d PRIVATE
-    clang
+    clangAST
+    clangBasic
+    clangDriver
+    clangFrontend
+    clangIndex
+    clangLex
+    clangSema
+    clangSerialization
+    clangTooling
+    clangARCMigrate
+    LLVMX86CodeGen
+    LLVMX86AsmParser
+    LLVMX86Desc
+    LLVMX86Disassembler
+    LLVMX86Info
+    LLVMCore
     LLVMSupport
+    clangFormat
+    clangToolingInclusions
+    clangToolingCore
+    clangFrontend
+    clangDriver
+    LLVMOption
+    clangParse
+    clangSerialization
+    clangSema
+    clangEdit
+    clangRewrite
+    clangAnalysis
+    clangASTMatchers
+    clangAST
+    clangLex
+    clangBasic
+    LLVMFrontendOpenMP
+    LLVMAsmPrinter
+    LLVMDebugInfoDWARF
+    LLVMCFGuard
+    LLVMGlobalISel
+    LLVMSelectionDAG
+    LLVMCodeGen
+    LLVMBitWriter
+    LLVMScalarOpts
+    LLVMAggressiveInstCombine
+    LLVMInstCombine
+    LLVMTransformUtils
+    LLVMTarget
+    LLVMAnalysis
+    LLVMProfileData
+    LLVMObject
+    LLVMBitReader
+    LLVMCore
+    LLVMRemarks
+    LLVMBitstreamReader
+    LLVMTextAPI
+    LLVMMCParser
+    LLVMMCDisassembler
+    LLVMMC
+    LLVMBinaryFormat
+    LLVMDebugInfoCodeView
+    LLVMDebugInfoMSF
+    LLVMSupport
+    LLVMDemangle
   )
 endif()

--- a/c3d/src/CMakeLists.txt
+++ b/c3d/src/CMakeLists.txt
@@ -1,58 +1,12 @@
-# General configuration
-# ---------------------
-#
-# Some bits taken from https://github.com/nsumner/clang-plugins-demo/blob/master/CMakeLists.txt
-# The overall idea is that LLVM provides some reusable CMake packages in its
-# build directory, so we just need to include those and we get the benefits of
-# all the proper definitions, etc.
+# Plugin
+# ------
 
-project(c3d)
-cmake_minimum_required(VERSION 3.16)
-
-# TODO: couldn't find how to reuse the flags as picked by the build of LLVM
-# itself
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++14 -fno-rtti -fno-omit-frame-pointer")
-
-# Reusing the LLVM CMake stuff
-# ----------------------------
-#
-# Note: we expect users to invoke cmake -DLLVM_BUILD_DIR=path/to/llvm-project/out
-
-set(CLANG_DIR "${LLVM_BUILD_ROOT}/lib/cmake/clang")
-set(LLVM_DIR "${LLVM_BUILD_ROOT}/lib/cmake/llvm")
-
-list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}")
-list(APPEND CMAKE_MODULE_PATH "${CLANG_DIR}")
-
-find_package(LLVM REQUIRED CONFIG HINTS ${LLVM_DIR})
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
-
-find_package(Clang REQUIRED CONFIG HINTS ${CLANG_DIR})
-message(STATUS "Using Clang.cmake in: ${CLANG_DIR}")
-
-# Relies on properly appending the LLVM_DIR to CMAKE_MODULE_PATH!
-include(AddLLVM)
-
-message("LLVM STATUS:
-  Definitions ${LLVM_DEFINITIONS}
-  Includes    ${LLVM_INCLUDE_DIRS}
-              ${CLANG_INCLUDE_DIRS}
-  Libraries   ${LLVM_LIBRARY_DIRS}")
-
-include_directories(SYSTEM ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS})
-link_directories(${LLVM_LIBRARY_DIRS})
-add_definitions(${LLVM_DEFINITIONS})
-
-# Actual project
-# --------------
+add_library(C3dCore C3d.cpp)
 
 add_llvm_library(C3d MODULE C3d.cpp PLUGIN_TOOL clang)
 
-set(LLVM_LINK_COMPONENTS Support)
-set(CMAKE_EXPORT_COMPILE_COMMANDS true)
 # TODO: I don't understand why, but this causes a segfault on Linux where some
-# global initializer seems to be called twice
+# global initializer seems to be called twice; try switching PRIVATE for PUBLIC?
 if(APPLE)
   target_link_libraries(C3d PRIVATE
     clang


### PR DESCRIPTION
I was able to fix the linking issues and work out the build. This worked on OSX and Linux. Please note that:
- if you have an existing "out" directory, you need to blast it
- from quackyducky/c3d, you now need to do: `mkdir out && cd out && cmake .. -DLLVM_BUILD_ROOT=... && make -j`

@tahina-pro does this change anything regarding the build? 

Thanks!