### PR TITLE
Some fixes related to C entry points

### DIFF
--- a/doc/3d-snapshot/BoundedSum.c
+++ b/doc/3d-snapshot/BoundedSum.c
@@ -5,17 +5,17 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define BOUNDEDSUM__LEFT ((uint64_t)1U)
+#define BOUNDEDSUM__BOUNDEDSUM__LEFT ((uint64_t)21U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define BOUNDEDSUM__RIGHT ((uint64_t)2U)
+#define BOUNDEDSUM__BOUNDEDSUM__RIGHT ((uint64_t)22U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define MYSUM__BOUND ((uint64_t)3U)
+#define BOUNDEDSUM_MYSUM__BOUND ((uint64_t)23U)
 
 static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t StartPosition)
 /*++
@@ -35,7 +35,10 @@ static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t Sta
   {
     endPositionOrError = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, BOUNDEDSUM__LEFT);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      BOUNDEDSUM__BOUNDEDSUM__LEFT);
 }
 
 static inline uint64_t
@@ -80,7 +83,10 @@ ValidateBoundedSumRight(
       EverParseCheckConstraintOk(boundedSumRightConstraintIsOk,
         positionAfterBoundedSumRight);
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, BOUNDEDSUM__RIGHT);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      BOUNDEDSUM__BOUNDEDSUM__RIGHT);
 }
 
 uint64_t
@@ -121,7 +127,7 @@ static inline uint64_t ValidateMySumBound(uint32_t InputLength, uint64_t StartPo
   {
     endPositionOrError = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, MYSUM__BOUND);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, BOUNDEDSUM_MYSUM__BOUND);
 }
 
 static inline uint64_t

--- a/doc/3d-snapshot/BoundedSumConst.c
+++ b/doc/3d-snapshot/BoundedSumConst.c
@@ -5,12 +5,12 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define BOUNDEDSUM__LEFT ((uint64_t)1U)
+#define BOUNDEDSUMCONST__BOUNDEDSUM__LEFT ((uint64_t)24U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define BOUNDEDSUM__RIGHT ((uint64_t)2U)
+#define BOUNDEDSUMCONST__BOUNDEDSUM__RIGHT ((uint64_t)25U)
 
 static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t StartPosition)
 /*++
@@ -30,7 +30,10 @@ static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t Sta
   {
     endPositionOrError = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, BOUNDEDSUM__LEFT);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      BOUNDEDSUMCONST__BOUNDEDSUM__LEFT);
 }
 
 static inline uint64_t
@@ -78,7 +81,10 @@ ValidateBoundedSumRight(
       EverParseCheckConstraintOk(boundedSumRightConstraintIsOk,
         positionAfterBoundedSumRight);
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, BOUNDEDSUM__RIGHT);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      BOUNDEDSUMCONST__BOUNDEDSUM__RIGHT);
 }
 
 uint64_t

--- a/doc/3d-snapshot/BoundedSumConstWrapper.c
+++ b/doc/3d-snapshot/BoundedSumConstWrapper.c
@@ -4,16 +4,62 @@
 void BoundedSumConstEverParseError(char *x, char *y, char *z);
 static char* BoundedSumConstStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BoundedSumConst._boundedSum";
-		case 2: return "BoundedSumConst._boundedSum"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair";
+		case 9: return "HelloWorld._point";
+		case 10: return "HelloWorld._point";
+		case 11: return "Triangle2._point";
+		case 12: return "Triangle2._point";
+		case 13: return "Triangle2._triangle";
+		case 14: return "Color._coloredPoint";
+		case 15: return "Color._coloredPoint";
+		case 16: return "Color._coloredPoint";
+		case 17: return "ReadPair._Pair";
+		case 18: return "ReadPair._Pair";
+		case 19: return "GetFieldPtr._T";
+		case 20: return "GetFieldPtr._T";
+		case 21: return "BoundedSum._boundedSum";
+		case 22: return "BoundedSum._boundedSum";
+		case 23: return "BoundedSum.mySum";
+		case 24: return "BoundedSumConst._boundedSum";
+		case 25: return "BoundedSumConst._boundedSum"; 
 		default: return "";
 	}
 }
 
 static char* BoundedSumConstFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "left";
-		case 2: return "right"; 
+		case 1: return "x";
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater";
+		case 9: return "x";
+		case 10: return "y";
+		case 11: return "x";
+		case 12: return "y";
+		case 13: return "corners";
+		case 14: return "col";
+		case 15: return "x";
+		case 16: return "y";
+		case 17: return "first";
+		case 18: return "second";
+		case 19: return "f1";
+		case 20: return "f2";
+		case 21: return "left";
+		case 22: return "right";
+		case 23: return "bound";
+		case 24: return "left";
+		case 25: return "right"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/BoundedSumWhere.c
+++ b/doc/3d-snapshot/BoundedSumWhere.c
@@ -5,17 +5,17 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define BOUNDEDSUM____PRECONDITION ((uint64_t)1U)
+#define BOUNDEDSUMWHERE__BOUNDEDSUM____PRECONDITION ((uint64_t)30U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define BOUNDEDSUM__LEFT ((uint64_t)2U)
+#define BOUNDEDSUMWHERE__BOUNDEDSUM__LEFT ((uint64_t)31U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define BOUNDEDSUM__RIGHT ((uint64_t)3U)
+#define BOUNDEDSUMWHERE__BOUNDEDSUM__RIGHT ((uint64_t)32U)
 
 static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t StartPosition)
 /*++
@@ -35,7 +35,10 @@ static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t Sta
   {
     endPositionOrError = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, BOUNDEDSUM__LEFT);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      BOUNDEDSUMWHERE__BOUNDEDSUM__LEFT);
 }
 
 static inline uint64_t
@@ -80,7 +83,10 @@ ValidateBoundedSumRight(
       EverParseCheckConstraintOk(boundedSumRightConstraintIsOk,
         positionAfterBoundedSumRight);
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, BOUNDEDSUM__RIGHT);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      BOUNDEDSUMWHERE__BOUNDEDSUM__RIGHT);
 }
 
 uint64_t
@@ -98,7 +104,7 @@ BoundedSumWhereValidateBoundedSum(
     EverParseCheckConstraintOkWithFieldId(preconditionConstraintIsOk,
       StartPosition,
       StartPosition,
-      BOUNDEDSUM____PRECONDITION);
+      BOUNDEDSUMWHERE__BOUNDEDSUM____PRECONDITION);
   if (EverParseIsError(positionOrErrorAfterPrecondition))
   {
     return positionOrErrorAfterPrecondition;

--- a/doc/3d-snapshot/BoundedSumWhereWrapper.c
+++ b/doc/3d-snapshot/BoundedSumWhereWrapper.c
@@ -4,18 +4,76 @@
 void BoundedSumWhereEverParseError(char *x, char *y, char *z);
 static char* BoundedSumWhereStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BoundedSumWhere._boundedSum";
-		case 2: return "BoundedSumWhere._boundedSum";
-		case 3: return "BoundedSumWhere._boundedSum"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair";
+		case 9: return "HelloWorld._point";
+		case 10: return "HelloWorld._point";
+		case 11: return "Triangle2._point";
+		case 12: return "Triangle2._point";
+		case 13: return "Triangle2._triangle";
+		case 14: return "Color._coloredPoint";
+		case 15: return "Color._coloredPoint";
+		case 16: return "Color._coloredPoint";
+		case 17: return "ReadPair._Pair";
+		case 18: return "ReadPair._Pair";
+		case 19: return "GetFieldPtr._T";
+		case 20: return "GetFieldPtr._T";
+		case 21: return "BoundedSum._boundedSum";
+		case 22: return "BoundedSum._boundedSum";
+		case 23: return "BoundedSum.mySum";
+		case 24: return "BoundedSumConst._boundedSum";
+		case 25: return "BoundedSumConst._boundedSum";
+		case 26: return "TaggedUnion._int_payload";
+		case 27: return "TaggedUnion._int_payload";
+		case 28: return "TaggedUnion._int_payload";
+		case 29: return "TaggedUnion._integer";
+		case 30: return "BoundedSumWhere._boundedSum";
+		case 31: return "BoundedSumWhere._boundedSum";
+		case 32: return "BoundedSumWhere._boundedSum"; 
 		default: return "";
 	}
 }
 
 static char* BoundedSumWhereFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "__precondition";
-		case 2: return "left";
-		case 3: return "right"; 
+		case 1: return "x";
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater";
+		case 9: return "x";
+		case 10: return "y";
+		case 11: return "x";
+		case 12: return "y";
+		case 13: return "corners";
+		case 14: return "col";
+		case 15: return "x";
+		case 16: return "y";
+		case 17: return "first";
+		case 18: return "second";
+		case 19: return "f1";
+		case 20: return "f2";
+		case 21: return "left";
+		case 22: return "right";
+		case 23: return "bound";
+		case 24: return "left";
+		case 25: return "right";
+		case 26: return "value8";
+		case 27: return "value16";
+		case 28: return "value32";
+		case 29: return "size";
+		case 30: return "__precondition";
+		case 31: return "left";
+		case 32: return "right"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/BoundedSumWrapper.c
+++ b/doc/3d-snapshot/BoundedSumWrapper.c
@@ -4,18 +4,58 @@
 void BoundedSumEverParseError(char *x, char *y, char *z);
 static char* BoundedSumStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BoundedSum._boundedSum";
-		case 2: return "BoundedSum._boundedSum";
-		case 3: return "BoundedSum.mySum"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair";
+		case 9: return "HelloWorld._point";
+		case 10: return "HelloWorld._point";
+		case 11: return "Triangle2._point";
+		case 12: return "Triangle2._point";
+		case 13: return "Triangle2._triangle";
+		case 14: return "Color._coloredPoint";
+		case 15: return "Color._coloredPoint";
+		case 16: return "Color._coloredPoint";
+		case 17: return "ReadPair._Pair";
+		case 18: return "ReadPair._Pair";
+		case 19: return "GetFieldPtr._T";
+		case 20: return "GetFieldPtr._T";
+		case 21: return "BoundedSum._boundedSum";
+		case 22: return "BoundedSum._boundedSum";
+		case 23: return "BoundedSum.mySum"; 
 		default: return "";
 	}
 }
 
 static char* BoundedSumFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "left";
-		case 2: return "right";
-		case 3: return "bound"; 
+		case 1: return "x";
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater";
+		case 9: return "x";
+		case 10: return "y";
+		case 11: return "x";
+		case 12: return "y";
+		case 13: return "corners";
+		case 14: return "col";
+		case 15: return "x";
+		case 16: return "y";
+		case 17: return "first";
+		case 18: return "second";
+		case 19: return "f1";
+		case 20: return "f2";
+		case 21: return "left";
+		case 22: return "right";
+		case 23: return "bound"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/Color.c
+++ b/doc/3d-snapshot/Color.c
@@ -5,17 +5,17 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define COLOREDPOINT__COL ((uint64_t)1U)
+#define COLOR__COLOREDPOINT__COL ((uint64_t)14U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define COLOREDPOINT__X ((uint64_t)2U)
+#define COLOR__COLOREDPOINT__X ((uint64_t)15U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define COLOREDPOINT__Y ((uint64_t)3U)
+#define COLOR__COLOREDPOINT__Y ((uint64_t)16U)
 
 /*
 Enum constant
@@ -68,7 +68,7 @@ ValidateColoredPointCol(uint32_t InputLength, uint8_t *Input, uint64_t StartPosi
 {
   /* Validating field col */
   uint64_t endPositionOrError = ValidateColor(InputLength, Input, StartPosition);
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOREDPOINT__COL);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOR__COLOREDPOINT__COL);
 }
 
 static inline uint64_t ValidateColoredPointX(uint32_t InputLength, uint64_t StartPosition)
