### PR TITLE
Nik check dep exists

### DIFF
--- a/src/3d/OS.fsti
+++ b/src/3d/OS.fsti
@@ -15,3 +15,6 @@ val remove_extension: string -> Tot string
 (* The extension of the filename, including its leading . *)
 
 val extension: string -> Tot string
+
+
+val file_exists: string -> Tot bool

--- a/src/3d/ocaml/OS.ml
+++ b/src/3d/ocaml/OS.ml
@@ -111,3 +111,5 @@ let rename ol ne =
   copy ol ne;
   Sys.remove ol
 
+
+let file_exists s = Sys.file_exists s


### PR DESCRIPTION
Given 

```
typedef A.t At
```
where A is unbound, this now fails with

```
.\Constants.3d:(15,9): (Error) Dependency not found: A
```