### PR TITLE
Use --load_cmxs option for loading WeakenTac in F* invocations from 3d

### DIFF
--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -4,7 +4,7 @@
     "BaseContainerIsEverestImage" : true,
     "BaseContainerImageName" : "fstar",
     "BaseContainerImageTagOrCommitId": "latest",
-    "BranchName" : "aseem_load_cmxs_option",
+    "BranchName" : "master",
     "GithubCommitUrl" : "https://github.com/FStarLang/FStar/commit",
     "OnDemandBuildDefinition" : "FStar\\FStar-{agentOS}",
 

--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -4,7 +4,7 @@
     "BaseContainerIsEverestImage" : true,
     "BaseContainerImageName" : "fstar",
     "BaseContainerImageTagOrCommitId": "latest",
-    "BranchName" : "master",
+    "BranchName" : "aseem_load_cmxs_option",
     "GithubCommitUrl" : "https://github.com/FStarLang/FStar/commit",
     "OnDemandBuildDefinition" : "FStar\\FStar-{agentOS}",
 

--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -75,7 +75,7 @@ let verify_and_extract_module
     "--odir" :: out_dir ::
       "--cache_dir" :: out_dir ::
         "--include" :: out_dir ::
-          "--load" :: "WeakenTac" ::
+          "--load_cmxs" :: "WeakenTac" ::
             fstar_args0
   in
   let fstar_args_types_fst = list_snoc fstar_args (types_fst_file) in


### PR DESCRIPTION
This would prevent any race conditions in trying to compile WeakenTac in multiple threads. If the cmxs is not found, we will fail hard.