@@ -89,7 +89,7 @@ static inline uint64_t ValidateColoredPointX(uint32_t InputLength, uint64_t Star
   {
     endPositionOrError = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOREDPOINT__X);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOR__COLOREDPOINT__X);
 }
 
 static inline uint64_t ValidateColoredPointY(uint32_t InputLength, uint64_t StartPosition)
@@ -110,7 +110,7 @@ static inline uint64_t ValidateColoredPointY(uint32_t InputLength, uint64_t Star
   {
     endPositionOrError = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOREDPOINT__Y);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOR__COLOREDPOINT__Y);
 }
 
 uint64_t ColorValidateColoredPoint(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)

--- a/doc/3d-snapshot/ColorWrapper.c
+++ b/doc/3d-snapshot/ColorWrapper.c
@@ -4,18 +4,44 @@
 void ColorEverParseError(char *x, char *y, char *z);
 static char* ColorStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "Color._coloredPoint";
-		case 2: return "Color._coloredPoint";
-		case 3: return "Color._coloredPoint"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair";
+		case 9: return "HelloWorld._point";
+		case 10: return "HelloWorld._point";
+		case 11: return "Triangle2._point";
+		case 12: return "Triangle2._point";
+		case 13: return "Triangle2._triangle";
+		case 14: return "Color._coloredPoint";
+		case 15: return "Color._coloredPoint";
+		case 16: return "Color._coloredPoint"; 
 		default: return "";
 	}
 }
 
 static char* ColorFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "col";
-		case 2: return "x";
-		case 3: return "y"; 
+		case 1: return "x";
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater";
+		case 9: return "x";
+		case 10: return "y";
+		case 11: return "x";
+		case 12: return "y";
+		case 13: return "corners";
+		case 14: return "col";
+		case 15: return "x";
+		case 16: return "y"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/ColoredPoint.c
+++ b/doc/3d-snapshot/ColoredPoint.c
@@ -5,22 +5,22 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define POINT__X ((uint64_t)1U)
+#define COLOREDPOINT__POINT__X ((uint64_t)1U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define POINT__Y ((uint64_t)2U)
+#define COLOREDPOINT__POINT__Y ((uint64_t)2U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define COLOREDPOINT1__COLOR ((uint64_t)3U)
+#define COLOREDPOINT__COLOREDPOINT1__COLOR ((uint64_t)3U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define COLOREDPOINT2__COLOR ((uint64_t)4U)
+#define COLOREDPOINT__COLOREDPOINT2__COLOR ((uint64_t)4U)
 
 static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPosition)
 /*++
@@ -40,7 +40,7 @@ static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPositi
   {
     endPositionOrError = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, POINT__X);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOREDPOINT__POINT__X);
 }
 
 static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPosition)
@@ -61,7 +61,7 @@ static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPositi
   {
     endPositionOrError = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, POINT__Y);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOREDPOINT__POINT__Y);
 }
 
 static inline uint64_t ValidatePoint(uint32_t Uu, uint64_t StartPosition)
@@ -94,7 +94,10 @@ static inline uint64_t ValidateColoredPoint1Color(uint32_t InputLength, uint64_t
   {
     endPositionOrError = StartPosition + (uint64_t)1U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOREDPOINT1__COLOR);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      COLOREDPOINT__COLOREDPOINT1__COLOR);
 }
 
 static inline uint64_t ValidateColoredPoint1Pt(uint32_t InputLength, uint64_t StartPosition)
@@ -149,7 +152,10 @@ static inline uint64_t ValidateColoredPoint2Color(uint32_t InputLength, uint64_t
   {
     endPositionOrError = StartPosition + (uint64_t)1U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOREDPOINT2__COLOR);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      COLOREDPOINT__COLOREDPOINT2__COLOR);
 }
 
 uint64_t ColoredPointValidateColoredPoint2(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)

--- a/doc/3d-snapshot/GetFieldPtr.c
+++ b/doc/3d-snapshot/GetFieldPtr.c
@@ -5,12 +5,12 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define T__F1 ((uint64_t)1U)
+#define GETFIELDPTR__T__F1 ((uint64_t)19U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define T__F2 ((uint64_t)2U)
+#define GETFIELDPTR__T__F2 ((uint64_t)20U)
 
 static inline uint64_t ValidateTF1(uint32_t InputLength, uint64_t StartPosition)
 /*++
@@ -29,7 +29,7 @@ static inline uint64_t ValidateTF1(uint32_t InputLength, uint64_t StartPosition)
   {
     endPositionOrError = StartPosition + (uint64_t)(uint32_t)(uint8_t)10U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, T__F1);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, GETFIELDPTR__T__F1);
 }
 
 static inline uint64_t
@@ -70,7 +70,7 @@ ValidateTF2(uint8_t **Out, uint32_t InputLength, uint8_t *Input, uint64_t StartP
   {
     endPositionOrError = positionAfterTF2;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, T__F2);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, GETFIELDPTR__T__F2);
 }
 
 uint64_t

--- a/doc/3d-snapshot/GetFieldPtrWrapper.c
+++ b/doc/3d-snapshot/GetFieldPtrWrapper.c
@@ -4,16 +4,52 @@
 void GetFieldPtrEverParseError(char *x, char *y, char *z);
 static char* GetFieldPtrStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "GetFieldPtr._T";
-		case 2: return "GetFieldPtr._T"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair";
+		case 9: return "HelloWorld._point";
+		case 10: return "HelloWorld._point";
+		case 11: return "Triangle2._point";
+		case 12: return "Triangle2._point";
+		case 13: return "Triangle2._triangle";
+		case 14: return "Color._coloredPoint";
+		case 15: return "Color._coloredPoint";
+		case 16: return "Color._coloredPoint";
+		case 17: return "ReadPair._Pair";
+		case 18: return "ReadPair._Pair";
+		case 19: return "GetFieldPtr._T";
+		case 20: return "GetFieldPtr._T"; 
 		default: return "";
 	}
 }
 
 static char* GetFieldPtrFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "f1";
-		case 2: return "f2"; 
+		case 1: return "x";
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater";
+		case 9: return "x";
+		case 10: return "y";
+		case 11: return "x";
+		case 12: return "y";
+		case 13: return "corners";
+		case 14: return "col";
+		case 15: return "x";
+		case 16: return "y";
+		case 17: return "first";
+		case 18: return "second";
+		case 19: return "f1";
+		case 20: return "f2"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/HelloWorld.c
+++ b/doc/3d-snapshot/HelloWorld.c
@@ -5,12 +5,12 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define POINT__X ((uint64_t)1U)
+#define HELLOWORLD__POINT__X ((uint64_t)9U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define POINT__Y ((uint64_t)2U)
+#define HELLOWORLD__POINT__Y ((uint64_t)10U)
 
 static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPosition)
 /*++
@@ -30,7 +30,7 @@ static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPositi
   {
     endPositionOrError = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, POINT__X);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, HELLOWORLD__POINT__X);
 }
 
 static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPosition)
@@ -51,7 +51,7 @@ static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPositi
   {
     endPositionOrError = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, POINT__Y);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, HELLOWORLD__POINT__Y);
 }
 
 uint64_t HelloWorldValidatePoint(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)

--- a/doc/3d-snapshot/HelloWorldWrapper.c
+++ b/doc/3d-snapshot/HelloWorldWrapper.c
@@ -4,8 +4,16 @@
 void HelloWorldEverParseError(char *x, char *y, char *z);
 static char* HelloWorldStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "HelloWorld._point";
-		case 2: return "HelloWorld._point"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair";
+		case 9: return "HelloWorld._point";
+		case 10: return "HelloWorld._point"; 
 		default: return "";
 	}
 }
@@ -13,7 +21,15 @@ static char* HelloWorldStructNameOfErr(uint64_t err) {
 static char* HelloWorldFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
 		case 1: return "x";
-		case 2: return "y"; 
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater";
+		case 9: return "x";
+		case 10: return "y"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/OrderedPair.c
+++ b/doc/3d-snapshot/OrderedPair.c
@@ -5,12 +5,12 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define ORDEREDPAIR__LESSER ((uint64_t)1U)
+#define ORDEREDPAIR__ORDEREDPAIR__LESSER ((uint64_t)7U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define ORDEREDPAIR__GREATER ((uint64_t)2U)
+#define ORDEREDPAIR__ORDEREDPAIR__GREATER ((uint64_t)8U)
 
 static inline uint64_t ValidateOrderedPairLesser(uint32_t InputLength, uint64_t StartPosition)
 /*++
@@ -30,7 +30,10 @@ static inline uint64_t ValidateOrderedPairLesser(uint32_t InputLength, uint64_t 
   {
     endPositionOrError = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, ORDEREDPAIR__LESSER);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      ORDEREDPAIR__ORDEREDPAIR__LESSER);
 }
 
 static inline uint64_t
@@ -74,7 +77,10 @@ ValidateOrderedPairGreater(
       EverParseCheckConstraintOk(orderedPairGreaterConstraintIsOk,
         positionAfterOrderedPairGreater);
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, ORDEREDPAIR__GREATER);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      ORDEREDPAIR__ORDEREDPAIR__GREATER);
 }
 
 uint64_t

--- a/doc/3d-snapshot/OrderedPairWrapper.c
+++ b/doc/3d-snapshot/OrderedPairWrapper.c
@@ -4,16 +4,28 @@
 void OrderedPairEverParseError(char *x, char *y, char *z);
 static char* OrderedPairStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "OrderedPair._orderedPair";
-		case 2: return "OrderedPair._orderedPair"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair"; 
 		default: return "";
 	}
 }
 
 static char* OrderedPairFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "lesser";
-		case 2: return "greater"; 
+		case 1: return "x";
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/ReadPair.c
+++ b/doc/3d-snapshot/ReadPair.c
@@ -5,12 +5,12 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define PAIR__FIRST ((uint64_t)1U)
+#define READPAIR__PAIR__FIRST ((uint64_t)17U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define PAIR__SECOND ((uint64_t)2U)
+#define READPAIR__PAIR__SECOND ((uint64_t)18U)
 
 static inline uint64_t
 ValidatePairFirst(uint32_t *X, uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
@@ -50,7 +50,7 @@ ValidatePairFirst(uint32_t *X, uint32_t InputLength, uint8_t *Input, uint64_t St
       endPositionOrError = EVERPARSE_VALIDATOR_ERROR_ACTION_FAILED;
     }
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, PAIR__FIRST);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, READPAIR__PAIR__FIRST);
 }
 
 static inline uint64_t
@@ -91,7 +91,7 @@ ValidatePairSecond(uint32_t *Y, uint32_t InputLength, uint8_t *Input, uint64_t S
       endPositionOrError = EVERPARSE_VALIDATOR_ERROR_ACTION_FAILED;
     }
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, PAIR__SECOND);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, READPAIR__PAIR__SECOND);
 }
 
 uint64_t

--- a/doc/3d-snapshot/ReadPairWrapper.c
+++ b/doc/3d-snapshot/ReadPairWrapper.c
@@ -4,16 +4,48 @@
 void ReadPairEverParseError(char *x, char *y, char *z);
 static char* ReadPairStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "ReadPair._Pair";
-		case 2: return "ReadPair._Pair"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair";
+		case 9: return "HelloWorld._point";
+		case 10: return "HelloWorld._point";
+		case 11: return "Triangle2._point";
+		case 12: return "Triangle2._point";
+		case 13: return "Triangle2._triangle";
+		case 14: return "Color._coloredPoint";
+		case 15: return "Color._coloredPoint";
+		case 16: return "Color._coloredPoint";
+		case 17: return "ReadPair._Pair";
+		case 18: return "ReadPair._Pair"; 
 		default: return "";
 	}
 }
 
 static char* ReadPairFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "first";
-		case 2: return "second"; 
+		case 1: return "x";
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater";
+		case 9: return "x";
+		case 10: return "y";
+		case 11: return "x";
+		case 12: return "y";
+		case 13: return "corners";
+		case 14: return "col";
+		case 15: return "x";
+		case 16: return "y";
+		case 17: return "first";
+		case 18: return "second"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/Smoker.c
+++ b/doc/3d-snapshot/Smoker.c
@@ -5,12 +5,12 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define SMOKER__AGE ((uint64_t)1U)
+#define SMOKER__SMOKER__AGE ((uint64_t)33U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define SMOKER__CIGARETTESCONSUMED ((uint64_t)2U)
+#define SMOKER__SMOKER__CIGARETTESCONSUMED ((uint64_t)34U)
 
 typedef uint8_t *InputBufferT;
 
@@ -36,7 +36,7 @@ ValidateSmokerCigarettesConsumed(uint32_t InputLength, uint64_t StartPosition)
   return
     EverParseMaybeSetErrorCode(endPositionOrError,
       StartPosition,
-      SMOKER__CIGARETTESCONSUMED);
+      SMOKER__SMOKER__CIGARETTESCONSUMED);
 }
 
 uint64_t SmokerValidateSmoker(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
@@ -53,7 +53,10 @@ uint64_t SmokerValidateSmoker(uint32_t InputLength, uint8_t *Input, uint64_t Sta
     endPositionOrError = StartPosition + (uint64_t)4U;
   }
   uint64_t
-  positionAfterage = EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, SMOKER__AGE);
+  positionAfterage =
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      SMOKER__SMOKER__AGE);
   if (EverParseIsError(positionAfterage))
   {
     return positionAfterage;
@@ -66,7 +69,7 @@ uint64_t SmokerValidateSmoker(uint32_t InputLength, uint8_t *Input, uint64_t Sta
     EverParseCheckConstraintOkWithFieldId(ageConstraintIsOk,
       StartPosition,
       positionAfterage,
-      SMOKER__AGE);
+      SMOKER__SMOKER__AGE);
   if (EverParseIsError(positionOrErrorAfterage))
   {
     return positionOrErrorAfterage;

--- a/doc/3d-snapshot/SmokerWrapper.c
+++ b/doc/3d-snapshot/SmokerWrapper.c
@@ -4,16 +4,80 @@
 void SmokerEverParseError(char *x, char *y, char *z);
 static char* SmokerStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "Smoker._smoker";
-		case 2: return "Smoker._smoker"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair";
+		case 9: return "HelloWorld._point";
+		case 10: return "HelloWorld._point";
+		case 11: return "Triangle2._point";
+		case 12: return "Triangle2._point";
+		case 13: return "Triangle2._triangle";
+		case 14: return "Color._coloredPoint";
+		case 15: return "Color._coloredPoint";
+		case 16: return "Color._coloredPoint";
+		case 17: return "ReadPair._Pair";
+		case 18: return "ReadPair._Pair";
+		case 19: return "GetFieldPtr._T";
+		case 20: return "GetFieldPtr._T";
+		case 21: return "BoundedSum._boundedSum";
+		case 22: return "BoundedSum._boundedSum";
+		case 23: return "BoundedSum.mySum";
+		case 24: return "BoundedSumConst._boundedSum";
+		case 25: return "BoundedSumConst._boundedSum";
+		case 26: return "TaggedUnion._int_payload";
+		case 27: return "TaggedUnion._int_payload";
+		case 28: return "TaggedUnion._int_payload";
+		case 29: return "TaggedUnion._integer";
+		case 30: return "BoundedSumWhere._boundedSum";
+		case 31: return "BoundedSumWhere._boundedSum";
+		case 32: return "BoundedSumWhere._boundedSum";
+		case 33: return "Smoker._smoker";
+		case 34: return "Smoker._smoker"; 
 		default: return "";
 	}
 }
 
 static char* SmokerFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "age";
-		case 2: return "cigarettesConsumed"; 
+		case 1: return "x";
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater";
+		case 9: return "x";
+		case 10: return "y";
+		case 11: return "x";
+		case 12: return "y";
+		case 13: return "corners";
+		case 14: return "col";
+		case 15: return "x";
+		case 16: return "y";
+		case 17: return "first";
+		case 18: return "second";
+		case 19: return "f1";
+		case 20: return "f2";
+		case 21: return "left";
+		case 22: return "right";
+		case 23: return "bound";
+		case 24: return "left";
+		case 25: return "right";
+		case 26: return "value8";
+		case 27: return "value16";
+		case 28: return "value32";
+		case 29: return "size";
+		case 30: return "__precondition";
+		case 31: return "left";
+		case 32: return "right";
+		case 33: return "age";
+		case 34: return "cigarettesConsumed"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/TaggedUnion.c
+++ b/doc/3d-snapshot/TaggedUnion.c
@@ -5,22 +5,22 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define INT_PAYLOAD__VALUE8 ((uint64_t)1U)
+#define TAGGEDUNION__INT_PAYLOAD__VALUE8 ((uint64_t)26U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define INT_PAYLOAD__VALUE16 ((uint64_t)2U)
+#define TAGGEDUNION__INT_PAYLOAD__VALUE16 ((uint64_t)27U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define INT_PAYLOAD__VALUE32 ((uint64_t)3U)
+#define TAGGEDUNION__INT_PAYLOAD__VALUE32 ((uint64_t)28U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define INTEGER__SIZE ((uint64_t)4U)
+#define TAGGEDUNION__INTEGER__SIZE ((uint64_t)29U)
 
 #define SIZE8 ((uint8_t)8U)
 
@@ -46,7 +46,10 @@ static inline uint64_t ValidateIntPayloadValue32(uint32_t InputLength, uint64_t 
   {
     endPositionOrError = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, INT_PAYLOAD__VALUE32);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      TAGGEDUNION__INT_PAYLOAD__VALUE32);
 }
 
 static inline uint64_t ValidateIntPayloadValue16(uint32_t InputLength, uint64_t StartPosition)
@@ -67,7 +70,10 @@ static inline uint64_t ValidateIntPayloadValue16(uint32_t InputLength, uint64_t 
   {
     endPositionOrError = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, INT_PAYLOAD__VALUE16);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      TAGGEDUNION__INT_PAYLOAD__VALUE16);
 }
 
 static inline uint64_t ValidateIntPayloadValue8(uint32_t InputLength, uint64_t StartPosition)
@@ -88,7 +94,10 @@ static inline uint64_t ValidateIntPayloadValue8(uint32_t InputLength, uint64_t S
   {
     endPositionOrError = StartPosition + (uint64_t)1U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, INT_PAYLOAD__VALUE8);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      TAGGEDUNION__INT_PAYLOAD__VALUE8);
 }
 
 static inline uint64_t
@@ -130,7 +139,10 @@ static inline uint64_t ValidateIntegerSize(uint32_t InputLength, uint64_t StartP
   {
     endPositionOrError = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, INTEGER__SIZE);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      TAGGEDUNION__INTEGER__SIZE);
 }
 
 static inline uint64_t

--- a/doc/3d-snapshot/TaggedUnionWrapper.c
+++ b/doc/3d-snapshot/TaggedUnionWrapper.c
@@ -4,20 +4,70 @@
 void TaggedUnionEverParseError(char *x, char *y, char *z);
 static char* TaggedUnionStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "TaggedUnion._int_payload";
-		case 2: return "TaggedUnion._int_payload";
-		case 3: return "TaggedUnion._int_payload";
-		case 4: return "TaggedUnion._integer"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair";
+		case 9: return "HelloWorld._point";
+		case 10: return "HelloWorld._point";
+		case 11: return "Triangle2._point";
+		case 12: return "Triangle2._point";
+		case 13: return "Triangle2._triangle";
+		case 14: return "Color._coloredPoint";
+		case 15: return "Color._coloredPoint";
+		case 16: return "Color._coloredPoint";
+		case 17: return "ReadPair._Pair";
+		case 18: return "ReadPair._Pair";
+		case 19: return "GetFieldPtr._T";
+		case 20: return "GetFieldPtr._T";
+		case 21: return "BoundedSum._boundedSum";
+		case 22: return "BoundedSum._boundedSum";
+		case 23: return "BoundedSum.mySum";
+		case 24: return "BoundedSumConst._boundedSum";
+		case 25: return "BoundedSumConst._boundedSum";
+		case 26: return "TaggedUnion._int_payload";
+		case 27: return "TaggedUnion._int_payload";
+		case 28: return "TaggedUnion._int_payload";
+		case 29: return "TaggedUnion._integer"; 
 		default: return "";
 	}
 }
 
 static char* TaggedUnionFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "value8";
-		case 2: return "value16";
-		case 3: return "value32";
-		case 4: return "size"; 
+		case 1: return "x";
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater";
+		case 9: return "x";
+		case 10: return "y";
+		case 11: return "x";
+		case 12: return "y";
+		case 13: return "corners";
+		case 14: return "col";
+		case 15: return "x";
+		case 16: return "y";
+		case 17: return "first";
+		case 18: return "second";
+		case 19: return "f1";
+		case 20: return "f2";
+		case 21: return "left";
+		case 22: return "right";
+		case 23: return "bound";
+		case 24: return "left";
+		case 25: return "right";
+		case 26: return "value8";
+		case 27: return "value16";
+		case 28: return "value32";
+		case 29: return "size"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/Triangle.c
+++ b/doc/3d-snapshot/Triangle.c
@@ -5,12 +5,12 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define POINT__X ((uint64_t)1U)
+#define TRIANGLE__POINT__X ((uint64_t)5U)
 
 /*
 Auto-generated field identifier for error reporting
 */
-#define POINT__Y ((uint64_t)2U)
+#define TRIANGLE__POINT__Y ((uint64_t)6U)
 
 static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPosition)
 /*++
@@ -30,7 +30,7 @@ static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPositi
   {
     endPositionOrError = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, POINT__X);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, TRIANGLE__POINT__X);
 }
 
 static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPosition)
@@ -51,7 +51,7 @@ static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPositi
   {
     endPositionOrError = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, POINT__Y);
+  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, TRIANGLE__POINT__Y);
 }
 
 static inline uint64_t ValidatePoint(uint32_t Uu, uint64_t StartPosition)

--- a/doc/3d-snapshot/Triangle2.c
+++ b/doc/3d-snapshot/Triangle2.c
@@ -5,7 +5,7 @@
 /*
 Auto-generated field identifier for error reporting
 */
-#define TRIANGLE__CORNERS ((uint64_t)3U)
+#define TRIANGLE2__TRIANGLE__CORNERS ((uint64_t)13U)
 
 static inline uint64_t ValidateTriangleCorners(uint32_t InputLength, uint64_t StartPosition)
 /*++
@@ -31,7 +31,10 @@ static inline uint64_t ValidateTriangleCorners(uint32_t InputLength, uint64_t St
   {
     endPositionOrError = EVERPARSE_VALIDATOR_ERROR_LIST_SIZE_NOT_MULTIPLE;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, TRIANGLE__CORNERS);
+  return
+    EverParseMaybeSetErrorCode(endPositionOrError,
+      StartPosition,
+      TRIANGLE2__TRIANGLE__CORNERS);
 }
 
 uint64_t

--- a/doc/3d-snapshot/Triangle2Wrapper.c
+++ b/doc/3d-snapshot/Triangle2Wrapper.c
@@ -4,9 +4,19 @@
 void Triangle2EverParseError(char *x, char *y, char *z);
 static char* Triangle2StructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "Triangle2._point";
-		case 2: return "Triangle2._point";
-		case 3: return "Triangle2._triangle"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point";
+		case 7: return "OrderedPair._orderedPair";
+		case 8: return "OrderedPair._orderedPair";
+		case 9: return "HelloWorld._point";
+		case 10: return "HelloWorld._point";
+		case 11: return "Triangle2._point";
+		case 12: return "Triangle2._point";
+		case 13: return "Triangle2._triangle"; 
 		default: return "";
 	}
 }
@@ -15,7 +25,17 @@ static char* Triangle2FieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
 		case 1: return "x";
 		case 2: return "y";
-		case 3: return "corners"; 
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y";
+		case 7: return "lesser";
+		case 8: return "greater";
+		case 9: return "x";
+		case 10: return "y";
+		case 11: return "x";
+		case 12: return "y";
+		case 13: return "corners"; 
 		default: return "";
 	}
 }

--- a/doc/3d-snapshot/TriangleWrapper.c
+++ b/doc/3d-snapshot/TriangleWrapper.c
@@ -4,8 +4,12 @@
 void TriangleEverParseError(char *x, char *y, char *z);
 static char* TriangleStructNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "Triangle._point";
-		case 2: return "Triangle._point"; 
+		case 1: return "ColoredPoint._point";
+		case 2: return "ColoredPoint._point";
+		case 3: return "ColoredPoint._coloredPoint1";
+		case 4: return "ColoredPoint._coloredPoint2";
+		case 5: return "Triangle._point";
+		case 6: return "Triangle._point"; 
 		default: return "";
 	}
 }
@@ -13,7 +17,11 @@ static char* TriangleStructNameOfErr(uint64_t err) {
 static char* TriangleFieldNameOfErr(uint64_t err) {
 	switch (EverParseFieldIdOfResult(err)) {
 		case 1: return "x";
-		case 2: return "y"; 
+		case 2: return "y";
+		case 3: return "color";
+		case 4: return "color";
+		case 5: return "x";
+		case 6: return "y"; 
 		default: return "";
 	}
 }

--- a/src/3d/Binding.fst
+++ b/src/3d/Binding.fst
@@ -1232,7 +1232,6 @@ let bind_decl (e:global_env) (d:decl) : ML decl =
     d
 
 let bind_decls (g:global_env) (p:list decl) : ML (list decl & global_env) =
-  let g = { g with ge_fd = mk_field_num_ops () } in
   List.map (bind_decl g) p, g
 
 let next_field_num (enclosing_struct:ident)

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -75,6 +75,12 @@ let print_ident (i:A.ident) =
 let print_maybe_qualified_ident (mname:string) (i:A.ident) =
   Printf.sprintf "%s%s" (maybe_mname_prefix mname i) (print_ident i)
 
+let print_field_id_name (i:A.ident) =
+  let open A in
+  match i.v.modul_name with
+  | None -> failwith "Unexpected: module name missing from the field id"
+  | Some m -> Printf.sprintf "%s_%s" (String.lowercase m) i.v.name
+
 let print_integer_type =
   let open A in
   function
@@ -465,7 +471,7 @@ let rec print_validator (mname:string) (v:validator) : ML string = //(decreases 
     Printf.sprintf "(validate_dep_pair_with_refinement %s \"%s\" %s %s %s %s %s)"
       (if p1_is_constant_size_without_actions then "true" else "false")
       (print_maybe_qualified_ident mname n1)
-      (print_ident f1)
+      (print_field_id_name f1)
       (print_validator mname p1)
       (print_reader mname r)
       (print_expr_lam mname e)
@@ -480,7 +486,7 @@ let rec print_validator (mname:string) (v:validator) : ML string = //(decreases 
     Printf.sprintf "(validate_dep_pair_with_refinement_and_action %s \"%s\" %s %s %s %s %s %s)"
       (if p1_is_constant_size_without_actions then "true" else "false")
       (print_maybe_qualified_ident mname n1)
-      (print_ident f1)
+      (print_field_id_name f1)
       (print_validator mname p1)
       (print_reader mname r)
       (print_expr_lam mname e)
@@ -535,7 +541,7 @@ let rec print_validator (mname:string) (v:validator) : ML string = //(decreases 
       (print_validator mname v2)
   | Validate_impos -> "(validate_impos())"
   | Validate_with_error fn v ->
-    Printf.sprintf "(validate_with_error %s %s)" (print_ident fn) (print_validator mname v)
+    Printf.sprintf "(validate_with_error %s %s)" (print_field_id_name fn) (print_validator mname v)
   | Validate_with_comment v c ->
     let c = String.concat "\n" c in
     Printf.sprintf "(validate_with_comment \"%s\" %s)"
@@ -640,7 +646,7 @@ let print_decl_for_types (mname:string) (d:decl) : ML string =
   | Definition (x, [], T_app ({Ast.v={Ast.name="field_id"}}) _, (Constant c, _)) ->
     Printf.sprintf "[@(CMacro)%s]\nlet %s = %s <: Tot field_id by (FStar.Tactics.trivial())\n\n"
      (print_comments (snd d).comments)
-     (print_ident x)
+     (print_field_id_name x)
      (A.print_constant c)
 
   | Definition (x, [], t, (Constant c, _)) ->

--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -149,13 +149,21 @@ let produce_c_files
                      (fun accu (_, modul) ->
                        let l =
                          filename_concat out_dir (Printf.sprintf "%s.krml" modul) ::
-                           Printf.sprintf "%sWrapper.c" modul ::
-                             filename_concat out_dir (Printf.sprintf "%s_Types.krml" modul) :: accu
+                         filename_concat out_dir (Printf.sprintf "%s_Types.krml" modul) :: accu
                        in
+
+		       let c_wrapper = Printf.sprintf "%sWrapper.c" modul in
+		       let l =
+		         if Sys.file_exists (filename_concat out_dir c_wrapper)
+                         then c_wrapper :: l
+                         else l in			 
+		       
                        let static_asserts = Printf.sprintf "%sStaticAssertions.c" modul in
-                       if Sys.file_exists (filename_concat out_dir static_asserts)
-                       then static_asserts :: l
-                       else l
+                       let l =
+		         if Sys.file_exists (filename_concat out_dir static_asserts)
+                         then static_asserts :: l
+                         else l in
+		       l
                      )
                      all_everparse_krmls
                      files_and_modules


### PR DESCRIPTION
This PR contains two fixes:

* Do not print C wrappers for 3d modules that do not have an entrypoint.
* We do not reset the field error code table across modules now. So, emitted code looks something like (where `Test` depends on `Point` and `TPoint`):

```
TestWrapper.c:

void TestEverParseError(char *x, char *y, char *z);
static char* TestStructNameOfErr(uint64_t err) {
        switch (EverParseFieldIdOfResult(err)) {
                case 1: return "Point._PVT";
                case 2: return "Point._PVT";
                case 3: return "Point._TWO_D_POINT";
                case 4: return "Point._TWO_D_POINT";
                case 5: return "TPoint._THREE_D_POINT";
                case 6: return "Test._CIRCLE";
                case 7: return "Test._T";
                case 8: return "Test._T";
                case 9: return "Test._T";
                default: return "";
        }
}

static char* TestFieldNameOfErr(uint64_t err) {
        switch (EverParseFieldIdOfResult(err)) {
                case 1: return "z";
                case 2: return "w";
                case 3: return "x";
                case 4: return "y";
                case 5: return "z";
                case 6: return "radius";
                case 7: return "f1";
                case 8: return "f2";
                case 9: return "f3";
                default: return "";
        }
}
```
