### PR TITLE
Fine-grained, user-controllable error reporting

### DIFF
--- a/doc/3d-snapshot/BF.c
+++ b/doc/3d-snapshot/BF.c
@@ -2,7 +2,24 @@
 
 #include "BF.h"
 
-static inline uint64_t ValidateDummyEmp(uint64_t StartPosition)
+static inline uint64_t
+ValidateDummyEmp(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _dummy_emp
@@ -10,13 +27,56 @@ static inline uint64_t ValidateDummyEmp(uint64_t StartPosition)
 --*/
 {
   /* Validating field emp */
-  return StartPosition;
+  uint64_t positionAfterDummy = StartPosition;
+  if (EverParseIsSuccess(positionAfterDummy))
+  {
+    return positionAfterDummy;
+  }
+  Err("_dummy",
+    "_dummy_emp",
+    EverParseErrorReasonOfResult(positionAfterDummy),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterDummy);
+  return positionAfterDummy;
 }
 
-uint64_t BfValidateDummy(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+BfValidateDummy(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _dummy_emp */
-  return ValidateDummyEmp(StartPosition);
+  uint64_t positionAfterDummy = ValidateDummyEmp(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterDummy))
+  {
+    return positionAfterDummy;
+  }
+  Err("_dummy",
+    "emp",
+    EverParseErrorReasonOfResult(positionAfterDummy),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterDummy);
+  return positionAfterDummy;
 }
 
 void BfReadDummy(uint32_t InputLength, uint8_t *Input, uint32_t StartPosition)

--- a/doc/3d-snapshot/BF.h
+++ b/doc/3d-snapshot/BF.h
@@ -10,9 +10,26 @@ extern "C" {
 #include "EverParse.h"
 
 
+#include "Lib.h"
 
-
-uint64_t BfValidateDummy(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition);
+uint64_t
+BfValidateDummy(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 void BfReadDummy(uint32_t InputLength, uint8_t *Input, uint32_t StartPosition);
 

--- a/doc/3d-snapshot/BF.h
+++ b/doc/3d-snapshot/BF.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 BfValidateDummy(

--- a/doc/3d-snapshot/BFWrapper.c
+++ b/doc/3d-snapshot/BFWrapper.c
@@ -1,22 +1,22 @@
 #include "BFWrapper.h"
 #include "EverParse.h"
 #include "BF.h"
-void BFEverParseError(char *StructName, char *FieldName, char *Reason);
+void BFEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/BFWrapper.c
+++ b/doc/3d-snapshot/BFWrapper.c
@@ -2,37 +2,49 @@
 #include "EverParse.h"
 #include "BF.h"
 void BFEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* BFStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2"; 
-		default: return "";
-	}
-}
 
-static char* BFFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN BfCheckDummy(uint8_t *base, uint32_t len) {
-	uint64_t result = BfValidateDummy(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		BFEverParseError(
-	BFStructNameOfErr(result),
-			BFFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = BfValidateDummy( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			BFEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/Base.c
+++ b/doc/3d-snapshot/Base.c
@@ -2,28 +2,68 @@
 
 #include "Base.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define BASE__PAIR__FIRST ((uint64_t)7U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define BASE__PAIR__SECOND ((uint64_t)8U)
-
-uint64_t BaseValidateUlong(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+BaseValidateUlong(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterUlong;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    return EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterUlong = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
-  return StartPosition + (uint64_t)4U;
+  else
+  {
+    positionAfterUlong = StartPosition + (uint64_t)4U;
+  }
+  if (EverParseIsSuccess(positionAfterUlong))
+  {
+    return positionAfterUlong;
+  }
+  Err("___ULONG",
+    "",
+    EverParseErrorReasonOfResult(positionAfterUlong),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterUlong);
+  return positionAfterUlong;
 }
 
 static inline uint64_t
-ValidatePairFirst(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidatePairFirst(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _Pair_first
@@ -31,12 +71,40 @@ ValidatePairFirst(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
 --*/
 {
   /* Validating field first */
-  uint64_t endPositionOrError = BaseValidateUlong(InputLength, Input, StartPosition);
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, BASE__PAIR__FIRST);
+  uint64_t positionAfterPair = BaseValidateUlong(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterPair))
+  {
+    return positionAfterPair;
+  }
+  Err("_Pair",
+    "_Pair_first",
+    EverParseErrorReasonOfResult(positionAfterPair),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterPair);
+  return positionAfterPair;
 }
 
 static inline uint64_t
-ValidatePairSecond(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidatePairSecond(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _Pair_second
@@ -44,19 +112,78 @@ ValidatePairSecond(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
 --*/
 {
   /* Validating field second */
-  uint64_t endPositionOrError = BaseValidateUlong(InputLength, Input, StartPosition);
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, BASE__PAIR__SECOND);
+  uint64_t positionAfterPair = BaseValidateUlong(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterPair))
+  {
+    return positionAfterPair;
+  }
+  Err("_Pair",
+    "_Pair_second",
+    EverParseErrorReasonOfResult(positionAfterPair),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterPair);
+  return positionAfterPair;
 }
 
-uint64_t BaseValidatePair(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+BaseValidatePair(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _Pair_first */
-  uint64_t positionAfterfirst = ValidatePairFirst(Uu, Input, StartPosition);
+  uint64_t positionAfterPair = ValidatePairFirst(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterfirst;
+  if (EverParseIsSuccess(positionAfterPair))
+  {
+    positionAfterfirst = positionAfterPair;
+  }
+  else
+  {
+    Err("_Pair",
+      "first",
+      EverParseErrorReasonOfResult(positionAfterPair),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterPair);
+    positionAfterfirst = positionAfterPair;
+  }
   if (EverParseIsError(positionAfterfirst))
   {
     return positionAfterfirst;
   }
   /* Field _Pair_second */
-  return ValidatePairSecond(Uu, Input, positionAfterfirst);
+  uint64_t positionAfterPair0 = ValidatePairSecond(Ctxt, Err, Uu, Input, positionAfterfirst);
+  if (EverParseIsSuccess(positionAfterPair0))
+  {
+    return positionAfterPair0;
+  }
+  Err("_Pair",
+    "second",
+    EverParseErrorReasonOfResult(positionAfterPair0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterfirst,
+    positionAfterPair0);
+  return positionAfterPair0;
 }
 

--- a/doc/3d-snapshot/Base.h
+++ b/doc/3d-snapshot/Base.h
@@ -10,11 +10,45 @@ extern "C" {
 #include "EverParse.h"
 
 
+#include "Lib.h"
 
+uint64_t
+BaseValidateUlong(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
-uint64_t BaseValidateUlong(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition);
-
-uint64_t BaseValidatePair(uint32_t Uu, uint8_t *Input, uint64_t StartPosition);
+uint64_t
+BaseValidatePair(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/Base.h
+++ b/doc/3d-snapshot/Base.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 BaseValidateUlong(

--- a/doc/3d-snapshot/BoundedSum.c
+++ b/doc/3d-snapshot/BoundedSum.c
@@ -2,22 +2,24 @@
 
 #include "BoundedSum.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define BOUNDEDSUM__BOUNDEDSUM__LEFT ((uint64_t)11U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define BOUNDEDSUM__BOUNDEDSUM__RIGHT ((uint64_t)12U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define BOUNDEDSUM_MYSUM__BOUND ((uint64_t)13U)
-
-static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateBoundedSumLeft(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _boundedSum_left
@@ -26,26 +28,47 @@ static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t Sta
 {
   /* SNIPPET_START: boundedSum */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterBoundedSum;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterBoundedSum = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAfterBoundedSum = StartPosition + (uint64_t)4U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      BOUNDEDSUM__BOUNDEDSUM__LEFT);
+  if (EverParseIsSuccess(positionAfterBoundedSum))
+  {
+    return positionAfterBoundedSum;
+  }
+  Err("_boundedSum",
+    "_boundedSum_left",
+    EverParseErrorReasonOfResult(positionAfterBoundedSum),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterBoundedSum);
+  return positionAfterBoundedSum;
 }
 
 static inline uint64_t
 ValidateBoundedSumRight(
   uint32_t Bound,
   uint32_t Left,
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 )
@@ -57,48 +80,103 @@ ValidateBoundedSumRight(
 {
   /* Validating field right */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t positionAfterBoundedSumRight;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterBoundedSum;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    positionAfterBoundedSumRight = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterBoundedSum = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    positionAfterBoundedSumRight = StartPosition + (uint64_t)4U;
+    positionAfterBoundedSum = StartPosition + (uint64_t)4U;
   }
-  uint64_t endPositionOrError;
-  if (EverParseIsError(positionAfterBoundedSumRight))
+  uint64_t positionAfterBoundedSum0;
+  if (EverParseIsSuccess(positionAfterBoundedSum))
   {
-    endPositionOrError = positionAfterBoundedSumRight;
+    positionAfterBoundedSum0 = positionAfterBoundedSum;
+  }
+  else
+  {
+    Err("_boundedSum",
+      "_boundedSum_right",
+      EverParseErrorReasonOfResult(positionAfterBoundedSum),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterBoundedSum);
+    positionAfterBoundedSum0 = positionAfterBoundedSum;
+  }
+  uint64_t positionAfterBoundedSum1;
+  if (EverParseIsError(positionAfterBoundedSum0))
+  {
+    positionAfterBoundedSum1 = positionAfterBoundedSum0;
   }
   else
   {
     /* reading field value */
     uint8_t *base = Input;
-    uint32_t boundedSumRight = Load32Le(base + (uint32_t)StartPosition);
+    uint32_t boundedSum1 = Load32Le(base + (uint32_t)StartPosition);
     /* start: checking constraint */
-    BOOLEAN boundedSumRightConstraintIsOk = Left <= Bound && boundedSumRight <= (Bound - Left);
+    BOOLEAN boundedSumConstraintIsOk = Left <= Bound && boundedSum1 <= (Bound - Left);
     /* end: checking constraint */
-    endPositionOrError =
-      EverParseCheckConstraintOk(boundedSumRightConstraintIsOk,
-        positionAfterBoundedSumRight);
+    positionAfterBoundedSum1 =
+      EverParseCheckConstraintOk(boundedSumConstraintIsOk,
+        positionAfterBoundedSum0);
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      BOUNDEDSUM__BOUNDEDSUM__RIGHT);
+  if (EverParseIsSuccess(positionAfterBoundedSum1))
+  {
+    return positionAfterBoundedSum1;
+  }
+  Err("_boundedSum",
+    "_boundedSum_right.refinement",
+    EverParseErrorReasonOfResult(positionAfterBoundedSum1),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterBoundedSum1);
+  return positionAfterBoundedSum1;
 }
 
 uint64_t
 BoundedSumValidateBoundedSum(
   uint32_t Bound,
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 )
 {
   /* Field _boundedSum_left */
-  uint64_t positionAfterleft = ValidateBoundedSumLeft(InputLength, StartPosition);
+  uint64_t positionAfterBoundedSum = ValidateBoundedSumLeft(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterleft;
+  if (EverParseIsSuccess(positionAfterBoundedSum))
+  {
+    positionAfterleft = positionAfterBoundedSum;
+  }
+  else
+  {
+    Err("_boundedSum",
+      "left",
+      EverParseErrorReasonOfResult(positionAfterBoundedSum),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterBoundedSum);
+    positionAfterleft = positionAfterBoundedSum;
+  }
   if (EverParseIsError(positionAfterleft))
   {
     return positionAfterleft;
@@ -106,10 +184,48 @@ BoundedSumValidateBoundedSum(
   uint8_t *base = Input;
   uint32_t left = Load32Le(base + (uint32_t)StartPosition);
   /* Field _boundedSum_right */
-  return ValidateBoundedSumRight(Bound, left, InputLength, Input, positionAfterleft);
+  uint64_t
+  positionAfterBoundedSum0 =
+    ValidateBoundedSumRight(Bound,
+      left,
+      Ctxt,
+      Err,
+      Uu,
+      Input,
+      positionAfterleft);
+  if (EverParseIsSuccess(positionAfterBoundedSum0))
+  {
+    return positionAfterBoundedSum0;
+  }
+  Err("_boundedSum",
+    "right",
+    EverParseErrorReasonOfResult(positionAfterBoundedSum0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterleft,
+    positionAfterBoundedSum0);
+  return positionAfterBoundedSum0;
 }
 
-static inline uint64_t ValidateMySumBound(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateMySumBound(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field mySum_bound
@@ -118,20 +234,49 @@ static inline uint64_t ValidateMySumBound(uint32_t InputLength, uint64_t StartPo
 {
   /* Validating field bound */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAftermySum;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAftermySum = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAftermySum = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, BOUNDEDSUM_MYSUM__BOUND);
+  if (EverParseIsSuccess(positionAftermySum))
+  {
+    return positionAftermySum;
+  }
+  Err("mySum",
+    "mySum_bound",
+    EverParseErrorReasonOfResult(positionAftermySum),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAftermySum);
+  return positionAftermySum;
 }
 
 static inline uint64_t
-ValidateMySumSum(uint32_t Bound, uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidateMySumSum(
+  uint32_t Bound,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field mySum_sum
@@ -139,13 +284,61 @@ ValidateMySumSum(uint32_t Bound, uint32_t InputLength, uint8_t *Input, uint64_t 
 --*/
 {
   /* Validating field sum */
-  return BoundedSumValidateBoundedSum(Bound, InputLength, Input, StartPosition);
+  uint64_t
+  positionAftermySum = BoundedSumValidateBoundedSum(Bound, Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAftermySum))
+  {
+    return positionAftermySum;
+  }
+  Err("mySum",
+    "mySum_sum",
+    EverParseErrorReasonOfResult(positionAftermySum),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAftermySum);
+  return positionAftermySum;
 }
 
-uint64_t BoundedSumValidateMySum(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+BoundedSumValidateMySum(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field mySum_bound */
-  uint64_t positionAfterbound = ValidateMySumBound(InputLength, StartPosition);
+  uint64_t positionAftermySum = ValidateMySumBound(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterbound;
+  if (EverParseIsSuccess(positionAftermySum))
+  {
+    positionAfterbound = positionAftermySum;
+  }
+  else
+  {
+    Err("mySum",
+      "bound",
+      EverParseErrorReasonOfResult(positionAftermySum),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAftermySum);
+    positionAfterbound = positionAftermySum;
+  }
   if (EverParseIsError(positionAfterbound))
   {
     return positionAfterbound;
@@ -153,6 +346,20 @@ uint64_t BoundedSumValidateMySum(uint32_t InputLength, uint8_t *Input, uint64_t 
   uint8_t *base = Input;
   uint32_t bound = Load32Le(base + (uint32_t)StartPosition);
   /* Field mySum_sum */
-  return ValidateMySumSum(bound, InputLength, Input, positionAfterbound);
+  uint64_t
+  positionAftermySum0 = ValidateMySumSum(bound, Ctxt, Err, Uu, Input, positionAfterbound);
+  if (EverParseIsSuccess(positionAftermySum0))
+  {
+    return positionAftermySum0;
+  }
+  Err("mySum",
+    "sum",
+    EverParseErrorReasonOfResult(positionAftermySum0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterbound,
+    positionAftermySum0);
+  return positionAftermySum0;
 }
 

--- a/doc/3d-snapshot/BoundedSum.h
+++ b/doc/3d-snapshot/BoundedSum.h
@@ -10,17 +10,46 @@ extern "C" {
 #include "EverParse.h"
 
 
-
+#include "Lib.h"
 
 uint64_t
 BoundedSumValidateBoundedSum(
   uint32_t Bound,
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 );
 
-uint64_t BoundedSumValidateMySum(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition);
+uint64_t
+BoundedSumValidateMySum(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/BoundedSum.h
+++ b/doc/3d-snapshot/BoundedSum.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 BoundedSumValidateBoundedSum(

--- a/doc/3d-snapshot/BoundedSumConst.c
+++ b/doc/3d-snapshot/BoundedSumConst.c
@@ -2,17 +2,24 @@
 
 #include "BoundedSumConst.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define BOUNDEDSUMCONST__BOUNDEDSUM__LEFT ((uint64_t)14U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define BOUNDEDSUMCONST__BOUNDEDSUM__RIGHT ((uint64_t)15U)
-
-static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateBoundedSumLeft(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _boundedSum_left
@@ -21,25 +28,46 @@ static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t Sta
 {
   /* SNIPPET_START: boundedSumCorrect */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterBoundedSum;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterBoundedSum = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAfterBoundedSum = StartPosition + (uint64_t)4U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      BOUNDEDSUMCONST__BOUNDEDSUM__LEFT);
+  if (EverParseIsSuccess(positionAfterBoundedSum))
+  {
+    return positionAfterBoundedSum;
+  }
+  Err("_boundedSum",
+    "_boundedSum_left",
+    EverParseErrorReasonOfResult(positionAfterBoundedSum),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterBoundedSum);
+  return positionAfterBoundedSum;
 }
 
 static inline uint64_t
 ValidateBoundedSumRight(
   uint32_t Left,
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 )
@@ -51,44 +79,86 @@ ValidateBoundedSumRight(
 {
   /* Validating field right */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t positionAfterBoundedSumRight;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterBoundedSum;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    positionAfterBoundedSumRight = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterBoundedSum = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    positionAfterBoundedSumRight = StartPosition + (uint64_t)4U;
+    positionAfterBoundedSum = StartPosition + (uint64_t)4U;
   }
-  uint64_t endPositionOrError;
-  if (EverParseIsError(positionAfterBoundedSumRight))
+  uint64_t positionAfterBoundedSum0;
+  if (EverParseIsSuccess(positionAfterBoundedSum))
   {
-    endPositionOrError = positionAfterBoundedSumRight;
+    positionAfterBoundedSum0 = positionAfterBoundedSum;
+  }
+  else
+  {
+    Err("_boundedSum",
+      "_boundedSum_right",
+      EverParseErrorReasonOfResult(positionAfterBoundedSum),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterBoundedSum);
+    positionAfterBoundedSum0 = positionAfterBoundedSum;
+  }
+  uint64_t positionAfterBoundedSum1;
+  if (EverParseIsError(positionAfterBoundedSum0))
+  {
+    positionAfterBoundedSum1 = positionAfterBoundedSum0;
   }
   else
   {
     /* reading field value */
     uint8_t *base = Input;
-    uint32_t boundedSumRight = Load32Le(base + (uint32_t)StartPosition);
+    uint32_t boundedSum1 = Load32Le(base + (uint32_t)StartPosition);
     /* start: checking constraint */
     BOOLEAN
-    boundedSumRightConstraintIsOk =
+    boundedSumConstraintIsOk =
       Left
       <= (uint32_t)(uint8_t)42U
-      && boundedSumRight <= ((uint32_t)(uint8_t)42U - Left);
+      && boundedSum1 <= ((uint32_t)(uint8_t)42U - Left);
     /* end: checking constraint */
-    endPositionOrError =
-      EverParseCheckConstraintOk(boundedSumRightConstraintIsOk,
-        positionAfterBoundedSumRight);
+    positionAfterBoundedSum1 =
+      EverParseCheckConstraintOk(boundedSumConstraintIsOk,
+        positionAfterBoundedSum0);
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      BOUNDEDSUMCONST__BOUNDEDSUM__RIGHT);
+  if (EverParseIsSuccess(positionAfterBoundedSum1))
+  {
+    return positionAfterBoundedSum1;
+  }
+  Err("_boundedSum",
+    "_boundedSum_right.refinement",
+    EverParseErrorReasonOfResult(positionAfterBoundedSum1),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterBoundedSum1);
+  return positionAfterBoundedSum1;
 }
 
 uint64_t
-BoundedSumConstValidateBoundedSum(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+BoundedSumConstValidateBoundedSum(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
  The following will fail because of integer overflow
 // SNIPPET_START: boundedSumNaive
@@ -101,7 +171,24 @@ entrypoint typedef struct _boundedSum {
 --*/
 {
   /* Field _boundedSum_left */
-  uint64_t positionAfterleft = ValidateBoundedSumLeft(InputLength, StartPosition);
+  uint64_t positionAfterBoundedSum = ValidateBoundedSumLeft(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterleft;
+  if (EverParseIsSuccess(positionAfterBoundedSum))
+  {
+    positionAfterleft = positionAfterBoundedSum;
+  }
+  else
+  {
+    Err("_boundedSum",
+      "left",
+      EverParseErrorReasonOfResult(positionAfterBoundedSum),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterBoundedSum);
+    positionAfterleft = positionAfterBoundedSum;
+  }
   if (EverParseIsError(positionAfterleft))
   {
     return positionAfterleft;
@@ -109,6 +196,26 @@ entrypoint typedef struct _boundedSum {
   uint8_t *base = Input;
   uint32_t left = Load32Le(base + (uint32_t)StartPosition);
   /* Field _boundedSum_right */
-  return ValidateBoundedSumRight(left, InputLength, Input, positionAfterleft);
+  uint64_t
+  positionAfterBoundedSum0 =
+    ValidateBoundedSumRight(left,
+      Ctxt,
+      Err,
+      Uu,
+      Input,
+      positionAfterleft);
+  if (EverParseIsSuccess(positionAfterBoundedSum0))
+  {
+    return positionAfterBoundedSum0;
+  }
+  Err("_boundedSum",
+    "right",
+    EverParseErrorReasonOfResult(positionAfterBoundedSum0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterleft,
+    positionAfterBoundedSum0);
+  return positionAfterBoundedSum0;
 }
 

--- a/doc/3d-snapshot/BoundedSumConst.h
+++ b/doc/3d-snapshot/BoundedSumConst.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 /*
  The following will fail because of integer overflow

--- a/doc/3d-snapshot/BoundedSumConst.h
+++ b/doc/3d-snapshot/BoundedSumConst.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-
+#include "Lib.h"
 
 /*
  The following will fail because of integer overflow
@@ -23,7 +23,23 @@ entrypoint typedef struct _boundedSum {
 
 */
 uint64_t
-BoundedSumConstValidateBoundedSum(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition);
+BoundedSumConstValidateBoundedSum(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/BoundedSumConstWrapper.c
+++ b/doc/3d-snapshot/BoundedSumConstWrapper.c
@@ -1,22 +1,22 @@
 #include "BoundedSumConstWrapper.h"
 #include "EverParse.h"
 #include "BoundedSumConst.h"
-void BoundedSumConstEverParseError(char *StructName, char *FieldName, char *Reason);
+void BoundedSumConstEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/BoundedSumConstWrapper.c
+++ b/doc/3d-snapshot/BoundedSumConstWrapper.c
@@ -2,55 +2,49 @@
 #include "EverParse.h"
 #include "BoundedSumConst.h"
 void BoundedSumConstEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* BoundedSumConstStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum"; 
-		default: return "";
-	}
-}
 
-static char* BoundedSumConstFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN BoundedSumConstCheckBoundedSum(uint8_t *base, uint32_t len) {
-	uint64_t result = BoundedSumConstValidateBoundedSum(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		BoundedSumConstEverParseError(
-	BoundedSumConstStructNameOfErr(result),
-			BoundedSumConstFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = BoundedSumConstValidateBoundedSum( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			BoundedSumConstEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/BoundedSumWhere.c
+++ b/doc/3d-snapshot/BoundedSumWhere.c
@@ -2,22 +2,24 @@
 
 #include "BoundedSumWhere.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define BOUNDEDSUMWHERE__BOUNDEDSUM____PRECONDITION ((uint64_t)16U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define BOUNDEDSUMWHERE__BOUNDEDSUM__LEFT ((uint64_t)17U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define BOUNDEDSUMWHERE__BOUNDEDSUM__RIGHT ((uint64_t)18U)
-
-static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateBoundedSumLeft(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _boundedSum_left
@@ -26,26 +28,47 @@ static inline uint64_t ValidateBoundedSumLeft(uint32_t InputLength, uint64_t Sta
 {
   /* Validating field left */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterBoundedSum;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterBoundedSum = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAfterBoundedSum = StartPosition + (uint64_t)4U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      BOUNDEDSUMWHERE__BOUNDEDSUM__LEFT);
+  if (EverParseIsSuccess(positionAfterBoundedSum))
+  {
+    return positionAfterBoundedSum;
+  }
+  Err("_boundedSum",
+    "_boundedSum_left",
+    EverParseErrorReasonOfResult(positionAfterBoundedSum),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterBoundedSum);
+  return positionAfterBoundedSum;
 }
 
 static inline uint64_t
 ValidateBoundedSumRight(
   uint32_t Bound,
   uint32_t Left,
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 )
@@ -57,42 +80,80 @@ ValidateBoundedSumRight(
 {
   /* Validating field right */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t positionAfterBoundedSumRight;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterBoundedSum;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    positionAfterBoundedSumRight = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterBoundedSum = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    positionAfterBoundedSumRight = StartPosition + (uint64_t)4U;
+    positionAfterBoundedSum = StartPosition + (uint64_t)4U;
   }
-  uint64_t endPositionOrError;
-  if (EverParseIsError(positionAfterBoundedSumRight))
+  uint64_t positionAfterBoundedSum0;
+  if (EverParseIsSuccess(positionAfterBoundedSum))
   {
-    endPositionOrError = positionAfterBoundedSumRight;
+    positionAfterBoundedSum0 = positionAfterBoundedSum;
+  }
+  else
+  {
+    Err("_boundedSum",
+      "_boundedSum_right",
+      EverParseErrorReasonOfResult(positionAfterBoundedSum),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterBoundedSum);
+    positionAfterBoundedSum0 = positionAfterBoundedSum;
+  }
+  uint64_t positionAfterBoundedSum1;
+  if (EverParseIsError(positionAfterBoundedSum0))
+  {
+    positionAfterBoundedSum1 = positionAfterBoundedSum0;
   }
   else
   {
     /* reading field value */
     uint8_t *base = Input;
-    uint32_t boundedSumRight = Load32Le(base + (uint32_t)StartPosition);
+    uint32_t boundedSum1 = Load32Le(base + (uint32_t)StartPosition);
     /* start: checking constraint */
-    BOOLEAN boundedSumRightConstraintIsOk = Left <= Bound && boundedSumRight <= (Bound - Left);
+    BOOLEAN boundedSumConstraintIsOk = Left <= Bound && boundedSum1 <= (Bound - Left);
     /* end: checking constraint */
-    endPositionOrError =
-      EverParseCheckConstraintOk(boundedSumRightConstraintIsOk,
-        positionAfterBoundedSumRight);
+    positionAfterBoundedSum1 =
+      EverParseCheckConstraintOk(boundedSumConstraintIsOk,
+        positionAfterBoundedSum0);
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      BOUNDEDSUMWHERE__BOUNDEDSUM__RIGHT);
+  if (EverParseIsSuccess(positionAfterBoundedSum1))
+  {
+    return positionAfterBoundedSum1;
+  }
+  Err("_boundedSum",
+    "_boundedSum_right.refinement",
+    EverParseErrorReasonOfResult(positionAfterBoundedSum1),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterBoundedSum1);
+  return positionAfterBoundedSum1;
 }
 
 uint64_t
 BoundedSumWhereValidateBoundedSum(
   uint32_t Bound,
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 )
@@ -104,14 +165,36 @@ BoundedSumWhereValidateBoundedSum(
     EverParseCheckConstraintOkWithFieldId(preconditionConstraintIsOk,
       StartPosition,
       StartPosition,
-      BOUNDEDSUMWHERE__BOUNDEDSUM____PRECONDITION);
+      (uint64_t)1U);
   if (EverParseIsError(positionOrErrorAfterPrecondition))
   {
     return positionOrErrorAfterPrecondition;
   }
   /* Field _boundedSum_left */
   uint64_t
-  positionAfterleft = ValidateBoundedSumLeft(InputLength, positionOrErrorAfterPrecondition);
+  positionAfterBoundedSum =
+    ValidateBoundedSumLeft(Ctxt,
+      Err,
+      Uu,
+      Input,
+      positionOrErrorAfterPrecondition);
+  uint64_t positionAfterleft;
+  if (EverParseIsSuccess(positionAfterBoundedSum))
+  {
+    positionAfterleft = positionAfterBoundedSum;
+  }
+  else
+  {
+    Err("_boundedSum",
+      "left",
+      EverParseErrorReasonOfResult(positionAfterBoundedSum),
+      Ctxt,
+      Uu,
+      Input,
+      positionOrErrorAfterPrecondition,
+      positionAfterBoundedSum);
+    positionAfterleft = positionAfterBoundedSum;
+  }
   if (EverParseIsError(positionAfterleft))
   {
     return positionAfterleft;
@@ -119,6 +202,27 @@ BoundedSumWhereValidateBoundedSum(
   uint8_t *base = Input;
   uint32_t left = Load32Le(base + (uint32_t)positionOrErrorAfterPrecondition);
   /* Field _boundedSum_right */
-  return ValidateBoundedSumRight(Bound, left, InputLength, Input, positionAfterleft);
+  uint64_t
+  positionAfterBoundedSum0 =
+    ValidateBoundedSumRight(Bound,
+      left,
+      Ctxt,
+      Err,
+      Uu,
+      Input,
+      positionAfterleft);
+  if (EverParseIsSuccess(positionAfterBoundedSum0))
+  {
+    return positionAfterBoundedSum0;
+  }
+  Err("_boundedSum",
+    "right",
+    EverParseErrorReasonOfResult(positionAfterBoundedSum0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterleft,
+    positionAfterBoundedSum0);
+  return positionAfterBoundedSum0;
 }
 

--- a/doc/3d-snapshot/BoundedSumWhere.h
+++ b/doc/3d-snapshot/BoundedSumWhere.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 BoundedSumWhereValidateBoundedSum(

--- a/doc/3d-snapshot/BoundedSumWhere.h
+++ b/doc/3d-snapshot/BoundedSumWhere.h
@@ -10,12 +10,24 @@ extern "C" {
 #include "EverParse.h"
 
 
-
+#include "Lib.h"
 
 uint64_t
 BoundedSumWhereValidateBoundedSum(
   uint32_t Bound,
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 );

--- a/doc/3d-snapshot/BoundedSumWhereWrapper.c
+++ b/doc/3d-snapshot/BoundedSumWhereWrapper.c
@@ -1,22 +1,22 @@
 #include "BoundedSumWhereWrapper.h"
 #include "EverParse.h"
 #include "BoundedSumWhere.h"
-void BoundedSumWhereEverParseError(char *StructName, char *FieldName, char *Reason);
+void BoundedSumWhereEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/BoundedSumWhereWrapper.c
+++ b/doc/3d-snapshot/BoundedSumWhereWrapper.c
@@ -2,61 +2,49 @@
 #include "EverParse.h"
 #include "BoundedSumWhere.h"
 void BoundedSumWhereEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* BoundedSumWhereStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum"; 
-		default: return "";
-	}
-}
 
-static char* BoundedSumWhereFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN BoundedSumWhereCheckBoundedSum(uint32_t bound, uint8_t *base, uint32_t len) {
-	uint64_t result = BoundedSumWhereValidateBoundedSum(bound, len, base, 0);
-	if (EverParseResultIsError(result)) {
-		BoundedSumWhereEverParseError(
-	BoundedSumWhereStructNameOfErr(result),
-			BoundedSumWhereFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = BoundedSumWhereValidateBoundedSum(bound,  (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			BoundedSumWhereEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/BoundedSumWrapper.c
+++ b/doc/3d-snapshot/BoundedSumWrapper.c
@@ -1,22 +1,22 @@
 #include "BoundedSumWrapper.h"
 #include "EverParse.h"
 #include "BoundedSum.h"
-void BoundedSumEverParseError(char *StructName, char *FieldName, char *Reason);
+void BoundedSumEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/BoundedSumWrapper.c
+++ b/doc/3d-snapshot/BoundedSumWrapper.c
@@ -2,63 +2,64 @@
 #include "EverParse.h"
 #include "BoundedSum.h"
 void BoundedSumEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* BoundedSumStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum"; 
-		default: return "";
-	}
-}
 
-static char* BoundedSumFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN BoundedSumCheckBoundedSum(uint32_t bound, uint8_t *base, uint32_t len) {
-	uint64_t result = BoundedSumValidateBoundedSum(bound, len, base, 0);
-	if (EverParseResultIsError(result)) {
-		BoundedSumEverParseError(
-	BoundedSumStructNameOfErr(result),
-			BoundedSumFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = BoundedSumValidateBoundedSum(bound,  (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			BoundedSumEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;
 }
 
 BOOLEAN BoundedSumCheckMySum(uint8_t *base, uint32_t len) {
-	uint64_t result = BoundedSumValidateMySum(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		BoundedSumEverParseError(
-	BoundedSumStructNameOfErr(result),
-			BoundedSumFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = BoundedSumValidateMySum( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			BoundedSumEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/Color.c
+++ b/doc/3d-snapshot/Color.c
@@ -3,21 +3,6 @@
 #include "Color.h"
 
 /*
-Auto-generated field identifier for error reporting
-*/
-#define COLOR__COLOREDPOINT__COL ((uint64_t)19U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define COLOR__COLOREDPOINT__X ((uint64_t)20U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define COLOR__COLOREDPOINT__Y ((uint64_t)21U)
-
-/*
 Enum constant
 */
 #define RED ((uint32_t)1U)
@@ -33,33 +18,99 @@ Enum constant
 #define BLUE ((uint32_t)42U)
 
 static inline uint64_t
-ValidateColor(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidateColor(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t positionAftercolor;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAftercolor0;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    positionAftercolor = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAftercolor0 = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    positionAftercolor = StartPosition + (uint64_t)4U;
+    positionAftercolor0 = StartPosition + (uint64_t)4U;
   }
-  if (EverParseIsError(positionAftercolor))
+  uint64_t positionAftercolor1;
+  if (EverParseIsSuccess(positionAftercolor0))
+  {
+    positionAftercolor1 = positionAftercolor0;
+  }
+  else
+  {
+    Err("color",
+      "",
+      EverParseErrorReasonOfResult(positionAftercolor0),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAftercolor0);
+    positionAftercolor1 = positionAftercolor0;
+  }
+  uint64_t positionAftercolor;
+  if (EverParseIsError(positionAftercolor1))
+  {
+    positionAftercolor = positionAftercolor1;
+  }
+  else
+  {
+    /* reading field value */
+    uint8_t *base = Input;
+    uint32_t color = Load32Le(base + (uint32_t)StartPosition);
+    /* start: checking constraint */
+    BOOLEAN colorConstraintIsOk = color == RED || color == GREEN || color == BLUE || FALSE;
+    /* end: checking constraint */
+    positionAftercolor = EverParseCheckConstraintOk(colorConstraintIsOk, positionAftercolor1);
+  }
+  if (EverParseIsSuccess(positionAftercolor))
   {
     return positionAftercolor;
   }
-  /* reading field value */
-  uint8_t *base = Input;
-  uint32_t color = Load32Le(base + (uint32_t)StartPosition);
-  /* start: checking constraint */
-  BOOLEAN colorConstraintIsOk = color == RED || color == GREEN || color == BLUE || FALSE;
-  /* end: checking constraint */
-  return EverParseCheckConstraintOk(colorConstraintIsOk, positionAftercolor);
+  Err("color",
+    ".refinement",
+    EverParseErrorReasonOfResult(positionAftercolor),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAftercolor);
+  return positionAftercolor;
 }
 
 static inline uint64_t
-ValidateColoredPointCol(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidateColoredPointCol(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _coloredPoint_col
@@ -67,11 +118,40 @@ ValidateColoredPointCol(uint32_t InputLength, uint8_t *Input, uint64_t StartPosi
 --*/
 {
   /* Validating field col */
-  uint64_t endPositionOrError = ValidateColor(InputLength, Input, StartPosition);
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOR__COLOREDPOINT__COL);
+  uint64_t positionAfterColoredPoint = ValidateColor(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterColoredPoint))
+  {
+    return positionAfterColoredPoint;
+  }
+  Err("_coloredPoint",
+    "_coloredPoint_col",
+    EverParseErrorReasonOfResult(positionAfterColoredPoint),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterColoredPoint);
+  return positionAfterColoredPoint;
 }
 
-static inline uint64_t ValidateColoredPointX(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateColoredPointX(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _coloredPoint_x
@@ -80,19 +160,48 @@ static inline uint64_t ValidateColoredPointX(uint32_t InputLength, uint64_t Star
 {
   /* Validating field x */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterColoredPoint;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterColoredPoint = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAfterColoredPoint = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOR__COLOREDPOINT__X);
+  if (EverParseIsSuccess(positionAfterColoredPoint))
+  {
+    return positionAfterColoredPoint;
+  }
+  Err("_coloredPoint",
+    "_coloredPoint_x",
+    EverParseErrorReasonOfResult(positionAfterColoredPoint),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterColoredPoint);
+  return positionAfterColoredPoint;
 }
 
-static inline uint64_t ValidateColoredPointY(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateColoredPointY(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _coloredPoint_y
@@ -101,33 +210,112 @@ static inline uint64_t ValidateColoredPointY(uint32_t InputLength, uint64_t Star
 {
   /* Validating field y */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterColoredPoint;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterColoredPoint = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAfterColoredPoint = StartPosition + (uint64_t)4U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOR__COLOREDPOINT__Y);
+  if (EverParseIsSuccess(positionAfterColoredPoint))
+  {
+    return positionAfterColoredPoint;
+  }
+  Err("_coloredPoint",
+    "_coloredPoint_y",
+    EverParseErrorReasonOfResult(positionAfterColoredPoint),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterColoredPoint);
+  return positionAfterColoredPoint;
 }
 
-uint64_t ColorValidateColoredPoint(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+ColorValidateColoredPoint(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _coloredPoint_col */
-  uint64_t positionAftercol = ValidateColoredPointCol(Uu, Input, StartPosition);
+  uint64_t
+  positionAfterColoredPoint = ValidateColoredPointCol(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAftercol;
+  if (EverParseIsSuccess(positionAfterColoredPoint))
+  {
+    positionAftercol = positionAfterColoredPoint;
+  }
+  else
+  {
+    Err("_coloredPoint",
+      "col",
+      EverParseErrorReasonOfResult(positionAfterColoredPoint),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterColoredPoint);
+    positionAftercol = positionAfterColoredPoint;
+  }
   if (EverParseIsError(positionAftercol))
   {
     return positionAftercol;
   }
   /* Field _coloredPoint_x */
-  uint64_t positionAfterx = ValidateColoredPointX(Uu, positionAftercol);
+  uint64_t
+  positionAfterColoredPoint0 = ValidateColoredPointX(Ctxt, Err, Uu, Input, positionAftercol);
+  uint64_t positionAfterx;
+  if (EverParseIsSuccess(positionAfterColoredPoint0))
+  {
+    positionAfterx = positionAfterColoredPoint0;
+  }
+  else
+  {
+    Err("_coloredPoint",
+      "x",
+      EverParseErrorReasonOfResult(positionAfterColoredPoint0),
+      Ctxt,
+      Uu,
+      Input,
+      positionAftercol,
+      positionAfterColoredPoint0);
+    positionAfterx = positionAfterColoredPoint0;
+  }
   if (EverParseIsError(positionAfterx))
   {
     return positionAfterx;
   }
   /* Field _coloredPoint_y */
-  return ValidateColoredPointY(Uu, positionAfterx);
+  uint64_t
+  positionAfterColoredPoint1 = ValidateColoredPointY(Ctxt, Err, Uu, Input, positionAfterx);
+  if (EverParseIsSuccess(positionAfterColoredPoint1))
+  {
+    return positionAfterColoredPoint1;
+  }
+  Err("_coloredPoint",
+    "y",
+    EverParseErrorReasonOfResult(positionAfterColoredPoint1),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterx,
+    positionAfterColoredPoint1);
+  return positionAfterColoredPoint1;
 }
 

--- a/doc/3d-snapshot/Color.h
+++ b/doc/3d-snapshot/Color.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 ColorValidateColoredPoint(

--- a/doc/3d-snapshot/Color.h
+++ b/doc/3d-snapshot/Color.h
@@ -10,9 +10,26 @@ extern "C" {
 #include "EverParse.h"
 
 
+#include "Lib.h"
 
-
-uint64_t ColorValidateColoredPoint(uint32_t Uu, uint8_t *Input, uint64_t StartPosition);
+uint64_t
+ColorValidateColoredPoint(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/ColorWrapper.c
+++ b/doc/3d-snapshot/ColorWrapper.c
@@ -2,67 +2,49 @@
 #include "EverParse.h"
 #include "Color.h"
 void ColorEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* ColorStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint"; 
-		default: return "";
-	}
-}
 
-static char* ColorFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN ColorCheckColoredPoint(uint8_t *base, uint32_t len) {
-	uint64_t result = ColorValidateColoredPoint(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		ColorEverParseError(
-	ColorStructNameOfErr(result),
-			ColorFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = ColorValidateColoredPoint( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			ColorEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/ColorWrapper.c
+++ b/doc/3d-snapshot/ColorWrapper.c
@@ -1,22 +1,22 @@
 #include "ColorWrapper.h"
 #include "EverParse.h"
 #include "Color.h"
-void ColorEverParseError(char *StructName, char *FieldName, char *Reason);
+void ColorEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/ColoredPoint.c
+++ b/doc/3d-snapshot/ColoredPoint.c
@@ -2,27 +2,24 @@
 
 #include "ColoredPoint.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define COLOREDPOINT__POINT__X ((uint64_t)22U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define COLOREDPOINT__POINT__Y ((uint64_t)23U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define COLOREDPOINT__COLOREDPOINT1__COLOR ((uint64_t)24U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define COLOREDPOINT__COLOREDPOINT2__COLOR ((uint64_t)25U)
-
-static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidatePointX(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _point_x
@@ -31,19 +28,48 @@ static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPositi
 {
   /* Validating field x */
   /* Checking that we have enough space for a UINT16, i.e., 2 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)2U)
+  uint64_t positionAfterPoint;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)2U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterPoint = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)2U;
+    positionAfterPoint = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOREDPOINT__POINT__X);
+  if (EverParseIsSuccess(positionAfterPoint))
+  {
+    return positionAfterPoint;
+  }
+  Err("_point",
+    "_point_x",
+    EverParseErrorReasonOfResult(positionAfterPoint),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterPoint);
+  return positionAfterPoint;
 }
 
-static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidatePointY(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _point_y
@@ -52,31 +78,107 @@ static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPositi
 {
   /* Validating field y */
   /* Checking that we have enough space for a UINT16, i.e., 2 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)2U)
+  uint64_t positionAfterPoint;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)2U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterPoint = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)2U;
+    positionAfterPoint = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, COLOREDPOINT__POINT__Y);
+  if (EverParseIsSuccess(positionAfterPoint))
+  {
+    return positionAfterPoint;
+  }
+  Err("_point",
+    "_point_y",
+    EverParseErrorReasonOfResult(positionAfterPoint),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterPoint);
+  return positionAfterPoint;
 }
 
-static inline uint64_t ValidatePoint(uint32_t Uu, uint64_t StartPosition)
+static inline uint64_t
+ValidatePoint(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _point_x */
-  uint64_t positionAfterx = ValidatePointX(Uu, StartPosition);
+  uint64_t positionAfterPoint = ValidatePointX(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterx;
+  if (EverParseIsSuccess(positionAfterPoint))
+  {
+    positionAfterx = positionAfterPoint;
+  }
+  else
+  {
+    Err("_point",
+      "x",
+      EverParseErrorReasonOfResult(positionAfterPoint),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterPoint);
+    positionAfterx = positionAfterPoint;
+  }
   if (EverParseIsError(positionAfterx))
   {
     return positionAfterx;
   }
   /* Field _point_y */
-  return ValidatePointY(Uu, positionAfterx);
+  uint64_t positionAfterPoint0 = ValidatePointY(Ctxt, Err, Uu, Input, positionAfterx);
+  if (EverParseIsSuccess(positionAfterPoint0))
+  {
+    return positionAfterPoint0;
+  }
+  Err("_point",
+    "y",
+    EverParseErrorReasonOfResult(positionAfterPoint0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterx,
+    positionAfterPoint0);
+  return positionAfterPoint0;
 }
 
-static inline uint64_t ValidateColoredPoint1Color(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateColoredPoint1Color(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _coloredPoint1_color
@@ -85,22 +187,48 @@ static inline uint64_t ValidateColoredPoint1Color(uint32_t InputLength, uint64_t
 {
   /* Validating field color */
   /* Checking that we have enough space for a UINT8, i.e., 1 byte */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)1U)
+  uint64_t positionAfterColoredPoint1;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)1U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterColoredPoint1 = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)1U;
+    positionAfterColoredPoint1 = StartPosition + (uint64_t)1U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      COLOREDPOINT__COLOREDPOINT1__COLOR);
+  if (EverParseIsSuccess(positionAfterColoredPoint1))
+  {
+    return positionAfterColoredPoint1;
+  }
+  Err("_coloredPoint1",
+    "_coloredPoint1_color",
+    EverParseErrorReasonOfResult(positionAfterColoredPoint1),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterColoredPoint1);
+  return positionAfterColoredPoint1;
 }
 
-static inline uint64_t ValidateColoredPoint1Pt(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateColoredPoint1Pt(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _coloredPoint1_pt
@@ -108,22 +236,101 @@ static inline uint64_t ValidateColoredPoint1Pt(uint32_t InputLength, uint64_t St
 --*/
 {
   /* Validating field pt */
-  return ValidatePoint(InputLength, StartPosition);
+  uint64_t positionAfterColoredPoint1 = ValidatePoint(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterColoredPoint1))
+  {
+    return positionAfterColoredPoint1;
+  }
+  Err("_coloredPoint1",
+    "_coloredPoint1_pt",
+    EverParseErrorReasonOfResult(positionAfterColoredPoint1),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterColoredPoint1);
+  return positionAfterColoredPoint1;
 }
 
-uint64_t ColoredPointValidateColoredPoint1(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+ColoredPointValidateColoredPoint1(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _coloredPoint1_color */
-  uint64_t positionAftercolor = ValidateColoredPoint1Color(Uu, StartPosition);
+  uint64_t
+  positionAfterColoredPoint1 = ValidateColoredPoint1Color(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAftercolor;
+  if (EverParseIsSuccess(positionAfterColoredPoint1))
+  {
+    positionAftercolor = positionAfterColoredPoint1;
+  }
+  else
+  {
+    Err("_coloredPoint1",
+      "color",
+      EverParseErrorReasonOfResult(positionAfterColoredPoint1),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterColoredPoint1);
+    positionAftercolor = positionAfterColoredPoint1;
+  }
   if (EverParseIsError(positionAftercolor))
   {
     return positionAftercolor;
   }
   /* Field _coloredPoint1_pt */
-  return ValidateColoredPoint1Pt(Uu, positionAftercolor);
+  uint64_t
+  positionAfterColoredPoint10 = ValidateColoredPoint1Pt(Ctxt, Err, Uu, Input, positionAftercolor);
+  if (EverParseIsSuccess(positionAfterColoredPoint10))
+  {
+    return positionAfterColoredPoint10;
+  }
+  Err("_coloredPoint1",
+    "pt",
+    EverParseErrorReasonOfResult(positionAfterColoredPoint10),
+    Ctxt,
+    Uu,
+    Input,
+    positionAftercolor,
+    positionAfterColoredPoint10);
+  return positionAfterColoredPoint10;
 }
 
-static inline uint64_t ValidateColoredPoint2Pt(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateColoredPoint2Pt(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _coloredPoint2_pt
@@ -131,10 +338,40 @@ static inline uint64_t ValidateColoredPoint2Pt(uint32_t InputLength, uint64_t St
 --*/
 {
   /* Validating field pt */
-  return ValidatePoint(InputLength, StartPosition);
+  uint64_t positionAfterColoredPoint2 = ValidatePoint(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterColoredPoint2))
+  {
+    return positionAfterColoredPoint2;
+  }
+  Err("_coloredPoint2",
+    "_coloredPoint2_pt",
+    EverParseErrorReasonOfResult(positionAfterColoredPoint2),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterColoredPoint2);
+  return positionAfterColoredPoint2;
 }
 
-static inline uint64_t ValidateColoredPoint2Color(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateColoredPoint2Color(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _coloredPoint2_color
@@ -143,30 +380,88 @@ static inline uint64_t ValidateColoredPoint2Color(uint32_t InputLength, uint64_t
 {
   /* Validating field color */
   /* Checking that we have enough space for a UINT8, i.e., 1 byte */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)1U)
+  uint64_t positionAfterColoredPoint2;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)1U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterColoredPoint2 = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)1U;
+    positionAfterColoredPoint2 = StartPosition + (uint64_t)1U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      COLOREDPOINT__COLOREDPOINT2__COLOR);
+  if (EverParseIsSuccess(positionAfterColoredPoint2))
+  {
+    return positionAfterColoredPoint2;
+  }
+  Err("_coloredPoint2",
+    "_coloredPoint2_color",
+    EverParseErrorReasonOfResult(positionAfterColoredPoint2),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterColoredPoint2);
+  return positionAfterColoredPoint2;
 }
 
-uint64_t ColoredPointValidateColoredPoint2(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+ColoredPointValidateColoredPoint2(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _coloredPoint2_pt */
-  uint64_t positionAfterpt = ValidateColoredPoint2Pt(Uu, StartPosition);
+  uint64_t
+  positionAfterColoredPoint2 = ValidateColoredPoint2Pt(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterpt;
+  if (EverParseIsSuccess(positionAfterColoredPoint2))
+  {
+    positionAfterpt = positionAfterColoredPoint2;
+  }
+  else
+  {
+    Err("_coloredPoint2",
+      "pt",
+      EverParseErrorReasonOfResult(positionAfterColoredPoint2),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterColoredPoint2);
+    positionAfterpt = positionAfterColoredPoint2;
+  }
   if (EverParseIsError(positionAfterpt))
   {
     return positionAfterpt;
   }
   /* Field _coloredPoint2_color */
-  return ValidateColoredPoint2Color(Uu, positionAfterpt);
+  uint64_t
+  positionAfterColoredPoint20 = ValidateColoredPoint2Color(Ctxt, Err, Uu, Input, positionAfterpt);
+  if (EverParseIsSuccess(positionAfterColoredPoint20))
+  {
+    return positionAfterColoredPoint20;
+  }
+  Err("_coloredPoint2",
+    "color",
+    EverParseErrorReasonOfResult(positionAfterColoredPoint20),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterpt,
+    positionAfterColoredPoint20);
+  return positionAfterColoredPoint20;
 }
 

--- a/doc/3d-snapshot/ColoredPoint.h
+++ b/doc/3d-snapshot/ColoredPoint.h
@@ -10,13 +10,45 @@ extern "C" {
 #include "EverParse.h"
 
 
-
-
-uint64_t
-ColoredPointValidateColoredPoint1(uint32_t Uu, uint8_t *Input, uint64_t StartPosition);
+#include "Lib.h"
 
 uint64_t
-ColoredPointValidateColoredPoint2(uint32_t Uu, uint8_t *Input, uint64_t StartPosition);
+ColoredPointValidateColoredPoint1(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
+
+uint64_t
+ColoredPointValidateColoredPoint2(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/ColoredPoint.h
+++ b/doc/3d-snapshot/ColoredPoint.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 ColoredPointValidateColoredPoint1(

--- a/doc/3d-snapshot/ColoredPointWrapper.c
+++ b/doc/3d-snapshot/ColoredPointWrapper.c
@@ -2,87 +2,64 @@
 #include "EverParse.h"
 #include "ColoredPoint.h"
 void ColoredPointEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* ColoredPointStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2"; 
-		default: return "";
-	}
-}
 
-static char* ColoredPointFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN ColoredPointCheckColoredPoint1(uint8_t *base, uint32_t len) {
-	uint64_t result = ColoredPointValidateColoredPoint1(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		ColoredPointEverParseError(
-	ColoredPointStructNameOfErr(result),
-			ColoredPointFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = ColoredPointValidateColoredPoint1( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			ColoredPointEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;
 }
 
 BOOLEAN ColoredPointCheckColoredPoint2(uint8_t *base, uint32_t len) {
-	uint64_t result = ColoredPointValidateColoredPoint2(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		ColoredPointEverParseError(
-	ColoredPointStructNameOfErr(result),
-			ColoredPointFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = ColoredPointValidateColoredPoint2( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			ColoredPointEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/ColoredPointWrapper.c
+++ b/doc/3d-snapshot/ColoredPointWrapper.c
@@ -1,22 +1,22 @@
 #include "ColoredPointWrapper.h"
 #include "EverParse.h"
 #include "ColoredPoint.h"
-void ColoredPointEverParseError(char *StructName, char *FieldName, char *Reason);
+void ColoredPointEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/Derived.c
+++ b/doc/3d-snapshot/Derived.c
@@ -2,13 +2,24 @@
 
 #include "Derived.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define DERIVED__TRIPLE__THIRD ((uint64_t)26U)
-
 static inline uint64_t
-ValidateTriplePair(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidateTriplePair(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _Triple_pair
@@ -16,11 +27,40 @@ ValidateTriplePair(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
 --*/
 {
   /* SNIPPET_START: Triple */
-  return BaseValidatePair(InputLength, Input, StartPosition);
+  uint64_t positionAfterTriple = BaseValidatePair(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterTriple))
+  {
+    return positionAfterTriple;
+  }
+  Err("_Triple",
+    "_Triple_pair",
+    EverParseErrorReasonOfResult(positionAfterTriple),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterTriple);
+  return positionAfterTriple;
 }
 
 static inline uint64_t
-ValidateTripleThird(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidateTripleThird(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _Triple_third
@@ -28,24 +68,99 @@ ValidateTripleThird(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition
 --*/
 {
   /* Validating field third */
-  uint64_t endPositionOrError = BaseValidateUlong(InputLength, Input, StartPosition);
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, DERIVED__TRIPLE__THIRD);
+  uint64_t positionAfterTriple = BaseValidateUlong(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterTriple))
+  {
+    return positionAfterTriple;
+  }
+  Err("_Triple",
+    "_Triple_third",
+    EverParseErrorReasonOfResult(positionAfterTriple),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterTriple);
+  return positionAfterTriple;
 }
 
-uint64_t DerivedValidateTriple(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+DerivedValidateTriple(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _Triple_pair */
-  uint64_t positionAfterpair = ValidateTriplePair(Uu, Input, StartPosition);
+  uint64_t positionAfterTriple = ValidateTriplePair(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterpair;
+  if (EverParseIsSuccess(positionAfterTriple))
+  {
+    positionAfterpair = positionAfterTriple;
+  }
+  else
+  {
+    Err("_Triple",
+      "pair",
+      EverParseErrorReasonOfResult(positionAfterTriple),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterTriple);
+    positionAfterpair = positionAfterTriple;
+  }
   if (EverParseIsError(positionAfterpair))
   {
     return positionAfterpair;
   }
   /* Field _Triple_third */
-  return ValidateTripleThird(Uu, Input, positionAfterpair);
+  uint64_t positionAfterTriple0 = ValidateTripleThird(Ctxt, Err, Uu, Input, positionAfterpair);
+  if (EverParseIsSuccess(positionAfterTriple0))
+  {
+    return positionAfterTriple0;
+  }
+  Err("_Triple",
+    "third",
+    EverParseErrorReasonOfResult(positionAfterTriple0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterpair,
+    positionAfterTriple0);
+  return positionAfterTriple0;
 }
 
 static inline uint64_t
-ValidateQuad12(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidateQuad12(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _Quad__12
@@ -53,11 +168,40 @@ ValidateQuad12(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
 --*/
 {
   /* Validating field _12 */
-  return BaseValidatePair(InputLength, Input, StartPosition);
+  uint64_t positionAfterQuad = BaseValidatePair(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterQuad))
+  {
+    return positionAfterQuad;
+  }
+  Err("_Quad",
+    "_Quad__12",
+    EverParseErrorReasonOfResult(positionAfterQuad),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterQuad);
+  return positionAfterQuad;
 }
 
 static inline uint64_t
-ValidateQuad34(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidateQuad34(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _Quad__34
@@ -65,18 +209,78 @@ ValidateQuad34(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
 --*/
 {
   /* Validating field _34 */
-  return BaseValidatePair(InputLength, Input, StartPosition);
+  uint64_t positionAfterQuad = BaseValidatePair(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterQuad))
+  {
+    return positionAfterQuad;
+  }
+  Err("_Quad",
+    "_Quad__34",
+    EverParseErrorReasonOfResult(positionAfterQuad),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterQuad);
+  return positionAfterQuad;
 }
 
-uint64_t DerivedValidateQuad(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+DerivedValidateQuad(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _Quad__12 */
-  uint64_t positionAfter12 = ValidateQuad12(Uu, Input, StartPosition);
+  uint64_t positionAfterQuad = ValidateQuad12(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfter12;
+  if (EverParseIsSuccess(positionAfterQuad))
+  {
+    positionAfter12 = positionAfterQuad;
+  }
+  else
+  {
+    Err("_Quad",
+      "_12",
+      EverParseErrorReasonOfResult(positionAfterQuad),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterQuad);
+    positionAfter12 = positionAfterQuad;
+  }
   if (EverParseIsError(positionAfter12))
   {
     return positionAfter12;
   }
   /* Field _Quad__34 */
-  return ValidateQuad34(Uu, Input, positionAfter12);
+  uint64_t positionAfterQuad0 = ValidateQuad34(Ctxt, Err, Uu, Input, positionAfter12);
+  if (EverParseIsSuccess(positionAfterQuad0))
+  {
+    return positionAfterQuad0;
+  }
+  Err("_Quad",
+    "_34",
+    EverParseErrorReasonOfResult(positionAfterQuad0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfter12,
+    positionAfterQuad0);
+  return positionAfterQuad0;
 }
 

--- a/doc/3d-snapshot/Derived.h
+++ b/doc/3d-snapshot/Derived.h
@@ -11,7 +11,6 @@ extern "C" {
 
 
 #include "Base.h"
-#include "Lib.h"
 
 uint64_t
 DerivedValidateTriple(

--- a/doc/3d-snapshot/Derived.h
+++ b/doc/3d-snapshot/Derived.h
@@ -11,10 +11,45 @@ extern "C" {
 
 
 #include "Base.h"
+#include "Lib.h"
 
-uint64_t DerivedValidateTriple(uint32_t Uu, uint8_t *Input, uint64_t StartPosition);
+uint64_t
+DerivedValidateTriple(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
-uint64_t DerivedValidateQuad(uint32_t Uu, uint8_t *Input, uint64_t StartPosition);
+uint64_t
+DerivedValidateQuad(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/DerivedWrapper.c
+++ b/doc/3d-snapshot/DerivedWrapper.c
@@ -2,89 +2,64 @@
 #include "EverParse.h"
 #include "Derived.h"
 void DerivedEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* DerivedStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2";
-		case 26: return "Derived._Triple"; 
-		default: return "";
-	}
-}
 
-static char* DerivedFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color";
-		case 26: return "third"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN DerivedCheckTriple(uint8_t *base, uint32_t len) {
-	uint64_t result = DerivedValidateTriple(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		DerivedEverParseError(
-	DerivedStructNameOfErr(result),
-			DerivedFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = DerivedValidateTriple( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			DerivedEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;
 }
 
 BOOLEAN DerivedCheckQuad(uint8_t *base, uint32_t len) {
-	uint64_t result = DerivedValidateQuad(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		DerivedEverParseError(
-	DerivedStructNameOfErr(result),
-			DerivedFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = DerivedValidateQuad( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			DerivedEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/DerivedWrapper.c
+++ b/doc/3d-snapshot/DerivedWrapper.c
@@ -1,22 +1,22 @@
 #include "DerivedWrapper.h"
 #include "EverParse.h"
 #include "Derived.h"
-void DerivedEverParseError(char *StructName, char *FieldName, char *Reason);
+void DerivedEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/EnumConstraint.c
+++ b/doc/3d-snapshot/EnumConstraint.c
@@ -3,16 +3,6 @@
 #include "EnumConstraint.h"
 
 /*
-Auto-generated field identifier for error reporting
-*/
-#define ENUMCONSTRAINT__ENUM_CONSTRAINT__COL ((uint64_t)27U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define ENUMCONSTRAINT__ENUM_CONSTRAINT__X ((uint64_t)28U)
-
-/*
 Enum constant
 */
 #define RED ((uint32_t)1U)
@@ -30,7 +20,19 @@ Enum constant
 static inline uint64_t
 ValidateEnumConstraintX(
   uint32_t Col,
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 )
@@ -42,62 +44,112 @@ ValidateEnumConstraintX(
 {
   /* Validating field x */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t positionAfterEnumConstraintX;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterEnumConstraint;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    positionAfterEnumConstraintX = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterEnumConstraint = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    positionAfterEnumConstraintX = StartPosition + (uint64_t)4U;
+    positionAfterEnumConstraint = StartPosition + (uint64_t)4U;
   }
-  uint64_t endPositionOrError;
-  if (EverParseIsError(positionAfterEnumConstraintX))
+  uint64_t positionAfterEnumConstraint0;
+  if (EverParseIsSuccess(positionAfterEnumConstraint))
   {
-    endPositionOrError = positionAfterEnumConstraintX;
+    positionAfterEnumConstraint0 = positionAfterEnumConstraint;
+  }
+  else
+  {
+    Err("_enum_constraint",
+      "_enum_constraint_x",
+      EverParseErrorReasonOfResult(positionAfterEnumConstraint),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterEnumConstraint);
+    positionAfterEnumConstraint0 = positionAfterEnumConstraint;
+  }
+  uint64_t positionAfterEnumConstraint1;
+  if (EverParseIsError(positionAfterEnumConstraint0))
+  {
+    positionAfterEnumConstraint1 = positionAfterEnumConstraint0;
   }
   else
   {
     /* reading field value */
     uint8_t *base = Input;
-    uint32_t enumConstraintX = Load32Le(base + (uint32_t)StartPosition);
+    uint32_t enumConstraint1 = Load32Le(base + (uint32_t)StartPosition);
     /* start: checking constraint */
     BOOLEAN
-    enumConstraintXConstraintIsOk = enumConstraintX == (uint32_t)(uint8_t)0U || Col == GREEN;
+    enumConstraintConstraintIsOk = enumConstraint1 == (uint32_t)(uint8_t)0U || Col == GREEN;
     /* end: checking constraint */
-    endPositionOrError =
-      EverParseCheckConstraintOk(enumConstraintXConstraintIsOk,
-        positionAfterEnumConstraintX);
+    positionAfterEnumConstraint1 =
+      EverParseCheckConstraintOk(enumConstraintConstraintIsOk,
+        positionAfterEnumConstraint0);
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      ENUMCONSTRAINT__ENUM_CONSTRAINT__X);
+  if (EverParseIsSuccess(positionAfterEnumConstraint1))
+  {
+    return positionAfterEnumConstraint1;
+  }
+  Err("_enum_constraint",
+    "_enum_constraint_x.refinement",
+    EverParseErrorReasonOfResult(positionAfterEnumConstraint1),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterEnumConstraint1);
+  return positionAfterEnumConstraint1;
 }
 
 uint64_t
 EnumConstraintValidateEnumConstraint(
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 )
 {
   /* Validating field col */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterEnumConstraint;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterEnumConstraint = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAfterEnumConstraint = StartPosition + (uint64_t)4U;
   }
-  uint64_t
-  positionAftercol =
-    EverParseMaybeSetErrorCode(endPositionOrError,
+  uint64_t positionAftercol;
+  if (EverParseIsSuccess(positionAfterEnumConstraint))
+  {
+    positionAftercol = positionAfterEnumConstraint;
+  }
+  else
+  {
+    Err("_enum_constraint",
+      "col",
+      EverParseErrorReasonOfResult(positionAfterEnumConstraint),
+      Ctxt,
+      Uu,
+      Input,
       StartPosition,
-      ENUMCONSTRAINT__ENUM_CONSTRAINT__COL);
+      positionAfterEnumConstraint);
+    positionAftercol = positionAfterEnumConstraint;
+  }
   if (EverParseIsError(positionAftercol))
   {
     return positionAftercol;
@@ -110,12 +162,32 @@ EnumConstraintValidateEnumConstraint(
     EverParseCheckConstraintOkWithFieldId(colConstraintIsOk,
       StartPosition,
       positionAftercol,
-      ENUMCONSTRAINT__ENUM_CONSTRAINT__COL);
+      (uint64_t)1U);
   if (EverParseIsError(positionOrErrorAftercol))
   {
     return positionOrErrorAftercol;
   }
   /* Field _enum_constraint_x */
-  return ValidateEnumConstraintX(col, InputLength, Input, positionOrErrorAftercol);
+  uint64_t
+  positionAfterEnumConstraint0 =
+    ValidateEnumConstraintX(col,
+      Ctxt,
+      Err,
+      Uu,
+      Input,
+      positionOrErrorAftercol);
+  if (EverParseIsSuccess(positionAfterEnumConstraint0))
+  {
+    return positionAfterEnumConstraint0;
+  }
+  Err("_enum_constraint",
+    "x",
+    EverParseErrorReasonOfResult(positionAfterEnumConstraint0),
+    Ctxt,
+    Uu,
+    Input,
+    positionOrErrorAftercol,
+    positionAfterEnumConstraint0);
+  return positionAfterEnumConstraint0;
 }
 

--- a/doc/3d-snapshot/EnumConstraint.h
+++ b/doc/3d-snapshot/EnumConstraint.h
@@ -10,11 +10,23 @@ extern "C" {
 #include "EverParse.h"
 
 
-
+#include "Lib.h"
 
 uint64_t
 EnumConstraintValidateEnumConstraint(
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 );

--- a/doc/3d-snapshot/EnumConstraint.h
+++ b/doc/3d-snapshot/EnumConstraint.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 EnumConstraintValidateEnumConstraint(

--- a/doc/3d-snapshot/EnumConstraintWrapper.c
+++ b/doc/3d-snapshot/EnumConstraintWrapper.c
@@ -1,22 +1,22 @@
 #include "EnumConstraintWrapper.h"
 #include "EverParse.h"
 #include "EnumConstraint.h"
-void EnumConstraintEverParseError(char *StructName, char *FieldName, char *Reason);
+void EnumConstraintEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/EnumConstraintWrapper.c
+++ b/doc/3d-snapshot/EnumConstraintWrapper.c
@@ -2,81 +2,49 @@
 #include "EverParse.h"
 #include "EnumConstraint.h"
 void EnumConstraintEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* EnumConstraintStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2";
-		case 26: return "Derived._Triple";
-		case 27: return "EnumConstraint._enum_constraint";
-		case 28: return "EnumConstraint._enum_constraint"; 
-		default: return "";
-	}
-}
 
-static char* EnumConstraintFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color";
-		case 26: return "third";
-		case 27: return "col";
-		case 28: return "x"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN EnumConstraintCheckEnumConstraint(uint8_t *base, uint32_t len) {
-	uint64_t result = EnumConstraintValidateEnumConstraint(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		EnumConstraintEverParseError(
-	EnumConstraintStructNameOfErr(result),
-			EnumConstraintFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = EnumConstraintValidateEnumConstraint( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			EnumConstraintEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/GetFieldPtr.c
+++ b/doc/3d-snapshot/GetFieldPtr.c
@@ -2,17 +2,24 @@
 
 #include "GetFieldPtr.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define GETFIELDPTR__T__F1 ((uint64_t)29U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define GETFIELDPTR__T__F2 ((uint64_t)30U)
-
-static inline uint64_t ValidateTF1(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateTF1(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _T_f1
@@ -20,20 +27,49 @@ static inline uint64_t ValidateTF1(uint32_t InputLength, uint64_t StartPosition)
 --*/
 {
   /* SNIPPET_START: GetFieldPtr.T */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)(uint32_t)(uint8_t)10U)
+  uint64_t positionAfterT;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)(uint32_t)(uint8_t)10U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterT = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)(uint32_t)(uint8_t)10U;
+    positionAfterT = StartPosition + (uint64_t)(uint32_t)(uint8_t)10U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, GETFIELDPTR__T__F1);
+  if (EverParseIsSuccess(positionAfterT))
+  {
+    return positionAfterT;
+  }
+  Err("_T",
+    "_T_f1",
+    EverParseErrorReasonOfResult(positionAfterT),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterT);
+  return positionAfterT;
 }
 
 static inline uint64_t
-ValidateTF2(uint8_t **Out, uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidateTF2(
+  uint8_t **Out,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _T_f2
@@ -41,48 +77,124 @@ ValidateTF2(uint8_t **Out, uint32_t InputLength, uint8_t *Input, uint64_t StartP
 --*/
 {
   /* Validating field f2 */
-  uint64_t positionAfterTF2;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)(uint32_t)(uint8_t)20U)
+  uint64_t positionAfterT;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)(uint32_t)(uint8_t)20U)
   {
-    positionAfterTF2 = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterT = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    positionAfterTF2 = StartPosition + (uint64_t)(uint32_t)(uint8_t)20U;
+    positionAfterT = StartPosition + (uint64_t)(uint32_t)(uint8_t)20U;
   }
-  uint64_t endPositionOrError;
-  if (EverParseIsSuccess(positionAfterTF2))
+  uint64_t positionAfterT0;
+  if (EverParseIsSuccess(positionAfterT))
+  {
+    positionAfterT0 = positionAfterT;
+  }
+  else
+  {
+    Err("_T",
+      "_T_f2.base",
+      EverParseErrorReasonOfResult(positionAfterT),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterT);
+    positionAfterT0 = positionAfterT;
+  }
+  uint64_t positionAfterT1;
+  if (EverParseIsSuccess(positionAfterT0))
   {
     uint8_t *base = Input;
     uint8_t *x = base + (uint32_t)StartPosition;
     *Out = x;
-    BOOLEAN actionSuccessTF2 = TRUE;
-    if (!actionSuccessTF2)
+    BOOLEAN actionSuccessT = TRUE;
+    if (!actionSuccessT)
     {
-      endPositionOrError = EVERPARSE_VALIDATOR_ERROR_ACTION_FAILED;
+      positionAfterT1 = EVERPARSE_VALIDATOR_ERROR_ACTION_FAILED;
     }
     else
     {
-      endPositionOrError = positionAfterTF2;
+      positionAfterT1 = positionAfterT0;
     }
   }
   else
   {
-    endPositionOrError = positionAfterTF2;
+    positionAfterT1 = positionAfterT0;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, GETFIELDPTR__T__F2);
+  if (EverParseIsSuccess(positionAfterT1))
+  {
+    return positionAfterT1;
+  }
+  Err("_T",
+    "_T_f2",
+    EverParseErrorReasonOfResult(positionAfterT1),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterT1);
+  return positionAfterT1;
 }
 
 uint64_t
-GetFieldPtrValidateT(uint8_t **Out, uint32_t Uu, uint8_t *Input, uint64_t StartPosition)
+GetFieldPtrValidateT(
+  uint8_t **Out,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _T_f1 */
-  uint64_t positionAfterf1 = ValidateTF1(Uu, StartPosition);
+  uint64_t positionAfterT = ValidateTF1(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterf1;
+  if (EverParseIsSuccess(positionAfterT))
+  {
+    positionAfterf1 = positionAfterT;
+  }
+  else
+  {
+    Err("_T",
+      "f1",
+      EverParseErrorReasonOfResult(positionAfterT),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterT);
+    positionAfterf1 = positionAfterT;
+  }
   if (EverParseIsError(positionAfterf1))
   {
     return positionAfterf1;
   }
   /* Field _T_f2 */
-  return ValidateTF2(Out, Uu, Input, positionAfterf1);
+  uint64_t positionAfterT0 = ValidateTF2(Out, Ctxt, Err, Uu, Input, positionAfterf1);
+  if (EverParseIsSuccess(positionAfterT0))
+  {
+    return positionAfterT0;
+  }
+  Err("_T",
+    "f2",
+    EverParseErrorReasonOfResult(positionAfterT0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterf1,
+    positionAfterT0);
+  return positionAfterT0;
 }
 

--- a/doc/3d-snapshot/GetFieldPtr.h
+++ b/doc/3d-snapshot/GetFieldPtr.h
@@ -10,10 +10,27 @@ extern "C" {
 #include "EverParse.h"
 
 
-
+#include "Lib.h"
 
 uint64_t
-GetFieldPtrValidateT(uint8_t **Out, uint32_t Uu, uint8_t *Input, uint64_t StartPosition);
+GetFieldPtrValidateT(
+  uint8_t **Out,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/GetFieldPtr.h
+++ b/doc/3d-snapshot/GetFieldPtr.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 GetFieldPtrValidateT(

--- a/doc/3d-snapshot/GetFieldPtrWrapper.c
+++ b/doc/3d-snapshot/GetFieldPtrWrapper.c
@@ -1,22 +1,22 @@
 #include "GetFieldPtrWrapper.h"
 #include "EverParse.h"
 #include "GetFieldPtr.h"
-void GetFieldPtrEverParseError(char *StructName, char *FieldName, char *Reason);
+void GetFieldPtrEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/GetFieldPtrWrapper.c
+++ b/doc/3d-snapshot/GetFieldPtrWrapper.c
@@ -2,85 +2,49 @@
 #include "EverParse.h"
 #include "GetFieldPtr.h"
 void GetFieldPtrEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* GetFieldPtrStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2";
-		case 26: return "Derived._Triple";
-		case 27: return "EnumConstraint._enum_constraint";
-		case 28: return "EnumConstraint._enum_constraint";
-		case 29: return "GetFieldPtr._T";
-		case 30: return "GetFieldPtr._T"; 
-		default: return "";
-	}
-}
 
-static char* GetFieldPtrFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color";
-		case 26: return "third";
-		case 27: return "col";
-		case 28: return "x";
-		case 29: return "f1";
-		case 30: return "f2"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN GetFieldPtrCheckT(uint8_t** out, uint8_t *base, uint32_t len) {
-	uint64_t result = GetFieldPtrValidateT(out, len, base, 0);
-	if (EverParseResultIsError(result)) {
-		GetFieldPtrEverParseError(
-	GetFieldPtrStructNameOfErr(result),
-			GetFieldPtrFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = GetFieldPtrValidateT(out,  (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			GetFieldPtrEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/HelloWorld.c
+++ b/doc/3d-snapshot/HelloWorld.c
@@ -2,17 +2,24 @@
 
 #include "HelloWorld.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define HELLOWORLD__POINT__X ((uint64_t)31U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define HELLOWORLD__POINT__Y ((uint64_t)32U)
-
-static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidatePointX(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _point_x
@@ -21,19 +28,48 @@ static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPositi
 {
   /* Validating field x */
   /* Checking that we have enough space for a UINT16, i.e., 2 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)2U)
+  uint64_t positionAfterPoint;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)2U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterPoint = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)2U;
+    positionAfterPoint = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, HELLOWORLD__POINT__X);
+  if (EverParseIsSuccess(positionAfterPoint))
+  {
+    return positionAfterPoint;
+  }
+  Err("_point",
+    "_point_x",
+    EverParseErrorReasonOfResult(positionAfterPoint),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterPoint);
+  return positionAfterPoint;
 }
 
-static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidatePointY(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _point_y
@@ -42,27 +78,86 @@ static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPositi
 {
   /* Validating field y */
   /* Checking that we have enough space for a UINT16, i.e., 2 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)2U)
+  uint64_t positionAfterPoint;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)2U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterPoint = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)2U;
+    positionAfterPoint = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, HELLOWORLD__POINT__Y);
+  if (EverParseIsSuccess(positionAfterPoint))
+  {
+    return positionAfterPoint;
+  }
+  Err("_point",
+    "_point_y",
+    EverParseErrorReasonOfResult(positionAfterPoint),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterPoint);
+  return positionAfterPoint;
 }
 
-uint64_t HelloWorldValidatePoint(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+HelloWorldValidatePoint(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _point_x */
-  uint64_t positionAfterx = ValidatePointX(Uu, StartPosition);
+  uint64_t positionAfterPoint = ValidatePointX(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterx;
+  if (EverParseIsSuccess(positionAfterPoint))
+  {
+    positionAfterx = positionAfterPoint;
+  }
+  else
+  {
+    Err("_point",
+      "x",
+      EverParseErrorReasonOfResult(positionAfterPoint),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterPoint);
+    positionAfterx = positionAfterPoint;
+  }
   if (EverParseIsError(positionAfterx))
   {
     return positionAfterx;
   }
   /* Field _point_y */
-  return ValidatePointY(Uu, positionAfterx);
+  uint64_t positionAfterPoint0 = ValidatePointY(Ctxt, Err, Uu, Input, positionAfterx);
+  if (EverParseIsSuccess(positionAfterPoint0))
+  {
+    return positionAfterPoint0;
+  }
+  Err("_point",
+    "y",
+    EverParseErrorReasonOfResult(positionAfterPoint0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterx,
+    positionAfterPoint0);
+  return positionAfterPoint0;
 }
 

--- a/doc/3d-snapshot/HelloWorld.h
+++ b/doc/3d-snapshot/HelloWorld.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 HelloWorldValidatePoint(

--- a/doc/3d-snapshot/HelloWorld.h
+++ b/doc/3d-snapshot/HelloWorld.h
@@ -10,9 +10,26 @@ extern "C" {
 #include "EverParse.h"
 
 
+#include "Lib.h"
 
-
-uint64_t HelloWorldValidatePoint(uint32_t Uu, uint8_t *Input, uint64_t StartPosition);
+uint64_t
+HelloWorldValidatePoint(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/HelloWorldWrapper.c
+++ b/doc/3d-snapshot/HelloWorldWrapper.c
@@ -2,89 +2,49 @@
 #include "EverParse.h"
 #include "HelloWorld.h"
 void HelloWorldEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* HelloWorldStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2";
-		case 26: return "Derived._Triple";
-		case 27: return "EnumConstraint._enum_constraint";
-		case 28: return "EnumConstraint._enum_constraint";
-		case 29: return "GetFieldPtr._T";
-		case 30: return "GetFieldPtr._T";
-		case 31: return "HelloWorld._point";
-		case 32: return "HelloWorld._point"; 
-		default: return "";
-	}
-}
 
-static char* HelloWorldFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color";
-		case 26: return "third";
-		case 27: return "col";
-		case 28: return "x";
-		case 29: return "f1";
-		case 30: return "f2";
-		case 31: return "x";
-		case 32: return "y"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN HelloWorldCheckPoint(uint8_t *base, uint32_t len) {
-	uint64_t result = HelloWorldValidatePoint(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		HelloWorldEverParseError(
-	HelloWorldStructNameOfErr(result),
-			HelloWorldFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = HelloWorldValidatePoint( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			HelloWorldEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/HelloWorldWrapper.c
+++ b/doc/3d-snapshot/HelloWorldWrapper.c
@@ -1,22 +1,22 @@
 #include "HelloWorldWrapper.h"
 #include "EverParse.h"
 #include "HelloWorld.h"
-void HelloWorldEverParseError(char *StructName, char *FieldName, char *Reason);
+void HelloWorldEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/OrderedPair.c
+++ b/doc/3d-snapshot/OrderedPair.c
@@ -2,17 +2,24 @@
 
 #include "OrderedPair.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define ORDEREDPAIR__ORDEREDPAIR__LESSER ((uint64_t)33U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define ORDEREDPAIR__ORDEREDPAIR__GREATER ((uint64_t)34U)
-
-static inline uint64_t ValidateOrderedPairLesser(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateOrderedPairLesser(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _orderedPair_lesser
@@ -21,25 +28,46 @@ static inline uint64_t ValidateOrderedPairLesser(uint32_t InputLength, uint64_t 
 {
   /* Validating field lesser */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterOrderedPair;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterOrderedPair = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAfterOrderedPair = StartPosition + (uint64_t)4U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      ORDEREDPAIR__ORDEREDPAIR__LESSER);
+  if (EverParseIsSuccess(positionAfterOrderedPair))
+  {
+    return positionAfterOrderedPair;
+  }
+  Err("_orderedPair",
+    "_orderedPair_lesser",
+    EverParseErrorReasonOfResult(positionAfterOrderedPair),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterOrderedPair);
+  return positionAfterOrderedPair;
 }
 
 static inline uint64_t
 ValidateOrderedPairGreater(
   uint32_t Lesser,
-  uint32_t InputLength,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 )
@@ -51,43 +79,103 @@ ValidateOrderedPairGreater(
 {
   /* Validating field greater */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t positionAfterOrderedPairGreater;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterOrderedPair;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    positionAfterOrderedPairGreater = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterOrderedPair = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    positionAfterOrderedPairGreater = StartPosition + (uint64_t)4U;
+    positionAfterOrderedPair = StartPosition + (uint64_t)4U;
   }
-  uint64_t endPositionOrError;
-  if (EverParseIsError(positionAfterOrderedPairGreater))
+  uint64_t positionAfterOrderedPair0;
+  if (EverParseIsSuccess(positionAfterOrderedPair))
   {
-    endPositionOrError = positionAfterOrderedPairGreater;
+    positionAfterOrderedPair0 = positionAfterOrderedPair;
+  }
+  else
+  {
+    Err("_orderedPair",
+      "_orderedPair_greater",
+      EverParseErrorReasonOfResult(positionAfterOrderedPair),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterOrderedPair);
+    positionAfterOrderedPair0 = positionAfterOrderedPair;
+  }
+  uint64_t positionAfterOrderedPair1;
+  if (EverParseIsError(positionAfterOrderedPair0))
+  {
+    positionAfterOrderedPair1 = positionAfterOrderedPair0;
   }
   else
   {
     /* reading field value */
     uint8_t *base = Input;
-    uint32_t orderedPairGreater = Load32Le(base + (uint32_t)StartPosition);
+    uint32_t orderedPair1 = Load32Le(base + (uint32_t)StartPosition);
     /* start: checking constraint */
-    BOOLEAN orderedPairGreaterConstraintIsOk = Lesser <= orderedPairGreater;
+    BOOLEAN orderedPairConstraintIsOk = Lesser <= orderedPair1;
     /* end: checking constraint */
-    endPositionOrError =
-      EverParseCheckConstraintOk(orderedPairGreaterConstraintIsOk,
-        positionAfterOrderedPairGreater);
+    positionAfterOrderedPair1 =
+      EverParseCheckConstraintOk(orderedPairConstraintIsOk,
+        positionAfterOrderedPair0);
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      ORDEREDPAIR__ORDEREDPAIR__GREATER);
+  if (EverParseIsSuccess(positionAfterOrderedPair1))
+  {
+    return positionAfterOrderedPair1;
+  }
+  Err("_orderedPair",
+    "_orderedPair_greater.refinement",
+    EverParseErrorReasonOfResult(positionAfterOrderedPair1),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterOrderedPair1);
+  return positionAfterOrderedPair1;
 }
 
 uint64_t
-OrderedPairValidateOrderedPair(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+OrderedPairValidateOrderedPair(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _orderedPair_lesser */
-  uint64_t positionAfterlesser = ValidateOrderedPairLesser(InputLength, StartPosition);
+  uint64_t
+  positionAfterOrderedPair = ValidateOrderedPairLesser(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterlesser;
+  if (EverParseIsSuccess(positionAfterOrderedPair))
+  {
+    positionAfterlesser = positionAfterOrderedPair;
+  }
+  else
+  {
+    Err("_orderedPair",
+      "lesser",
+      EverParseErrorReasonOfResult(positionAfterOrderedPair),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterOrderedPair);
+    positionAfterlesser = positionAfterOrderedPair;
+  }
   if (EverParseIsError(positionAfterlesser))
   {
     return positionAfterlesser;
@@ -95,6 +183,26 @@ OrderedPairValidateOrderedPair(uint32_t InputLength, uint8_t *Input, uint64_t St
   uint8_t *base = Input;
   uint32_t lesser = Load32Le(base + (uint32_t)StartPosition);
   /* Field _orderedPair_greater */
-  return ValidateOrderedPairGreater(lesser, InputLength, Input, positionAfterlesser);
+  uint64_t
+  positionAfterOrderedPair0 =
+    ValidateOrderedPairGreater(lesser,
+      Ctxt,
+      Err,
+      Uu,
+      Input,
+      positionAfterlesser);
+  if (EverParseIsSuccess(positionAfterOrderedPair0))
+  {
+    return positionAfterOrderedPair0;
+  }
+  Err("_orderedPair",
+    "greater",
+    EverParseErrorReasonOfResult(positionAfterOrderedPair0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterlesser,
+    positionAfterOrderedPair0);
+  return positionAfterOrderedPair0;
 }
 

--- a/doc/3d-snapshot/OrderedPair.h
+++ b/doc/3d-snapshot/OrderedPair.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 OrderedPairValidateOrderedPair(

--- a/doc/3d-snapshot/OrderedPair.h
+++ b/doc/3d-snapshot/OrderedPair.h
@@ -10,10 +10,26 @@ extern "C" {
 #include "EverParse.h"
 
 
-
+#include "Lib.h"
 
 uint64_t
-OrderedPairValidateOrderedPair(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition);
+OrderedPairValidateOrderedPair(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/OrderedPairWrapper.c
+++ b/doc/3d-snapshot/OrderedPairWrapper.c
@@ -2,93 +2,49 @@
 #include "EverParse.h"
 #include "OrderedPair.h"
 void OrderedPairEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* OrderedPairStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2";
-		case 26: return "Derived._Triple";
-		case 27: return "EnumConstraint._enum_constraint";
-		case 28: return "EnumConstraint._enum_constraint";
-		case 29: return "GetFieldPtr._T";
-		case 30: return "GetFieldPtr._T";
-		case 31: return "HelloWorld._point";
-		case 32: return "HelloWorld._point";
-		case 33: return "OrderedPair._orderedPair";
-		case 34: return "OrderedPair._orderedPair"; 
-		default: return "";
-	}
-}
 
-static char* OrderedPairFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color";
-		case 26: return "third";
-		case 27: return "col";
-		case 28: return "x";
-		case 29: return "f1";
-		case 30: return "f2";
-		case 31: return "x";
-		case 32: return "y";
-		case 33: return "lesser";
-		case 34: return "greater"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN OrderedPairCheckOrderedPair(uint8_t *base, uint32_t len) {
-	uint64_t result = OrderedPairValidateOrderedPair(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		OrderedPairEverParseError(
-	OrderedPairStructNameOfErr(result),
-			OrderedPairFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = OrderedPairValidateOrderedPair( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			OrderedPairEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/OrderedPairWrapper.c
+++ b/doc/3d-snapshot/OrderedPairWrapper.c
@@ -1,22 +1,22 @@
 #include "OrderedPairWrapper.h"
 #include "EverParse.h"
 #include "OrderedPair.h"
-void OrderedPairEverParseError(char *StructName, char *FieldName, char *Reason);
+void OrderedPairEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/ReadPair.c
+++ b/doc/3d-snapshot/ReadPair.c
@@ -2,18 +2,25 @@
 
 #include "ReadPair.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define READPAIR__PAIR__FIRST ((uint64_t)35U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define READPAIR__PAIR__SECOND ((uint64_t)36U)
-
 static inline uint64_t
-ValidatePairFirst(uint32_t *X, uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidatePairFirst(
+  uint32_t *X,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _Pair_first
@@ -22,39 +29,85 @@ ValidatePairFirst(uint32_t *X, uint32_t InputLength, uint8_t *Input, uint64_t St
 {
   /* Validating field first */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t positionAfterPairFirst;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterPair;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    positionAfterPairFirst = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterPair = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    positionAfterPairFirst = StartPosition + (uint64_t)4U;
+    positionAfterPair = StartPosition + (uint64_t)4U;
   }
-  uint64_t endPositionOrError;
-  if (EverParseIsError(positionAfterPairFirst))
+  uint64_t positionAfterPair0;
+  if (EverParseIsSuccess(positionAfterPair))
   {
-    endPositionOrError = positionAfterPairFirst;
+    positionAfterPair0 = positionAfterPair;
+  }
+  else
+  {
+    Err("_Pair",
+      "_Pair_first.base",
+      EverParseErrorReasonOfResult(positionAfterPair),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterPair);
+    positionAfterPair0 = positionAfterPair;
+  }
+  uint64_t positionAfterPair1;
+  if (EverParseIsError(positionAfterPair0))
+  {
+    positionAfterPair1 = positionAfterPair0;
   }
   else
   {
     uint8_t *base = Input;
-    uint32_t pairFirst = Load32Le(base + (uint32_t)StartPosition);
-    *X = pairFirst;
+    uint32_t pair1 = Load32Le(base + (uint32_t)StartPosition);
+    *X = pair1;
     if (TRUE)
     {
-      endPositionOrError = positionAfterPairFirst;
+      positionAfterPair1 = positionAfterPair0;
     }
     else
     {
-      endPositionOrError = EVERPARSE_VALIDATOR_ERROR_ACTION_FAILED;
+      positionAfterPair1 = EVERPARSE_VALIDATOR_ERROR_ACTION_FAILED;
     }
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, READPAIR__PAIR__FIRST);
+  if (EverParseIsSuccess(positionAfterPair1))
+  {
+    return positionAfterPair1;
+  }
+  Err("_Pair",
+    "_Pair_first",
+    EverParseErrorReasonOfResult(positionAfterPair1),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterPair1);
+  return positionAfterPair1;
 }
 
 static inline uint64_t
-ValidatePairSecond(uint32_t *Y, uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+ValidatePairSecond(
+  uint32_t *Y,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _Pair_second
@@ -63,53 +116,124 @@ ValidatePairSecond(uint32_t *Y, uint32_t InputLength, uint8_t *Input, uint64_t S
 {
   /* Validating field second */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t positionAfterPairSecond;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterPair;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    positionAfterPairSecond = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterPair = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    positionAfterPairSecond = StartPosition + (uint64_t)4U;
+    positionAfterPair = StartPosition + (uint64_t)4U;
   }
-  uint64_t endPositionOrError;
-  if (EverParseIsError(positionAfterPairSecond))
+  uint64_t positionAfterPair0;
+  if (EverParseIsSuccess(positionAfterPair))
   {
-    endPositionOrError = positionAfterPairSecond;
+    positionAfterPair0 = positionAfterPair;
+  }
+  else
+  {
+    Err("_Pair",
+      "_Pair_second.base",
+      EverParseErrorReasonOfResult(positionAfterPair),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterPair);
+    positionAfterPair0 = positionAfterPair;
+  }
+  uint64_t positionAfterPair1;
+  if (EverParseIsError(positionAfterPair0))
+  {
+    positionAfterPair1 = positionAfterPair0;
   }
   else
   {
     uint8_t *base = Input;
-    uint32_t pairSecond = Load32Le(base + (uint32_t)StartPosition);
-    *Y = pairSecond;
+    uint32_t pair1 = Load32Le(base + (uint32_t)StartPosition);
+    *Y = pair1;
     if (TRUE)
     {
-      endPositionOrError = positionAfterPairSecond;
+      positionAfterPair1 = positionAfterPair0;
     }
     else
     {
-      endPositionOrError = EVERPARSE_VALIDATOR_ERROR_ACTION_FAILED;
+      positionAfterPair1 = EVERPARSE_VALIDATOR_ERROR_ACTION_FAILED;
     }
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, READPAIR__PAIR__SECOND);
+  if (EverParseIsSuccess(positionAfterPair1))
+  {
+    return positionAfterPair1;
+  }
+  Err("_Pair",
+    "_Pair_second",
+    EverParseErrorReasonOfResult(positionAfterPair1),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterPair1);
+  return positionAfterPair1;
 }
 
 uint64_t
 ReadPairValidatePair(
   uint32_t *X,
   uint32_t *Y,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
   uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition
 )
 {
   /* Field _Pair_first */
-  uint64_t positionAfterfirst = ValidatePairFirst(X, Uu, Input, StartPosition);
+  uint64_t positionAfterPair = ValidatePairFirst(X, Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterfirst;
+  if (EverParseIsSuccess(positionAfterPair))
+  {
+    positionAfterfirst = positionAfterPair;
+  }
+  else
+  {
+    Err("_Pair",
+      "first",
+      EverParseErrorReasonOfResult(positionAfterPair),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterPair);
+    positionAfterfirst = positionAfterPair;
+  }
   if (EverParseIsError(positionAfterfirst))
   {
     return positionAfterfirst;
   }
   /* Field _Pair_second */
-  return ValidatePairSecond(Y, Uu, Input, positionAfterfirst);
+  uint64_t positionAfterPair0 = ValidatePairSecond(Y, Ctxt, Err, Uu, Input, positionAfterfirst);
+  if (EverParseIsSuccess(positionAfterPair0))
+  {
+    return positionAfterPair0;
+  }
+  Err("_Pair",
+    "second",
+    EverParseErrorReasonOfResult(positionAfterPair0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterfirst,
+    positionAfterPair0);
+  return positionAfterPair0;
 }
 

--- a/doc/3d-snapshot/ReadPair.h
+++ b/doc/3d-snapshot/ReadPair.h
@@ -10,12 +10,24 @@ extern "C" {
 #include "EverParse.h"
 
 
-
+#include "Lib.h"
 
 uint64_t
 ReadPairValidatePair(
   uint32_t *X,
   uint32_t *Y,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
   uint32_t Uu,
   uint8_t *Input,
   uint64_t StartPosition

--- a/doc/3d-snapshot/ReadPair.h
+++ b/doc/3d-snapshot/ReadPair.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 ReadPairValidatePair(

--- a/doc/3d-snapshot/ReadPairWrapper.c
+++ b/doc/3d-snapshot/ReadPairWrapper.c
@@ -2,97 +2,49 @@
 #include "EverParse.h"
 #include "ReadPair.h"
 void ReadPairEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* ReadPairStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2";
-		case 26: return "Derived._Triple";
-		case 27: return "EnumConstraint._enum_constraint";
-		case 28: return "EnumConstraint._enum_constraint";
-		case 29: return "GetFieldPtr._T";
-		case 30: return "GetFieldPtr._T";
-		case 31: return "HelloWorld._point";
-		case 32: return "HelloWorld._point";
-		case 33: return "OrderedPair._orderedPair";
-		case 34: return "OrderedPair._orderedPair";
-		case 35: return "ReadPair._Pair";
-		case 36: return "ReadPair._Pair"; 
-		default: return "";
-	}
-}
 
-static char* ReadPairFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color";
-		case 26: return "third";
-		case 27: return "col";
-		case 28: return "x";
-		case 29: return "f1";
-		case 30: return "f2";
-		case 31: return "x";
-		case 32: return "y";
-		case 33: return "lesser";
-		case 34: return "greater";
-		case 35: return "first";
-		case 36: return "second"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN ReadPairCheckPair(uint32_t* x, uint32_t* y, uint8_t *base, uint32_t len) {
-	uint64_t result = ReadPairValidatePair(x, y, len, base, 0);
-	if (EverParseResultIsError(result)) {
-		ReadPairEverParseError(
-	ReadPairStructNameOfErr(result),
-			ReadPairFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = ReadPairValidatePair(x, y,  (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			ReadPairEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/ReadPairWrapper.c
+++ b/doc/3d-snapshot/ReadPairWrapper.c
@@ -1,22 +1,22 @@
 #include "ReadPairWrapper.h"
 #include "EverParse.h"
 #include "ReadPair.h"
-void ReadPairEverParseError(char *StructName, char *FieldName, char *Reason);
+void ReadPairEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/Smoker.c
+++ b/doc/3d-snapshot/Smoker.c
@@ -2,18 +2,24 @@
 
 #include "Smoker.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define SMOKER__SMOKER__AGE ((uint64_t)37U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define SMOKER__SMOKER__CIGARETTESCONSUMED ((uint64_t)38U)
-
 static inline uint64_t
-ValidateSmokerCigarettesConsumed(uint32_t InputLength, uint64_t StartPosition)
+ValidateSmokerCigarettesConsumed(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _smoker_cigarettesConsumed
@@ -22,39 +28,77 @@ ValidateSmokerCigarettesConsumed(uint32_t InputLength, uint64_t StartPosition)
 {
   /* Validating field cigarettesConsumed */
   /* Checking that we have enough space for a UINT8, i.e., 1 byte */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)1U)
+  uint64_t positionAfterSmoker;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)1U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterSmoker = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)1U;
+    positionAfterSmoker = StartPosition + (uint64_t)1U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      SMOKER__SMOKER__CIGARETTESCONSUMED);
+  if (EverParseIsSuccess(positionAfterSmoker))
+  {
+    return positionAfterSmoker;
+  }
+  Err("_smoker",
+    "_smoker_cigarettesConsumed",
+    EverParseErrorReasonOfResult(positionAfterSmoker),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterSmoker);
+  return positionAfterSmoker;
 }
 
-uint64_t SmokerValidateSmoker(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+SmokerValidateSmoker(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Validating field age */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterSmoker;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterSmoker = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAfterSmoker = StartPosition + (uint64_t)4U;
   }
-  uint64_t
-  positionAfterage =
-    EverParseMaybeSetErrorCode(endPositionOrError,
+  uint64_t positionAfterage;
+  if (EverParseIsSuccess(positionAfterSmoker))
+  {
+    positionAfterage = positionAfterSmoker;
+  }
+  else
+  {
+    Err("_smoker",
+      "age",
+      EverParseErrorReasonOfResult(positionAfterSmoker),
+      Ctxt,
+      Uu,
+      Input,
       StartPosition,
-      SMOKER__SMOKER__AGE);
+      positionAfterSmoker);
+    positionAfterage = positionAfterSmoker;
+  }
   if (EverParseIsError(positionAfterage))
   {
     return positionAfterage;
@@ -67,12 +111,31 @@ uint64_t SmokerValidateSmoker(uint32_t InputLength, uint8_t *Input, uint64_t Sta
     EverParseCheckConstraintOkWithFieldId(ageConstraintIsOk,
       StartPosition,
       positionAfterage,
-      SMOKER__SMOKER__AGE);
+      (uint64_t)1U);
   if (EverParseIsError(positionOrErrorAfterage))
   {
     return positionOrErrorAfterage;
   }
   /* Field _smoker_cigarettesConsumed */
-  return ValidateSmokerCigarettesConsumed(InputLength, positionOrErrorAfterage);
+  uint64_t
+  positionAfterSmoker0 =
+    ValidateSmokerCigarettesConsumed(Ctxt,
+      Err,
+      Uu,
+      Input,
+      positionOrErrorAfterage);
+  if (EverParseIsSuccess(positionAfterSmoker0))
+  {
+    return positionAfterSmoker0;
+  }
+  Err("_smoker",
+    "cigarettesConsumed",
+    EverParseErrorReasonOfResult(positionAfterSmoker0),
+    Ctxt,
+    Uu,
+    Input,
+    positionOrErrorAfterage,
+    positionAfterSmoker0);
+  return positionAfterSmoker0;
 }
 

--- a/doc/3d-snapshot/Smoker.h
+++ b/doc/3d-snapshot/Smoker.h
@@ -10,9 +10,26 @@ extern "C" {
 #include "EverParse.h"
 
 
+#include "Lib.h"
 
-
-uint64_t SmokerValidateSmoker(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition);
+uint64_t
+SmokerValidateSmoker(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/Smoker.h
+++ b/doc/3d-snapshot/Smoker.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 SmokerValidateSmoker(

--- a/doc/3d-snapshot/SmokerWrapper.c
+++ b/doc/3d-snapshot/SmokerWrapper.c
@@ -1,22 +1,22 @@
 #include "SmokerWrapper.h"
 #include "EverParse.h"
 #include "Smoker.h"
-void SmokerEverParseError(char *StructName, char *FieldName, char *Reason);
+void SmokerEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/SmokerWrapper.c
+++ b/doc/3d-snapshot/SmokerWrapper.c
@@ -2,101 +2,49 @@
 #include "EverParse.h"
 #include "Smoker.h"
 void SmokerEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* SmokerStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2";
-		case 26: return "Derived._Triple";
-		case 27: return "EnumConstraint._enum_constraint";
-		case 28: return "EnumConstraint._enum_constraint";
-		case 29: return "GetFieldPtr._T";
-		case 30: return "GetFieldPtr._T";
-		case 31: return "HelloWorld._point";
-		case 32: return "HelloWorld._point";
-		case 33: return "OrderedPair._orderedPair";
-		case 34: return "OrderedPair._orderedPair";
-		case 35: return "ReadPair._Pair";
-		case 36: return "ReadPair._Pair";
-		case 37: return "Smoker._smoker";
-		case 38: return "Smoker._smoker"; 
-		default: return "";
-	}
-}
 
-static char* SmokerFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color";
-		case 26: return "third";
-		case 27: return "col";
-		case 28: return "x";
-		case 29: return "f1";
-		case 30: return "f2";
-		case 31: return "x";
-		case 32: return "y";
-		case 33: return "lesser";
-		case 34: return "greater";
-		case 35: return "first";
-		case 36: return "second";
-		case 37: return "age";
-		case 38: return "cigarettesConsumed"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN SmokerCheckSmoker(uint8_t *base, uint32_t len) {
-	uint64_t result = SmokerValidateSmoker(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		SmokerEverParseError(
-	SmokerStructNameOfErr(result),
-			SmokerFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = SmokerValidateSmoker( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			SmokerEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/TaggedUnion.c
+++ b/doc/3d-snapshot/TaggedUnion.c
@@ -2,33 +2,30 @@
 
 #include "TaggedUnion.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define TAGGEDUNION__INT_PAYLOAD__VALUE8 ((uint64_t)39U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define TAGGEDUNION__INT_PAYLOAD__VALUE16 ((uint64_t)40U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define TAGGEDUNION__INT_PAYLOAD__VALUE32 ((uint64_t)41U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define TAGGEDUNION__INTEGER__SIZE ((uint64_t)42U)
-
 #define SIZE8 ((uint8_t)8U)
 
 #define SIZE16 ((uint8_t)16U)
 
 #define SIZE32 ((uint8_t)32U)
 
-static inline uint64_t ValidateIntPayloadValue32(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateIntPayloadValue32(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _int_payload_value32
@@ -37,22 +34,48 @@ static inline uint64_t ValidateIntPayloadValue32(uint32_t InputLength, uint64_t 
 {
   /* Validating field value32 */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterIntPayload;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterIntPayload = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAfterIntPayload = StartPosition + (uint64_t)4U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      TAGGEDUNION__INT_PAYLOAD__VALUE32);
+  if (EverParseIsSuccess(positionAfterIntPayload))
+  {
+    return positionAfterIntPayload;
+  }
+  Err("_int_payload",
+    "_int_payload_value32",
+    EverParseErrorReasonOfResult(positionAfterIntPayload),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterIntPayload);
+  return positionAfterIntPayload;
 }
 
-static inline uint64_t ValidateIntPayloadValue16(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateIntPayloadValue16(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _int_payload_value16
@@ -61,22 +84,48 @@ static inline uint64_t ValidateIntPayloadValue16(uint32_t InputLength, uint64_t 
 {
   /* Validating field value16 */
   /* Checking that we have enough space for a UINT16, i.e., 2 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)2U)
+  uint64_t positionAfterIntPayload;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)2U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterIntPayload = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)2U;
+    positionAfterIntPayload = StartPosition + (uint64_t)2U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      TAGGEDUNION__INT_PAYLOAD__VALUE16);
+  if (EverParseIsSuccess(positionAfterIntPayload))
+  {
+    return positionAfterIntPayload;
+  }
+  Err("_int_payload",
+    "_int_payload_value16",
+    EverParseErrorReasonOfResult(positionAfterIntPayload),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterIntPayload);
+  return positionAfterIntPayload;
 }
 
-static inline uint64_t ValidateIntPayloadValue8(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateIntPayloadValue8(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _int_payload_value8
@@ -85,43 +134,210 @@ static inline uint64_t ValidateIntPayloadValue8(uint32_t InputLength, uint64_t S
 {
   /* Validating field value8 */
   /* Checking that we have enough space for a UINT8, i.e., 1 byte */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)1U)
+  uint64_t positionAfterIntPayload;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)1U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterIntPayload = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)1U;
+    positionAfterIntPayload = StartPosition + (uint64_t)1U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      TAGGEDUNION__INT_PAYLOAD__VALUE8);
+  if (EverParseIsSuccess(positionAfterIntPayload))
+  {
+    return positionAfterIntPayload;
+  }
+  Err("_int_payload",
+    "_int_payload_value8",
+    EverParseErrorReasonOfResult(positionAfterIntPayload),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterIntPayload);
+  return positionAfterIntPayload;
 }
 
 static inline uint64_t
-ValidateIntPayload(uint32_t Size, uint32_t InputLength, uint64_t StartPosition)
+ValidateIntPayload(
+  uint32_t Size,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
+  uint64_t positionAfterIntPayload;
   if (Size == (uint32_t)SIZE8)
   {
     /* Field _int_payload_value8 */
-    return ValidateIntPayloadValue8(InputLength, StartPosition);
+    uint64_t
+    positionAfterIntPayload0 = ValidateIntPayloadValue8(Ctxt, Err, Uu, Input, StartPosition);
+    if (EverParseIsSuccess(positionAfterIntPayload0))
+    {
+      positionAfterIntPayload = positionAfterIntPayload0;
+    }
+    else
+    {
+      Err("_int_payload",
+        "_int_payload_ite_2",
+        EverParseErrorReasonOfResult(positionAfterIntPayload0),
+        Ctxt,
+        Uu,
+        Input,
+        StartPosition,
+        positionAfterIntPayload0);
+      positionAfterIntPayload = positionAfterIntPayload0;
+    }
   }
-  if (Size == (uint32_t)SIZE16)
+  else
   {
-    /* Field _int_payload_value16 */
-    return ValidateIntPayloadValue16(InputLength, StartPosition);
+    uint64_t positionAfterIntPayload0;
+    if (Size == (uint32_t)SIZE16)
+    {
+      /* Field _int_payload_value16 */
+      uint64_t
+      positionAfterIntPayload = ValidateIntPayloadValue16(Ctxt, Err, Uu, Input, StartPosition);
+      if (EverParseIsSuccess(positionAfterIntPayload))
+      {
+        positionAfterIntPayload0 = positionAfterIntPayload;
+      }
+      else
+      {
+        Err("_int_payload",
+          "_int_payload_ite_1",
+          EverParseErrorReasonOfResult(positionAfterIntPayload),
+          Ctxt,
+          Uu,
+          Input,
+          StartPosition,
+          positionAfterIntPayload);
+        positionAfterIntPayload0 = positionAfterIntPayload;
+      }
+    }
+    else
+    {
+      uint64_t positionAfterIntPayload;
+      if (Size == (uint32_t)SIZE32)
+      {
+        /* Field _int_payload_value32 */
+        uint64_t
+        positionAfterIntPayload0 = ValidateIntPayloadValue32(Ctxt, Err, Uu, Input, StartPosition);
+        if (EverParseIsSuccess(positionAfterIntPayload0))
+        {
+          positionAfterIntPayload = positionAfterIntPayload0;
+        }
+        else
+        {
+          Err("_int_payload",
+            "_int_payload_ite_0",
+            EverParseErrorReasonOfResult(positionAfterIntPayload0),
+            Ctxt,
+            Uu,
+            Input,
+            StartPosition,
+            positionAfterIntPayload0);
+          positionAfterIntPayload = positionAfterIntPayload0;
+        }
+      }
+      else
+      {
+        uint64_t positionAfterIntPayload0 = EVERPARSE_VALIDATOR_ERROR_IMPOSSIBLE;
+        if (EverParseIsSuccess(positionAfterIntPayload0))
+        {
+          positionAfterIntPayload = positionAfterIntPayload0;
+        }
+        else
+        {
+          Err("_int_payload",
+            "_int_payload_ite_0",
+            EverParseErrorReasonOfResult(positionAfterIntPayload0),
+            Ctxt,
+            Uu,
+            Input,
+            StartPosition,
+            positionAfterIntPayload0);
+          positionAfterIntPayload = positionAfterIntPayload0;
+        }
+      }
+      if (EverParseIsSuccess(positionAfterIntPayload))
+      {
+        positionAfterIntPayload0 = positionAfterIntPayload;
+      }
+      else
+      {
+        Err("_int_payload",
+          "_int_payload_ite_1",
+          EverParseErrorReasonOfResult(positionAfterIntPayload),
+          Ctxt,
+          Uu,
+          Input,
+          StartPosition,
+          positionAfterIntPayload);
+        positionAfterIntPayload0 = positionAfterIntPayload;
+      }
+    }
+    if (EverParseIsSuccess(positionAfterIntPayload0))
+    {
+      positionAfterIntPayload = positionAfterIntPayload0;
+    }
+    else
+    {
+      Err("_int_payload",
+        "_int_payload_ite_2",
+        EverParseErrorReasonOfResult(positionAfterIntPayload0),
+        Ctxt,
+        Uu,
+        Input,
+        StartPosition,
+        positionAfterIntPayload0);
+      positionAfterIntPayload = positionAfterIntPayload0;
+    }
   }
-  if (Size == (uint32_t)SIZE32)
+  if (EverParseIsSuccess(positionAfterIntPayload))
   {
-    /* Field _int_payload_value32 */
-    return ValidateIntPayloadValue32(InputLength, StartPosition);
+    return positionAfterIntPayload;
   }
-  return EVERPARSE_VALIDATOR_ERROR_IMPOSSIBLE;
+  Err("_int_payload",
+    "",
+    EverParseErrorReasonOfResult(positionAfterIntPayload),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterIntPayload);
+  return positionAfterIntPayload;
 }
 
-static inline uint64_t ValidateIntegerSize(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateIntegerSize(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _integer_size
@@ -130,23 +346,49 @@ static inline uint64_t ValidateIntegerSize(uint32_t InputLength, uint64_t StartP
 {
   /* Validating field size */
   /* Checking that we have enough space for a ULONG, i.e., 4 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)4U)
+  uint64_t positionAfterInteger;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)4U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterInteger = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)4U;
+    positionAfterInteger = StartPosition + (uint64_t)4U;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      TAGGEDUNION__INTEGER__SIZE);
+  if (EverParseIsSuccess(positionAfterInteger))
+  {
+    return positionAfterInteger;
+  }
+  Err("_integer",
+    "_integer_size",
+    EverParseErrorReasonOfResult(positionAfterInteger),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterInteger);
+  return positionAfterInteger;
 }
 
 static inline uint64_t
-ValidateIntegerPayload(uint32_t Size, uint32_t InputLength, uint64_t StartPosition)
+ValidateIntegerPayload(
+  uint32_t Size,
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _integer_payload
@@ -154,14 +396,60 @@ ValidateIntegerPayload(uint32_t Size, uint32_t InputLength, uint64_t StartPositi
 --*/
 {
   /* Validating field payload */
-  return ValidateIntPayload(Size, InputLength, StartPosition);
+  uint64_t positionAfterInteger = ValidateIntPayload(Size, Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterInteger))
+  {
+    return positionAfterInteger;
+  }
+  Err("_integer",
+    "_integer_payload",
+    EverParseErrorReasonOfResult(positionAfterInteger),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterInteger);
+  return positionAfterInteger;
 }
 
 uint64_t
-TaggedUnionValidateInteger(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+TaggedUnionValidateInteger(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _integer_size */
-  uint64_t positionAftersize = ValidateIntegerSize(InputLength, StartPosition);
+  uint64_t positionAfterInteger = ValidateIntegerSize(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAftersize;
+  if (EverParseIsSuccess(positionAfterInteger))
+  {
+    positionAftersize = positionAfterInteger;
+  }
+  else
+  {
+    Err("_integer",
+      "size",
+      EverParseErrorReasonOfResult(positionAfterInteger),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterInteger);
+    positionAftersize = positionAfterInteger;
+  }
   if (EverParseIsError(positionAftersize))
   {
     return positionAftersize;
@@ -169,6 +457,20 @@ TaggedUnionValidateInteger(uint32_t InputLength, uint8_t *Input, uint64_t StartP
   uint8_t *base = Input;
   uint32_t size = Load32Le(base + (uint32_t)StartPosition);
   /* Field _integer_payload */
-  return ValidateIntegerPayload(size, InputLength, positionAftersize);
+  uint64_t
+  positionAfterInteger0 = ValidateIntegerPayload(size, Ctxt, Err, Uu, Input, positionAftersize);
+  if (EverParseIsSuccess(positionAfterInteger0))
+  {
+    return positionAfterInteger0;
+  }
+  Err("_integer",
+    "payload",
+    EverParseErrorReasonOfResult(positionAfterInteger0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAftersize,
+    positionAfterInteger0);
+  return positionAfterInteger0;
 }
 

--- a/doc/3d-snapshot/TaggedUnion.h
+++ b/doc/3d-snapshot/TaggedUnion.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 TaggedUnionValidateInteger(

--- a/doc/3d-snapshot/TaggedUnion.h
+++ b/doc/3d-snapshot/TaggedUnion.h
@@ -10,10 +10,26 @@ extern "C" {
 #include "EverParse.h"
 
 
-
+#include "Lib.h"
 
 uint64_t
-TaggedUnionValidateInteger(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition);
+TaggedUnionValidateInteger(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/TaggedUnionWrapper.c
+++ b/doc/3d-snapshot/TaggedUnionWrapper.c
@@ -2,109 +2,49 @@
 #include "EverParse.h"
 #include "TaggedUnion.h"
 void TaggedUnionEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* TaggedUnionStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2";
-		case 26: return "Derived._Triple";
-		case 27: return "EnumConstraint._enum_constraint";
-		case 28: return "EnumConstraint._enum_constraint";
-		case 29: return "GetFieldPtr._T";
-		case 30: return "GetFieldPtr._T";
-		case 31: return "HelloWorld._point";
-		case 32: return "HelloWorld._point";
-		case 33: return "OrderedPair._orderedPair";
-		case 34: return "OrderedPair._orderedPair";
-		case 35: return "ReadPair._Pair";
-		case 36: return "ReadPair._Pair";
-		case 37: return "Smoker._smoker";
-		case 38: return "Smoker._smoker";
-		case 39: return "TaggedUnion._int_payload";
-		case 40: return "TaggedUnion._int_payload";
-		case 41: return "TaggedUnion._int_payload";
-		case 42: return "TaggedUnion._integer"; 
-		default: return "";
-	}
-}
 
-static char* TaggedUnionFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color";
-		case 26: return "third";
-		case 27: return "col";
-		case 28: return "x";
-		case 29: return "f1";
-		case 30: return "f2";
-		case 31: return "x";
-		case 32: return "y";
-		case 33: return "lesser";
-		case 34: return "greater";
-		case 35: return "first";
-		case 36: return "second";
-		case 37: return "age";
-		case 38: return "cigarettesConsumed";
-		case 39: return "value8";
-		case 40: return "value16";
-		case 41: return "value32";
-		case 42: return "size"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN TaggedUnionCheckInteger(uint8_t *base, uint32_t len) {
-	uint64_t result = TaggedUnionValidateInteger(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		TaggedUnionEverParseError(
-	TaggedUnionStructNameOfErr(result),
-			TaggedUnionFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = TaggedUnionValidateInteger( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			TaggedUnionEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/TaggedUnionWrapper.c
+++ b/doc/3d-snapshot/TaggedUnionWrapper.c
@@ -1,22 +1,22 @@
 #include "TaggedUnionWrapper.h"
 #include "EverParse.h"
 #include "TaggedUnion.h"
-void TaggedUnionEverParseError(char *StructName, char *FieldName, char *Reason);
+void TaggedUnionEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/Triangle.c
+++ b/doc/3d-snapshot/Triangle.c
@@ -2,17 +2,24 @@
 
 #include "Triangle.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define TRIANGLE__POINT__X ((uint64_t)43U)
-
-/*
-Auto-generated field identifier for error reporting
-*/
-#define TRIANGLE__POINT__Y ((uint64_t)44U)
-
-static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidatePointX(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _point_x
@@ -21,19 +28,48 @@ static inline uint64_t ValidatePointX(uint32_t InputLength, uint64_t StartPositi
 {
   /* Validating field x */
   /* Checking that we have enough space for a UINT16, i.e., 2 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)2U)
+  uint64_t positionAfterPoint;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)2U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterPoint = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)2U;
+    positionAfterPoint = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, TRIANGLE__POINT__X);
+  if (EverParseIsSuccess(positionAfterPoint))
+  {
+    return positionAfterPoint;
+  }
+  Err("_point",
+    "_point_x",
+    EverParseErrorReasonOfResult(positionAfterPoint),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterPoint);
+  return positionAfterPoint;
 }
 
-static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidatePointY(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _point_y
@@ -42,31 +78,107 @@ static inline uint64_t ValidatePointY(uint32_t InputLength, uint64_t StartPositi
 {
   /* Validating field y */
   /* Checking that we have enough space for a UINT16, i.e., 2 bytes */
-  uint64_t endPositionOrError;
-  if (((uint64_t)InputLength - StartPosition) < (uint64_t)2U)
+  uint64_t positionAfterPoint;
+  if (((uint64_t)Uu - StartPosition) < (uint64_t)2U)
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+    positionAfterPoint = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
   }
   else
   {
-    endPositionOrError = StartPosition + (uint64_t)2U;
+    positionAfterPoint = StartPosition + (uint64_t)2U;
   }
-  return EverParseMaybeSetErrorCode(endPositionOrError, StartPosition, TRIANGLE__POINT__Y);
+  if (EverParseIsSuccess(positionAfterPoint))
+  {
+    return positionAfterPoint;
+  }
+  Err("_point",
+    "_point_y",
+    EverParseErrorReasonOfResult(positionAfterPoint),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterPoint);
+  return positionAfterPoint;
 }
 
-static inline uint64_t ValidatePoint(uint32_t Uu, uint64_t StartPosition)
+static inline uint64_t
+ValidatePoint(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _point_x */
-  uint64_t positionAfterx = ValidatePointX(Uu, StartPosition);
+  uint64_t positionAfterPoint = ValidatePointX(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAfterx;
+  if (EverParseIsSuccess(positionAfterPoint))
+  {
+    positionAfterx = positionAfterPoint;
+  }
+  else
+  {
+    Err("_point",
+      "x",
+      EverParseErrorReasonOfResult(positionAfterPoint),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterPoint);
+    positionAfterx = positionAfterPoint;
+  }
   if (EverParseIsError(positionAfterx))
   {
     return positionAfterx;
   }
   /* Field _point_y */
-  return ValidatePointY(Uu, positionAfterx);
+  uint64_t positionAfterPoint0 = ValidatePointY(Ctxt, Err, Uu, Input, positionAfterx);
+  if (EverParseIsSuccess(positionAfterPoint0))
+  {
+    return positionAfterPoint0;
+  }
+  Err("_point",
+    "y",
+    EverParseErrorReasonOfResult(positionAfterPoint0),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterx,
+    positionAfterPoint0);
+  return positionAfterPoint0;
 }
 
-static inline uint64_t ValidateTriangleA(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateTriangleA(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _triangle_a
@@ -74,10 +186,40 @@ static inline uint64_t ValidateTriangleA(uint32_t InputLength, uint64_t StartPos
 --*/
 {
   /* Validating field a */
-  return ValidatePoint(InputLength, StartPosition);
+  uint64_t positionAfterTriangle = ValidatePoint(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterTriangle))
+  {
+    return positionAfterTriangle;
+  }
+  Err("_triangle",
+    "_triangle_a",
+    EverParseErrorReasonOfResult(positionAfterTriangle),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterTriangle);
+  return positionAfterTriangle;
 }
 
-static inline uint64_t ValidateTriangleB(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateTriangleB(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _triangle_b
@@ -85,10 +227,40 @@ static inline uint64_t ValidateTriangleB(uint32_t InputLength, uint64_t StartPos
 --*/
 {
   /* Validating field b */
-  return ValidatePoint(InputLength, StartPosition);
+  uint64_t positionAfterTriangle = ValidatePoint(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterTriangle))
+  {
+    return positionAfterTriangle;
+  }
+  Err("_triangle",
+    "_triangle_b",
+    EverParseErrorReasonOfResult(positionAfterTriangle),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterTriangle);
+  return positionAfterTriangle;
 }
 
-static inline uint64_t ValidateTriangleC(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateTriangleC(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _triangle_c
@@ -96,24 +268,101 @@ static inline uint64_t ValidateTriangleC(uint32_t InputLength, uint64_t StartPos
 --*/
 {
   /* Validating field c */
-  return ValidatePoint(InputLength, StartPosition);
+  uint64_t positionAfterTriangle = ValidatePoint(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterTriangle))
+  {
+    return positionAfterTriangle;
+  }
+  Err("_triangle",
+    "_triangle_c",
+    EverParseErrorReasonOfResult(positionAfterTriangle),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterTriangle);
+  return positionAfterTriangle;
 }
 
-uint64_t TriangleValidateTriangle(uint32_t Uu, uint8_t *Input, uint64_t StartPosition)
+uint64_t
+TriangleValidateTriangle(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _triangle_a */
-  uint64_t positionAftera = ValidateTriangleA(Uu, StartPosition);
+  uint64_t positionAfterTriangle = ValidateTriangleA(Ctxt, Err, Uu, Input, StartPosition);
+  uint64_t positionAftera;
+  if (EverParseIsSuccess(positionAfterTriangle))
+  {
+    positionAftera = positionAfterTriangle;
+  }
+  else
+  {
+    Err("_triangle",
+      "a",
+      EverParseErrorReasonOfResult(positionAfterTriangle),
+      Ctxt,
+      Uu,
+      Input,
+      StartPosition,
+      positionAfterTriangle);
+    positionAftera = positionAfterTriangle;
+  }
   if (EverParseIsError(positionAftera))
   {
     return positionAftera;
   }
   /* Field _triangle_b */
-  uint64_t positionAfterb = ValidateTriangleB(Uu, positionAftera);
+  uint64_t positionAfterTriangle0 = ValidateTriangleB(Ctxt, Err, Uu, Input, positionAftera);
+  uint64_t positionAfterb;
+  if (EverParseIsSuccess(positionAfterTriangle0))
+  {
+    positionAfterb = positionAfterTriangle0;
+  }
+  else
+  {
+    Err("_triangle",
+      "b",
+      EverParseErrorReasonOfResult(positionAfterTriangle0),
+      Ctxt,
+      Uu,
+      Input,
+      positionAftera,
+      positionAfterTriangle0);
+    positionAfterb = positionAfterTriangle0;
+  }
   if (EverParseIsError(positionAfterb))
   {
     return positionAfterb;
   }
   /* Field _triangle_c */
-  return ValidateTriangleC(Uu, positionAfterb);
+  uint64_t positionAfterTriangle1 = ValidateTriangleC(Ctxt, Err, Uu, Input, positionAfterb);
+  if (EverParseIsSuccess(positionAfterTriangle1))
+  {
+    return positionAfterTriangle1;
+  }
+  Err("_triangle",
+    "c",
+    EverParseErrorReasonOfResult(positionAfterTriangle1),
+    Ctxt,
+    Uu,
+    Input,
+    positionAfterb,
+    positionAfterTriangle1);
+  return positionAfterTriangle1;
 }
 

--- a/doc/3d-snapshot/Triangle.h
+++ b/doc/3d-snapshot/Triangle.h
@@ -10,9 +10,26 @@ extern "C" {
 #include "EverParse.h"
 
 
+#include "Lib.h"
 
-
-uint64_t TriangleValidateTriangle(uint32_t Uu, uint8_t *Input, uint64_t StartPosition);
+uint64_t
+TriangleValidateTriangle(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/Triangle.h
+++ b/doc/3d-snapshot/Triangle.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 TriangleValidateTriangle(

--- a/doc/3d-snapshot/Triangle2.c
+++ b/doc/3d-snapshot/Triangle2.c
@@ -2,14 +2,24 @@
 
 #include "Triangle2.h"
 
-/*
-Auto-generated field identifier for error reporting
-*/
-#define TRIANGLE2__TRIANGLE__CORNERS ((uint64_t)47U)
-
-typedef uint8_t *Dtuple2_uint8T___;
-
-static inline uint64_t ValidateTriangleCorners(uint32_t InputLength, uint64_t StartPosition)
+static inline uint64_t
+ValidateTriangleCorners(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 /*++
     Internal helper function:
         Validator for field _triangle_corners
@@ -17,32 +27,70 @@ static inline uint64_t ValidateTriangleCorners(uint32_t InputLength, uint64_t St
 --*/
 {
   /* Validating field corners */
-  uint64_t endPositionOrError;
+  uint64_t positionAfterTriangle;
   if ((uint32_t)4U * (uint32_t)(uint8_t)3U % (uint32_t)4U == (uint32_t)0U)
   {
-    if (((uint64_t)InputLength - StartPosition) < (uint64_t)((uint32_t)4U * (uint32_t)(uint8_t)3U))
+    if (((uint64_t)Uu - StartPosition) < (uint64_t)((uint32_t)4U * (uint32_t)(uint8_t)3U))
     {
-      endPositionOrError = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
+      positionAfterTriangle = EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA;
     }
     else
     {
-      endPositionOrError = StartPosition + (uint64_t)((uint32_t)4U * (uint32_t)(uint8_t)3U);
+      positionAfterTriangle = StartPosition + (uint64_t)((uint32_t)4U * (uint32_t)(uint8_t)3U);
     }
   }
   else
   {
-    endPositionOrError = EVERPARSE_VALIDATOR_ERROR_LIST_SIZE_NOT_MULTIPLE;
+    positionAfterTriangle = EVERPARSE_VALIDATOR_ERROR_LIST_SIZE_NOT_MULTIPLE;
   }
-  return
-    EverParseMaybeSetErrorCode(endPositionOrError,
-      StartPosition,
-      TRIANGLE2__TRIANGLE__CORNERS);
+  if (EverParseIsSuccess(positionAfterTriangle))
+  {
+    return positionAfterTriangle;
+  }
+  Err("_triangle",
+    "_triangle_corners",
+    EverParseErrorReasonOfResult(positionAfterTriangle),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterTriangle);
+  return positionAfterTriangle;
 }
 
 uint64_t
-Triangle2ValidateTriangle(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition)
+Triangle2ValidateTriangle(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+)
 {
   /* Field _triangle_corners */
-  return ValidateTriangleCorners(InputLength, StartPosition);
+  uint64_t positionAfterTriangle = ValidateTriangleCorners(Ctxt, Err, Uu, Input, StartPosition);
+  if (EverParseIsSuccess(positionAfterTriangle))
+  {
+    return positionAfterTriangle;
+  }
+  Err("_triangle",
+    "corners",
+    EverParseErrorReasonOfResult(positionAfterTriangle),
+    Ctxt,
+    Uu,
+    Input,
+    StartPosition,
+    positionAfterTriangle);
+  return positionAfterTriangle;
 }
 

--- a/doc/3d-snapshot/Triangle2.c
+++ b/doc/3d-snapshot/Triangle2.c
@@ -2,6 +2,8 @@
 
 #include "Triangle2.h"
 
+typedef uint8_t *Dtuple2_uint8T___;
+
 static inline uint64_t
 ValidateTriangleCorners(
   uint8_t *Ctxt,

--- a/doc/3d-snapshot/Triangle2.h
+++ b/doc/3d-snapshot/Triangle2.h
@@ -10,10 +10,26 @@ extern "C" {
 #include "EverParse.h"
 
 
-
+#include "Lib.h"
 
 uint64_t
-Triangle2ValidateTriangle(uint32_t InputLength, uint8_t *Input, uint64_t StartPosition);
+Triangle2ValidateTriangle(
+  uint8_t *Ctxt,
+  void
+  (*Err)(
+    EverParseString x0,
+    EverParseString x1,
+    EverParseString x2,
+    uint8_t *x3,
+    uint32_t x4,
+    uint8_t *x5,
+    uint64_t x6,
+    uint64_t x7
+  ),
+  uint32_t Uu,
+  uint8_t *Input,
+  uint64_t StartPosition
+);
 
 #if defined(__cplusplus)
 }

--- a/doc/3d-snapshot/Triangle2.h
+++ b/doc/3d-snapshot/Triangle2.h
@@ -10,7 +10,7 @@ extern "C" {
 #include "EverParse.h"
 
 
-#include "Lib.h"
+
 
 uint64_t
 Triangle2ValidateTriangle(

--- a/doc/3d-snapshot/Triangle2Wrapper.c
+++ b/doc/3d-snapshot/Triangle2Wrapper.c
@@ -1,22 +1,22 @@
 #include "Triangle2Wrapper.h"
 #include "EverParse.h"
 #include "Triangle2.h"
-void Triangle2EverParseError(char *StructName, char *FieldName, char *Reason);
+void Triangle2EverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/Triangle2Wrapper.c
+++ b/doc/3d-snapshot/Triangle2Wrapper.c
@@ -2,119 +2,49 @@
 #include "EverParse.h"
 #include "Triangle2.h"
 void Triangle2EverParseError(char *StructName, char *FieldName, char *Reason);
-static char* Triangle2StructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2";
-		case 26: return "Derived._Triple";
-		case 27: return "EnumConstraint._enum_constraint";
-		case 28: return "EnumConstraint._enum_constraint";
-		case 29: return "GetFieldPtr._T";
-		case 30: return "GetFieldPtr._T";
-		case 31: return "HelloWorld._point";
-		case 32: return "HelloWorld._point";
-		case 33: return "OrderedPair._orderedPair";
-		case 34: return "OrderedPair._orderedPair";
-		case 35: return "ReadPair._Pair";
-		case 36: return "ReadPair._Pair";
-		case 37: return "Smoker._smoker";
-		case 38: return "Smoker._smoker";
-		case 39: return "TaggedUnion._int_payload";
-		case 40: return "TaggedUnion._int_payload";
-		case 41: return "TaggedUnion._int_payload";
-		case 42: return "TaggedUnion._integer";
-		case 43: return "Triangle._point";
-		case 44: return "Triangle._point";
-		case 45: return "Triangle2._point";
-		case 46: return "Triangle2._point";
-		case 47: return "Triangle2._triangle"; 
-		default: return "";
-	}
-}
 
-static char* Triangle2FieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color";
-		case 26: return "third";
-		case 27: return "col";
-		case 28: return "x";
-		case 29: return "f1";
-		case 30: return "f2";
-		case 31: return "x";
-		case 32: return "y";
-		case 33: return "lesser";
-		case 34: return "greater";
-		case 35: return "first";
-		case 36: return "second";
-		case 37: return "age";
-		case 38: return "cigarettesConsumed";
-		case 39: return "value8";
-		case 40: return "value16";
-		case 41: return "value32";
-		case 42: return "size";
-		case 43: return "x";
-		case 44: return "y";
-		case 45: return "x";
-		case 46: return "y";
-		case 47: return "corners"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN Triangle2CheckTriangle(uint8_t *base, uint32_t len) {
-	uint64_t result = Triangle2ValidateTriangle(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		Triangle2EverParseError(
-	Triangle2StructNameOfErr(result),
-			Triangle2FieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = Triangle2ValidateTriangle( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			Triangle2EverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/doc/3d-snapshot/TriangleWrapper.c
+++ b/doc/3d-snapshot/TriangleWrapper.c
@@ -1,22 +1,22 @@
 #include "TriangleWrapper.h"
 #include "EverParse.h"
 #include "Triangle.h"
-void TriangleEverParseError(char *StructName, char *FieldName, char *Reason);
+void TriangleEverParseError(const char *StructName, const char *FieldName, const char *Reason);
 
 typedef struct _ErrorFrame
 {
 	BOOLEAN filled;
 	uint32_t start_pos;
 	uint32_t end_pos;
-	char *typename;
-	char *fieldname;
-	char *reason;
+	const char *typename;
+	const char *fieldname;
+	const char *reason;
 } ErrorFrame;
 
 void DefaultErrorHandler(
-	EverParseString typename,
-	EverParseString fieldname,
-	EverParseString reason,
+	const char *typename,
+	const char *fieldname,
+	const char *reason,
 	uint8_t *context,
 	uint32_t len,
 	uint8_t *base,

--- a/doc/3d-snapshot/TriangleWrapper.c
+++ b/doc/3d-snapshot/TriangleWrapper.c
@@ -2,113 +2,49 @@
 #include "EverParse.h"
 #include "Triangle.h"
 void TriangleEverParseError(char *StructName, char *FieldName, char *Reason);
-static char* TriangleStructNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "BF._BF";
-		case 2: return "BF._BF";
-		case 3: return "BF._BF";
-		case 4: return "BF._BF2";
-		case 5: return "BF._BF2";
-		case 6: return "BF._BF2";
-		case 7: return "Base._Pair";
-		case 8: return "Base._Pair";
-		case 9: return "Base._Mine";
-		case 10: return "Base._Mine";
-		case 11: return "BoundedSum._boundedSum";
-		case 12: return "BoundedSum._boundedSum";
-		case 13: return "BoundedSum.mySum";
-		case 14: return "BoundedSumConst._boundedSum";
-		case 15: return "BoundedSumConst._boundedSum";
-		case 16: return "BoundedSumWhere._boundedSum";
-		case 17: return "BoundedSumWhere._boundedSum";
-		case 18: return "BoundedSumWhere._boundedSum";
-		case 19: return "Color._coloredPoint";
-		case 20: return "Color._coloredPoint";
-		case 21: return "Color._coloredPoint";
-		case 22: return "ColoredPoint._point";
-		case 23: return "ColoredPoint._point";
-		case 24: return "ColoredPoint._coloredPoint1";
-		case 25: return "ColoredPoint._coloredPoint2";
-		case 26: return "Derived._Triple";
-		case 27: return "EnumConstraint._enum_constraint";
-		case 28: return "EnumConstraint._enum_constraint";
-		case 29: return "GetFieldPtr._T";
-		case 30: return "GetFieldPtr._T";
-		case 31: return "HelloWorld._point";
-		case 32: return "HelloWorld._point";
-		case 33: return "OrderedPair._orderedPair";
-		case 34: return "OrderedPair._orderedPair";
-		case 35: return "ReadPair._Pair";
-		case 36: return "ReadPair._Pair";
-		case 37: return "Smoker._smoker";
-		case 38: return "Smoker._smoker";
-		case 39: return "TaggedUnion._int_payload";
-		case 40: return "TaggedUnion._int_payload";
-		case 41: return "TaggedUnion._int_payload";
-		case 42: return "TaggedUnion._integer";
-		case 43: return "Triangle._point";
-		case 44: return "Triangle._point"; 
-		default: return "";
-	}
-}
 
-static char* TriangleFieldNameOfErr(uint64_t err) {
-	switch (EverParseFieldIdOfResult(err)) {
-		case 1: return "x";
-		case 2: return "y";
-		case 3: return "z";
-		case 4: return "x";
-		case 5: return "y";
-		case 6: return "z";
-		case 7: return "first";
-		case 8: return "second";
-		case 9: return "f";
-		case 10: return "g";
-		case 11: return "left";
-		case 12: return "right";
-		case 13: return "bound";
-		case 14: return "left";
-		case 15: return "right";
-		case 16: return "__precondition";
-		case 17: return "left";
-		case 18: return "right";
-		case 19: return "col";
-		case 20: return "x";
-		case 21: return "y";
-		case 22: return "x";
-		case 23: return "y";
-		case 24: return "color";
-		case 25: return "color";
-		case 26: return "third";
-		case 27: return "col";
-		case 28: return "x";
-		case 29: return "f1";
-		case 30: return "f2";
-		case 31: return "x";
-		case 32: return "y";
-		case 33: return "lesser";
-		case 34: return "greater";
-		case 35: return "first";
-		case 36: return "second";
-		case 37: return "age";
-		case 38: return "cigarettesConsumed";
-		case 39: return "value8";
-		case 40: return "value16";
-		case 41: return "value32";
-		case 42: return "size";
-		case 43: return "x";
-		case 44: return "y"; 
-		default: return "";
+typedef struct _ErrorFrame
+{
+	BOOLEAN filled;
+	uint32_t start_pos;
+	uint32_t end_pos;
+	char *typename;
+	char *fieldname;
+	char *reason;
+} ErrorFrame;
+
+void DefaultErrorHandler(
+	EverParseString typename,
+	EverParseString fieldname,
+	EverParseString reason,
+	uint8_t *context,
+	uint32_t len,
+	uint8_t *base,
+	uint64_t start_pos,
+	uint64_t end_pos)
+{
+	ErrorFrame *frame = (ErrorFrame*)context;
+	if (!frame->filled)
+	{
+		frame->filled = TRUE;
+		frame->start_pos = start_pos;
+		frame->end_pos = end_pos;
+		frame->typename = typename;
+		frame->fieldname = fieldname;
+		frame->reason = reason;
 	}
 }
 
 BOOLEAN TriangleCheckTriangle(uint8_t *base, uint32_t len) {
-	uint64_t result = TriangleValidateTriangle(len, base, 0);
-	if (EverParseResultIsError(result)) {
-		TriangleEverParseError(
-	TriangleStructNameOfErr(result),
-			TriangleFieldNameOfErr (result),
-			EverParseErrorReasonOfResult(result));
+	ErrorFrame frame;
+	frame.filled = FALSE;
+	uint64_t result = TriangleValidateTriangle( (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);
+	if (EverParseResultIsError(result))
+	{
+		if (frame.filled)
+		{
+			TriangleEverParseError(frame.typename, frame.fieldname, frame.reason);
+		}
 		return FALSE;
 	}
 	return TRUE;

--- a/src/3d/Ast.fst
+++ b/src/3d/Ast.fst
@@ -279,14 +279,6 @@ type qualifier =
 ///   Parameters have a name and are always annoted with their type
 type param =  typ & ident & qualifier
 
-// /// field_num: Every field in a struct is assigned a unique identifier
-// ///   which is then reported in case validation fails. The identifier
-// ///   has to be suitably small, so that it fits in the 32 bits that
-// ///   LowParse reserves for both field identifiers and error codes.
-// ///
-// ///   We pick this to be 2^16 now. Which is to say that a single en
-// let field_num = n:nat{ 0 < n /\ n < pow2 16 }
-
 noeq
 type bitfield_attr' = {
   bitfield_width : int;
@@ -318,7 +310,6 @@ type struct_field = {
   field_type:typ;          //type of the field
   field_array_opt: field_array_t;
   field_constraint:option expr; //refinement constraint
-  // field_number:option field_num; //computed; field identifiers, used for error reporting
   field_bitwidth:option field_bitwidth_t;  //bits used for the field; elaborate from Inl to Inr
   field_action:option (action & bool); //boo indicates if the action depends on the field value
 }

--- a/src/3d/Ast.fst
+++ b/src/3d/Ast.fst
@@ -279,13 +279,13 @@ type qualifier =
 ///   Parameters have a name and are always annoted with their type
 type param =  typ & ident & qualifier
 
-/// field_num: Every field in a struct is assigned a unique identifier
-///   which is then reported in case validation fails. The identifier
-///   has to be suitably small, so that it fits in the 32 bits that
-///   LowParse reserves for both field identifiers and error codes.
-///
-///   We pick this to be 2^16 now. Which is to say that a single en
-let field_num = n:nat{ 0 < n /\ n < pow2 16 }
+// /// field_num: Every field in a struct is assigned a unique identifier
+// ///   which is then reported in case validation fails. The identifier
+// ///   has to be suitably small, so that it fits in the 32 bits that
+// ///   LowParse reserves for both field identifiers and error codes.
+// ///
+// ///   We pick this to be 2^16 now. Which is to say that a single en
+// let field_num = n:nat{ 0 < n /\ n < pow2 16 }
 
 noeq
 type bitfield_attr' = {
@@ -318,7 +318,7 @@ type struct_field = {
   field_type:typ;          //type of the field
   field_array_opt: field_array_t;
   field_constraint:option expr; //refinement constraint
-  field_number:option field_num; //computed; field identifiers, used for error reporting
+  // field_number:option field_num; //computed; field identifiers, used for error reporting
   field_bitwidth:option field_bitwidth_t;  //bits used for the field; elaborate from Inl to Inr
   field_action:option (action & bool); //boo indicates if the action depends on the field value
 }
@@ -456,7 +456,6 @@ let tuint16 = mk_prim_t "UINT16"
 let tuint32 = mk_prim_t "UINT32"
 let tuint64 = mk_prim_t "UINT64"
 let tunknown = mk_prim_t "?"
-let tfield_id = mk_prim_t "field_id"
 
 let map_opt (f:'a -> ML 'b) (o:option 'a) : ML (option 'b) =
   match o with

--- a/src/3d/Binding.fsti
+++ b/src/3d/Binding.fsti
@@ -19,11 +19,11 @@ open Ast
 
 val global_env : Type0
 
-val all_nums (ge: global_env)
-  : ML (list (field_num & option ident & string)) //retrieve a table of identifier/field-name mappings
+// val all_nums (ge: global_env)
+//   : ML (list (field_num & option ident & string)) //retrieve a table of identifier/field-name mappings
 
-(* retrieve the name of the field code variable *)
-val lookup_field_num : global_env -> field_num -> ML (option ident)
+// (* retrieve the name of the field code variable *)
+// val lookup_field_num : global_env -> field_num -> ML (option ident)
 
 val env : Type0
 val mk_env (g:global_env) : ML env
@@ -37,16 +37,9 @@ val parser_kind_nz (env:global_env) (id:ident) : ML (option bool)
 val parser_weak_kind  (env:global_env) (id:ident) : ML (option weak_kind)
 val size_of_integral_typ (_:env) (_:typ) (_:range) : ML int
 val bind_decls (g:global_env) (p:list decl) : ML (list decl & global_env)
-val next_field_num (enclosing_struct:ident)
-                   (field_name:ident)
-                   (_:env)
-    : ML field_num
-val add_field_error_code_decls (ge: env)
-  : ML (list decl)
+//val add_field_error_code_decls (ge: env) : ML (list decl)
 
 val initial_global_env (_:unit) : ML global_env
-
 val get_exported_decls (ge:global_env) (mname:string) : ML (list ident' & list ident')  //exported, private
-
 val finish_module (ge:global_env) (mname:string) (e_and_p:list ident' & list ident')
   : ML global_env

--- a/src/3d/Binding.fsti
+++ b/src/3d/Binding.fsti
@@ -19,12 +19,6 @@ open Ast
 
 val global_env : Type0
 
-// val all_nums (ge: global_env)
-//   : ML (list (field_num & option ident & string)) //retrieve a table of identifier/field-name mappings
-
-// (* retrieve the name of the field code variable *)
-// val lookup_field_num : global_env -> field_num -> ML (option ident)
-
 val env : Type0
 val mk_env (g:global_env) : ML env
 val global_env_of_env (e:env) : ML global_env

--- a/src/3d/BitFields.fst
+++ b/src/3d/BitFields.fst
@@ -66,9 +66,9 @@ let coalesce_grouped_bit_field env (f:bitfield_group)
       | Some (Inr bf) -> bf.v
       | _ -> failwith "Must have elaborated bitfield"
     in
-    let field_dependence, field_constraint, field_num, subst =
+    let field_dependence, field_constraint, subst =
       List.fold_left
-        (fun (dep, acc_constraint, num, subst) f ->
+        (fun (dep, acc_constraint, subst) f ->
           let f = f.v in
           let dep = dep || f.field_dependence in
           let acc_constraint =
@@ -85,8 +85,8 @@ let coalesce_grouped_bit_field env (f:bitfield_group)
               mk_e (Constant (Int UInt32 (bitfield_attrs f).bitfield_to))]
           in
           let subst = (f.field_ident, mk_e bf_exp) :: subst in
-          dep, acc_constraint, f.field_number, subst)
-       (false, None, None, [])
+          dep, acc_constraint, subst)
+       (false, None, [])
        fields
     in
     let struct_field = {
@@ -95,7 +95,6 @@ let coalesce_grouped_bit_field env (f:bitfield_group)
       field_type = typ;
       field_array_opt = FieldScalar;
       field_constraint = field_constraint;
-      field_number = field_num;
       field_bitwidth = None;
       field_action = None; //TODO conjunction of all actions on individual fields?
     } in

--- a/src/3d/EverParseEndianness.h
+++ b/src/3d/EverParseEndianness.h
@@ -33,7 +33,7 @@ extern "C" {
 #include <string.h>
 #include <stdint.h>
 
-typedef char * const EverParseString;
+typedef const char * EverParseString;
 
 /* ... for Windows (MSVC)... not targeting XBOX 360! */
 #if defined(_MSC_VER)

--- a/src/3d/EverParseEndianness_Windows_NT.h
+++ b/src/3d/EverParseEndianness_Windows_NT.h
@@ -34,7 +34,7 @@ nswamy, protz, taramana 5-Feb-2020
 
 #  include <windef.h>
 
-typedef char * const EverParseString;
+typedef const char * EverParseString;
 
 #  define htobe16(x) _byteswap_ushort(x)
 #  define htole16(x) (x)

--- a/src/3d/StaticAssertions.fst
+++ b/src/3d/StaticAssertions.fst
@@ -79,8 +79,7 @@ let has_static_asserts (sas: static_asserts) : Tot bool =
 
 let print_static_asserts (sas:static_asserts)
   : ML string
-  = let open StaticAssertions in
-    let includes =
+  = let includes =
         sas.includes
         |> List.map (fun i -> Printf.sprintf "#include \"%s\"" i)
         |> String.concat "\n"

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -609,11 +609,10 @@ let rec print_validator (mname:string) (v:validator) : ML string = //(decreases 
     "(validate_impos())"
 
   | Validate_with_error_handler typename fieldname v ->
-    Printf.sprintf "(validate_with_error_handler \"%s\" \"%s\" %s %s)"
+    Printf.sprintf "(validate_with_error_handler \"%s\" \"%s\" %s)"
                    (print_maybe_qualified_ident mname typename)
                    fieldname
                    (print_validator mname v)
-                   (print_maybe_qualified_ident mname error_handler_name)      
 
   | Validate_with_comment v c ->
     let c = String.concat "\n" c in
@@ -985,9 +984,7 @@ let print_c_entry (modul: string)
                   (ds:list decl)
     : ML (string & string)
     =  let default_error_handler =
-        Printf.sprintf
-          "\
-          typedef struct _ErrorFrame\n\
+         "typedef struct _ErrorFrame\n\
           {\n\t\
              BOOLEAN filled;\n\t\
              uint32_t start_pos;\n\t\
@@ -997,7 +994,7 @@ let print_c_entry (modul: string)
              char *reason;\n\
           } ErrorFrame;\n\
           \n\
-          void %sHandleError(\n\t\
+          void DefaultErrorHandler(\n\t\
                               EverParseString typename,\n\t\
                               EverParseString fieldname,\n\t\
                               EverParseString reason,\n\t\
@@ -1018,13 +1015,12 @@ let print_c_entry (modul: string)
               frame->reason = reason;\n\t\
             }\n\
           }" 
-          modul
    in
    let wrapped_call name params =
      Printf.sprintf
        "ErrorFrame frame;\n\t\
        frame.filled = FALSE;\n\t\
-       uint64_t result = %s(%s (uint8_t*)&frame, len, base, 0);\n\t\
+       uint64_t result = %s(%s (uint8_t*)&frame, &DefaultErrorHandler, len, base, 0);\n\t\
        if (EverParseResultIsError(result))\n\t\
        {\n\t\t\
          if (frame.filled)\n\t\t\

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -53,6 +53,35 @@ let rec parser_kind_eq k k' =
     && parser_kind_eq k2 k2'
   | _ -> false
 
+// Some constants
+
+let default_attrs = {
+    is_hoisted = false;
+    is_exported = false;
+    should_inline = false;
+    comments = []
+}
+
+let error_handler_name =
+  let open A in
+  let id' = {
+    modul_name = None;
+    name = "handle_error";
+  } in
+  let id = with_range id' dummy_range in
+  id
+  
+let error_handler_decl =
+  let open A in
+  let error_handler_id' = {
+    modul_name = Some "Actions";
+    name = "error_handler"
+  } in
+  let error_handler_id = with_range error_handler_id' dummy_range in
+  let typ = T_app error_handler_id [] in
+  let a = Assumption (error_handler_name, typ) in
+  a, default_attrs
+
 ////////////////////////////////////////////////////////////////////////////////
 // Printing the target AST in F* concrete syntax
 ////////////////////////////////////////////////////////////////////////////////
@@ -360,8 +389,8 @@ let rec print_parser (mname:string) (p:parser) : ML string = //(decreases p) =
     Printf.sprintf "(%s `parse_dep_pair` %s)"
       (print_parser mname p1)
       (print_lam (print_parser mname) p2)
-  | Parse_dep_pair_with_refinement _ _ p1 e p2
-  | Parse_dep_pair_with_refinement_and_action _ _ p1 e _ p2 ->
+  | Parse_dep_pair_with_refinement _ p1 e p2
+  | Parse_dep_pair_with_refinement_and_action _ p1 e _ p2 ->
     Printf.sprintf "((%s `parse_filter` %s) `parse_dep_pair` %s)"
                    (print_parser mname p1)
                    (print_expr_lam mname e)
@@ -385,7 +414,6 @@ let rec print_parser (mname:string) (p:parser) : ML string = //(decreases p) =
       (print_parser mname p1)
       (print_parser mname p2)
   | Parse_impos -> "(parse_impos())"
-  | Parse_with_error _ p
   | Parse_with_dep_action _ p _
   | Parse_with_action _ p _
   | Parse_with_comment p _ -> print_parser mname p
@@ -448,58 +476,83 @@ let rec print_validator (mname:string) (v:validator) : ML string = //(decreases 
   in
   match v.v_validator with
   | Validate_return ->
-    Printf.sprintf "validate_ret"
+    "validate_ret"
+
   | Validate_app hd args ->
-    Printf.sprintf "(validate_eta (%svalidate_%s %s))" (maybe_mname_prefix mname hd) (print_ident hd) (String.concat " " (print_indexes mname args))
+    Printf.sprintf "(validate_eta (%svalidate_%s %s))"
+                   (maybe_mname_prefix mname hd)
+                   (print_ident hd)
+                   (String.concat " " (print_indexes mname args))
+
   | Validate_nlist e p ->
-    Printf.sprintf "(validate_nlist %s %s)" (print_expr mname e) (print_validator mname p)
+    Printf.sprintf "(validate_nlist %s %s)"
+                   (print_expr mname e)
+                   (print_validator mname p)
+
   | Validate_t_at_most e p ->
-    Printf.sprintf "(validate_t_at_most %s %s)" (print_expr mname e) (print_validator mname p)
+    Printf.sprintf "(validate_t_at_most %s %s)"
+                   (print_expr mname e)
+                   (print_validator mname p)
+
   | Validate_t_exact e p ->
-    Printf.sprintf "(validate_t_exact %s %s)" (print_expr mname e) (print_validator mname p)
+    Printf.sprintf "(validate_t_exact %s %s)"
+                   (print_expr mname e)
+                   (print_validator mname p)
+
   | Validate_nlist_constant_size_without_actions e p ->
     let n_is_const = match fst e with
     | Constant (A.Int _ _) -> true
     | _ -> false
     in
-    Printf.sprintf "(validate_nlist_constant_size_without_actions %s %s %s)" (if n_is_const then "true" else "false") (print_expr mname e) (print_validator mname p)
+    Printf.sprintf "(validate_nlist_constant_size_without_actions %s %s %s)"
+                   (if n_is_const then "true" else "false")
+                   (print_expr mname e)
+                   (print_validator mname p)
+
   | Validate_pair n1 p1 p2 ->
-    Printf.sprintf "(validate_pair \"%s\" %s %s)" (print_maybe_qualified_ident mname n1) (print_validator mname p1) (print_validator mname p2)
+    Printf.sprintf "(validate_pair \"%s\" %s %s)"
+                   (print_maybe_qualified_ident mname n1)
+                   (print_validator mname p1)
+                   (print_validator mname p2)
+
   | Validate_dep_pair n1 p1 r p2 ->
     Printf.sprintf "(validate_dep_pair \"%s\" %s %s %s)"
-      (print_ident n1)
-      (print_validator mname p1)
-      (print_reader mname r)
-      (print_lam (print_validator mname) p2)
-  | Validate_dep_pair_with_refinement p1_is_constant_size_without_actions n1 f1 p1 r e p2 ->
-    Printf.sprintf "(validate_dep_pair_with_refinement %s \"%s\" %s %s %s %s %s)"
-      (if p1_is_constant_size_without_actions then "true" else "false")
-      (print_maybe_qualified_ident mname n1)
-      (print_field_id_name f1)
-      (print_validator mname p1)
-      (print_reader mname r)
-      (print_expr_lam mname e)
-      (print_lam (print_validator mname) p2)
+                   (print_ident n1)
+                   (print_validator mname p1)
+                   (print_reader mname r)
+                   (print_lam (print_validator mname) p2)
+
+  | Validate_dep_pair_with_refinement p1_is_constant_size_without_actions n1 p1 r e p2 ->
+    Printf.sprintf "(validate_dep_pair_with_refinement %s \"%s\" 1uL %s %s %s %s)"
+                   (if p1_is_constant_size_without_actions then "true" else "false")
+                   (print_maybe_qualified_ident mname n1)
+                   (print_validator mname p1)
+                   (print_reader mname r)
+                   (print_expr_lam mname e)
+                   (print_lam (print_validator mname) p2)
+
   | Validate_dep_pair_with_action p1 r a p2 ->
     Printf.sprintf "(validate_dep_pair_with_action %s %s %s %s)"
-      (print_validator mname p1)
-      (print_reader mname r)
-      (print_lam (print_action mname) a)
-      (print_lam (print_validator mname) p2)
-  | Validate_dep_pair_with_refinement_and_action p1_is_constant_size_without_actions n1 f1 p1 r e a p2 ->
-    Printf.sprintf "(validate_dep_pair_with_refinement_and_action %s \"%s\" %s %s %s %s %s %s)"
-      (if p1_is_constant_size_without_actions then "true" else "false")
-      (print_maybe_qualified_ident mname n1)
-      (print_field_id_name f1)
-      (print_validator mname p1)
-      (print_reader mname r)
-      (print_expr_lam mname e)
-      (print_lam (print_action mname) a)
-      (print_lam (print_validator mname) p2)
+                   (print_validator mname p1)
+                   (print_reader mname r)
+                   (print_lam (print_action mname) a)
+                   (print_lam (print_validator mname) p2)
+
+  | Validate_dep_pair_with_refinement_and_action p1_is_constant_size_without_actions n1 p1 r e a p2 ->
+    Printf.sprintf "(validate_dep_pair_with_refinement_and_action %s \"%s\" %s %s %s %s %s)"
+                   (if p1_is_constant_size_without_actions then "true" else "false")
+                   (print_maybe_qualified_ident mname n1)
+                   (print_validator mname p1)
+                   (print_reader mname r)
+                   (print_expr_lam mname e)
+                   (print_lam (print_action mname) a)
+                   (print_lam (print_validator mname) p2)
+
   | Validate_map p1 e ->
     Printf.sprintf "(%s `validate_map` %s)"
-      (print_validator mname p1)
-      (print_expr_lam mname e)
+                   (print_validator mname p1)
+                   (print_expr_lam mname e)
+
   | Validate_refinement n1 p1 r e ->
     begin
       if is_unit_validator p1
@@ -512,53 +565,78 @@ let rec print_validator (mname:string) (v:validator) : ML string = //(decreases 
                           (print_reader mname r)
                           (print_expr_lam mname e)
     end
+
   | Validate_refinement_with_action n1 p1 r e a ->
     Printf.sprintf "(validate_filter_with_action \"%s\" %s %s %s
                                             \"reading field value\" \"checking constraint\"
                                             %s)"
-                          (print_maybe_qualified_ident mname n1)
-                          (print_validator mname p1)
-                          (print_reader mname r)
-                          (print_expr_lam mname e)
-                          (print_lam (print_action mname) a)
+                   (print_maybe_qualified_ident mname n1)
+                   (print_validator mname p1)
+                   (print_reader mname r)
+                   (print_expr_lam mname e)
+                   (print_lam (print_action mname) a)
+
   | Validate_with_action name v a ->
     Printf.sprintf "(validate_with_success_action \"%s\" %s %s)"
-      (print_maybe_qualified_ident mname name)
-      (print_validator mname v)
-      (print_action mname a)
+                   (print_maybe_qualified_ident mname name)
+                   (print_validator mname v)
+                   (print_action mname a)
+
   | Validate_with_dep_action n v r a ->
     Printf.sprintf "(validate_with_dep_action \"%s\" %s %s %s)"
-      (print_maybe_qualified_ident mname n)
-      (print_validator mname v)
-      (print_reader mname r)
-      (print_lam (print_action mname) a)
+                   (print_maybe_qualified_ident mname n)
+                   (print_validator mname v)
+                   (print_reader mname r)
+                   (print_lam (print_action mname) a)
+
   | Validate_weaken_left p1 k ->
-    Printf.sprintf "(validate_weaken_left %s _)" (print_validator mname p1) // (print_kind mname k)
+    Printf.sprintf "(validate_weaken_left %s _)"
+                   (print_validator mname p1)
+
   | Validate_weaken_right p1 k ->
-    Printf.sprintf "(validate_weaken_right %s _)" (print_validator mname p1) // (print_kind mname k)
+    Printf.sprintf "(validate_weaken_right %s _)"
+                   (print_validator mname p1)
+
   | Validate_if_else e v1 v2 ->
     Printf.sprintf "(validate_ite %s (fun _ -> %s) (fun _ -> %s) (fun _ -> %s) (fun _ -> %s))"
-      (print_expr mname e)
-      (print_parser mname v1.v_parser)
-      (print_validator mname v1)
-      (print_parser mname v2.v_parser)
-      (print_validator mname v2)
-  | Validate_impos -> "(validate_impos())"
-  | Validate_with_error fn v ->
-    Printf.sprintf "(validate_with_error %s %s)" (print_field_id_name fn) (print_validator mname v)
+                   (print_expr mname e)
+                   (print_parser mname v1.v_parser)
+                   (print_validator mname v1)
+                   (print_parser mname v2.v_parser)
+                   (print_validator mname v2)
+
+  | Validate_impos ->
+    "(validate_impos())"
+
+  | Validate_with_error_handler typename fieldname v ->
+    Printf.sprintf "(validate_with_error_handler \"%s\" \"%s\" %s %s)"
+                   (print_maybe_qualified_ident mname typename)
+                   fieldname
+                   (print_validator mname v)
+                   (print_maybe_qualified_ident mname error_handler_name)      
+
   | Validate_with_comment v c ->
     let c = String.concat "\n" c in
     Printf.sprintf "(validate_with_comment \"%s\" %s)"
-      c
-      (print_validator mname v)
+                   c
+                   (print_validator mname v)
+
   | Validate_string velem relem zero ->
-    Printf.sprintf "(validate_string %s %s %s)" (print_validator mname velem) (print_reader mname relem) (print_expr mname zero)
+    Printf.sprintf "(validate_string %s %s %s)" 
+                   (print_validator mname velem)
+                   (print_reader mname relem)
+                   (print_expr mname zero)
 
 let print_typedef_name (mname:string) (tdn:typedef_name) : ML string =
   Printf.sprintf "%s %s"
-    (print_ident tdn.td_name)
-    (String.concat " "
-      (List.map (fun (id, t) -> Printf.sprintf "(%s:%s)" (print_ident id) (print_typ mname t)) tdn.td_params))
+                 (print_ident tdn.td_name)
+                 (String.concat " "
+                   (List.map 
+                     (fun (id, t) -> 
+                       Printf.sprintf "(%s:%s)"
+                                      (print_ident id)
+                                      (print_typ mname t))
+                     tdn.td_params))
 
 let print_typedef_typ (tdn:typedef_name) : ML string =
   Printf.sprintf "%s %s"
@@ -571,11 +649,10 @@ let print_typedef_body (mname:string) (b:typedef_body) : ML string =
   | TD_abbrev t -> print_typ mname t
   | TD_struct fields ->
     let print_field (sf:field) : ML string =
-        Printf.sprintf "%s : %s%s%s"
+        Printf.sprintf "%s : %s%s"
           (print_ident sf.sf_ident)
           (print_typ mname sf.sf_typ)
           (if sf.sf_dependence then " (*dep*)" else "")
-          (match sf.sf_field_number with | None -> "" | Some n -> Printf.sprintf "(* %d *)" n)
     in
     let fields = String.concat ";\n" (List.map print_field fields) in
     Printf.sprintf "{\n%s\n}" fields
@@ -647,6 +724,11 @@ let maybe_print_type_equality (mname:string) (td:type_decl) : ML string =
 
 let print_decl_for_types (mname:string) (d:decl) : ML string =
   match fst d with
+  | Assumption (x, t) ->
+    Printf.sprintf "assume\nval %s : %s\n\n"
+      (print_ident x)      
+      (print_typ mname t) 
+
   | Definition (x, [], T_app ({Ast.v={Ast.name="field_id"}}) _, (Constant c, _)) ->
     Printf.sprintf "[@(CMacro)%s]\nlet %s = %s <: Tot field_id by (FStar.Tactics.trivial())\n\n"
      (print_comments (snd d).comments)
@@ -693,6 +775,7 @@ let is_type_abbreviation (td:type_decl) : bool =
 
 let print_decl_for_validators (mname:string) (d:decl) : ML string =
   match fst d with
+  | Assumption _
   | Definition _ -> ""
   | Type_decl td ->
     (if false //not td.decl_name.td_entrypoint
@@ -778,6 +861,7 @@ let print_type_decl_signature (mname:string) (d:decl{Type_decl? (fst d)}) : ML s
 
 let print_decl_signature (mname:string) (d:decl) : ML string =
   match fst d with
+  | Assumption _
   | Definition _ -> ""
   | Type_decl td ->
     if (snd d).is_hoisted
@@ -839,42 +923,6 @@ let print_decls_signature (mname: string) (ds:list decl) =
   // in
   decls // ^ "\n" ^ dummy
 
-let print_error_map (modul: string) (env: global_env) : ML (string & string) =
-  let errs = Binding.all_nums env in
-  let struct_names =
-    List.map
-    (fun (kis: (A.field_num * option A.ident * string)) ->
-      let k, i, s = kis in
-      Printf.sprintf "case %d: return \"%s\";"
-        k
-        (match i with
-         | None -> ""
-         | Some i -> A.print_ident i))
-    errs
- in
- let field_names =
-    List.map
-    (fun (kis: (A.field_num * option A.ident * string)) ->
-      let k, i, s = kis in
-      Printf.sprintf "case %d: return \"%s\";"
-        k s)
-    errs
- in
- let print_switch fname cases =
-   Printf.sprintf
-     "static char* %s%s(uint64_t err) {\n\t\
-        switch (EverParseFieldIdOfResult(err)) {\n\t\t\
-          %s \n\t\t\
-          default: return \"\";\n\t\
-       }\n\
-      }\n"
-      modul
-      fname
-      (String.concat "\n\t\t" cases)
- in
- print_switch "StructNameOfErr" struct_names,
- print_switch "FieldNameOfErr" field_names
-
 #push-options "--z3rlimit_factor 4"
 let rec print_as_c_type (t:typ) : Tot string =
     let open Ast in
@@ -934,9 +982,7 @@ let print_c_entry (modul: string)
                   (env: global_env)
                   (ds:list decl)
 : ML (string & string)
-= let struct_name_map, field_name_map = print_error_map modul env in
-
-  let print_one_validator (d:type_decl) : ML (string & string) =
+= let print_one_validator (d:type_decl) : ML (string & string) =
     let print_params (ps:list param) : Tot string =
       let params =
         String.concat
@@ -1023,14 +1069,10 @@ let print_c_entry (modul: string)
        #include \"EverParse.h\"\n\
        #include \"%s.h\"\n\
        %s\n\
-       %s\n\
-       %s\n\
        %s\n"
       modul
       modul
       error_callback_proto
-      struct_name_map
-      field_name_map
       (impls |> String.concat "\n\n")
   in
   header,

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -523,7 +523,7 @@ let rec print_validator (mname:string) (v:validator) : ML string = //(decreases 
                    (print_lam (print_validator mname) p2)
 
   | Validate_dep_pair_with_refinement p1_is_constant_size_without_actions n1 p1 r e p2 ->
-    Printf.sprintf "(validate_dep_pair_with_refinement %s \"%s\" 1uL %s %s %s %s)"
+    Printf.sprintf "(validate_dep_pair_with_refinement %s \"%s\" %s %s %s %s)"
                    (if p1_is_constant_size_without_actions then "true" else "false")
                    (print_maybe_qualified_ident mname n1)
                    (print_validator mname p1)

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -989,15 +989,15 @@ let print_c_entry (modul: string)
              BOOLEAN filled;\n\t\
              uint32_t start_pos;\n\t\
              uint32_t end_pos;\n\t\
-             char *typename;\n\t\
-             char *fieldname;\n\t\
-             char *reason;\n\
+             const char *typename;\n\t\
+             const char *fieldname;\n\t\
+             const char *reason;\n\
           } ErrorFrame;\n\
           \n\
           void DefaultErrorHandler(\n\t\
-                              EverParseString typename,\n\t\
-                              EverParseString fieldname,\n\t\
-                              EverParseString reason,\n\t\
+                              const char *typename,\n\t\
+                              const char *fieldname,\n\t\
+                              const char *reason,\n\t\
                               uint8_t *context,\n\t\
                               uint32_t len,\n\t\
                               uint8_t *base,\n\t\
@@ -1112,7 +1112,7 @@ let print_c_entry (modul: string)
       (signatures |> String.concat "\n\n")
   in
   let error_callback_proto =
-    Printf.sprintf "void %sEverParseError(char *StructName, char *FieldName, char *Reason);"
+    Printf.sprintf "void %sEverParseError(const char *StructName, const char *FieldName, const char *Reason);"
       modul
   in
   let impl =

--- a/src/3d/Translate.fst
+++ b/src/3d/Translate.fst
@@ -1285,7 +1285,6 @@ let translate_decls benv senv tenv ds =
     parser_weak_kind = tenv.t_parser_weak_kind;
     parser_kind_is_constant_size = tenv.t_parser_kind_is_constant_size;
   } in
-  Target.error_handler_decl ::
   List.collect (translate_decl env) ds,
   { tenv with t_has_reader = env.has_reader;
               t_parser_kind_nz = env.parser_kind_nz;

--- a/src/3d/Translate.fst
+++ b/src/3d/Translate.fst
@@ -102,10 +102,12 @@ let mk_lam (f:(A.ident -> ML 'a)) : ML (T.lam 'a) =
 let map_lam (x:T.lam 'a) (g: 'a -> ML 'b) : ML (T.lam 'b) =
   fst x, g (snd x)
 
-let mk_parser k t p = T.({
+let mk_parser k t typename fieldname p = T.({
   p_kind = k;
   p_typ = t;
-  p_parser = p
+  p_parser = p;
+  p_typename = typename;
+  p_fieldname = fieldname
 })
 
 // Kind constructors
@@ -166,7 +168,8 @@ let unit_typ =
 let unit_val =
     T.(mk_expr (App (Ext "()") []))
 let unit_parser =
-    mk_parser pk_return unit_typ (T.Parse_return unit_val)
+    let unit_id = with_dummy_range (to_ident' "unit") in
+    mk_parser pk_return unit_typ unit_id "none" (T.Parse_return unit_val)
 let pair_typ t1 t2 =
     T.T_app (with_dummy_range (to_ident' "tuple2")) [Inl t1; Inl t2]
 let pair_value x y =
@@ -176,7 +179,12 @@ let pair_value x y =
 let pair_parser n1 p1 p2 =
     let open T in
     let pt = pair_typ p1.p_typ p2.p_typ in
-    mk_parser (pk_and_then p1.p_kind p2.p_kind) pt (Parse_pair n1 p1 p2)
+    let t_id = with_dummy_range (to_ident' "tuple2") in
+    mk_parser (pk_and_then p1.p_kind p2.p_kind)
+              pt
+              t_id
+              "none"
+              (Parse_pair n1 p1 p2)
 let dep_pair_typ t1 (t2:(A.ident & T.typ)) : T.typ =
     T.T_dep_pair t1 t2
 let dep_pair_value x y : T.expr =
@@ -187,38 +195,49 @@ let dep_pair_value x y : T.expr =
 let dep_pair_parser n1 p1 (p2:A.ident & T.parser) =
   let open T in
   let t = T_dep_pair p1.p_typ (fst p2, (snd p2).p_typ) in
+  let t_id = with_dummy_range (to_ident' "dtuple2") in
   mk_parser
-      (pk_and_then p1.p_kind (snd p2).p_kind) t
+      (pk_and_then p1.p_kind (snd p2).p_kind) 
+      t
+      t_id
+      "none"
       (Parse_dep_pair n1 p1 (Some (fst p2), snd p2))
-let dep_pair_with_refinement_parser n1 f1 p1 (e:T.lam T.expr) (p2:A.ident & T.parser) =
+let dep_pair_with_refinement_parser n1 p1 (e:T.lam T.expr) (p2:A.ident & T.parser) =
   let open T in
   let t1 = T_refine p1.p_typ e in
   let t = T_dep_pair t1 (fst p2, (snd p2).p_typ) in
   let k1 = pk_filter p1.p_kind in
+  let t_id = with_dummy_range (to_ident' "dtuple2") in
   mk_parser
       (pk_and_then k1 (snd p2).p_kind)
       t
-      (Parse_dep_pair_with_refinement n1 f1 p1 e (Some (fst p2), snd p2))
-let dep_pair_with_refinement_and_action_parser n1 f1 p1 (e:T.lam T.expr) (a:T.lam T.action) (p2:A.ident & T.parser) =
+      t_id
+      "none"
+      (Parse_dep_pair_with_refinement n1 p1 e (Some (fst p2), snd p2))
+let dep_pair_with_refinement_and_action_parser n1 p1 (e:T.lam T.expr) (a:T.lam T.action) (p2:A.ident & T.parser) =
   let open T in
   let t1 = T_refine p1.p_typ e in
   let t = T_dep_pair t1 (fst p2, (snd p2).p_typ) in
   let k1 = pk_filter p1.p_kind in
+  let t_id = with_dummy_range (to_ident' "dtuple2") in  
   mk_parser
       (pk_and_then k1 (snd p2).p_kind)
       t
-      (Parse_dep_pair_with_refinement_and_action n1 f1 p1 e a (Some (fst p2), snd p2))
+      t_id
+      "none"
+      (Parse_dep_pair_with_refinement_and_action n1 p1 e a (Some (fst p2), snd p2))
 let dep_pair_with_action_parser p1 (a:T.lam T.action) (p2:A.ident & T.parser) =
   let open T in
   let t1 = p1.p_typ in
   let t = T_dep_pair t1 (fst p2, (snd p2).p_typ) in
   let k1 = p1.p_kind in
+  let t_id = with_dummy_range (to_ident' "dtuple2") in
   mk_parser
       (pk_and_then k1 (snd p2).p_kind)
       t
+      t_id
+      "none"
       (Parse_dep_pair_with_action p1 a (Some (fst p2), snd p2))
-
-
 let translate_op : A.op -> ML T.op = 
   let force_topt (o:option A.integer_type) 
     : ML integer_type
@@ -337,59 +356,76 @@ let maybe_add_comment t copt =
     | None -> t
     | Some c -> T.T_with_comment t c
 
-let rec parse_typ (env:global_env) (name: A.ident) (t:T.typ) : ML T.parser =
+let rec parse_typ (env:global_env)
+                  (typename: A.ident) 
+                  (fieldname:string)
+                  (t:T.typ) : ML T.parser =
   let open T in
+  let extend_fieldname e = Printf.sprintf "%s.%s" fieldname e in
   match t with
   | T_false ->
-    mk_parser pk_impos T_false Parse_impos
+    mk_parser pk_impos T_false typename fieldname Parse_impos
 
   | T.T_app {v={name="nlist"}} [Inr e; Inl t] ->
-    let pt = parse_typ env name t in
+    let pt = parse_typ env typename (extend_fieldname "element") t in
     mk_parser pk_list
               t
+              typename
+              fieldname
               (T.Parse_nlist e pt)
 
   | T.T_app {v={name="t_at_most"}} [Inr e; Inl t] ->
-    let pt = parse_typ env name t in
+    let pt = parse_typ env typename (extend_fieldname "element") t in
     mk_parser pk_t_at_most
               t
+              typename
+              fieldname
               (T.Parse_t_at_most e pt)
 
   | T.T_app {v={name="t_exact"}} [Inr e; Inl t] ->
-    let pt = parse_typ env name t in
+    let pt = parse_typ env typename (extend_fieldname "element") t in
     mk_parser pk_t_exact
               t
+              typename
+              fieldname
               (T.Parse_t_exact e pt)
 
   | T.T_app {v={name="cstring"}} [Inl t; Inr e] ->
-    let pt = parse_typ env name t in
+    let pt = parse_typ env typename (extend_fieldname "element") t in
     mk_parser pk_string
               t
+              typename
+              fieldname
               (T.Parse_string pt e)
 
   | T.T_app hd args ->
-    mk_parser (pk_base hd (parser_kind_nz env hd) (parser_weak_kind env hd)) t (T.Parse_app hd args)
+    mk_parser (pk_base hd (parser_kind_nz env hd) (parser_weak_kind env hd))
+              t
+              typename
+              fieldname
+              (T.Parse_app hd args)
 
   | T.T_refine t_base refinement ->
-    let base = parse_typ env name t_base in
-    let refined = T.Parse_refinement name base refinement in
-    mk_parser (pk_filter base.p_kind) t refined
+    let base = parse_typ env typename fieldname t_base in
+    let refined = T.Parse_refinement typename base refinement in
+    mk_parser (pk_filter base.p_kind) t typename (extend_fieldname "refinement") refined
 
   | T.T_if_else e t1 t2 ->
-    let p1 = parse_typ env name t1 in
-    let p2 = parse_typ env name t2 in
+    let p1 = parse_typ env typename fieldname t1 in
+    let p2 = parse_typ env typename fieldname t2 in
     let k, p1, p2 =
       if parser_kind_eq p1.p_kind p2.p_kind
       then p1.p_kind, p1, p2
       else let k = pk_glb p1.p_kind p2.p_kind in
            k,
-           mk_parser k t1 (Parse_weaken_right p1 p2.p_kind),
-           mk_parser k t2 (Parse_weaken_left p2 p1.p_kind)
+           mk_parser k t1 typename (extend_fieldname "case_left") (Parse_weaken_right p1 p2.p_kind),
+           mk_parser k t2 typename (extend_fieldname "case_right") (Parse_weaken_left p2 p1.p_kind)
     in
-    mk_parser k t (Parse_if_else e p1 p2)
+    mk_parser k t typename fieldname (Parse_if_else e p1 p2)
 
   | T.T_dep_pair t1 (x, t2) ->
-    dep_pair_parser name (parse_typ env name t1) (x, parse_typ env name t2)
+    dep_pair_parser typename (parse_typ env typename (extend_fieldname "first") t1) 
+                             (x, parse_typ env typename (extend_fieldname "second") t2)
 
   | T.T_with_action _ _
   | T.T_with_dep_action _ _ ->
@@ -401,27 +437,31 @@ let rec parse_typ (env:global_env) (name: A.ident) (t:T.typ) : ML T.parser =
       failwith "Impossible"
     | Some (t, None, Some (Inl a), copt) ->
       let t = maybe_add_comment t copt in
-      let p = parse_typ env name t in
-      mk_parser p.p_kind t (T.Parse_with_action name p a)
+      let p = parse_typ env typename (extend_fieldname "base") t in
+      mk_parser p.p_kind t typename fieldname (T.Parse_with_action typename p a)
     | Some (t, None, Some (Inr a), copt) ->
       let t = maybe_add_comment t copt in    
-      let p = parse_typ env name t in
-      mk_parser p.p_kind t (T.Parse_with_dep_action name p a)
+      let p = parse_typ env typename (extend_fieldname "base") t in
+      mk_parser p.p_kind t typename fieldname (T.Parse_with_dep_action typename p a)
     | Some (t, Some r, Some (Inl a), copt) ->
       let t = maybe_add_comment t copt in        
-      let p = parse_typ env name t in
+      let p = parse_typ env typename (extend_fieldname "base") t in
       mk_parser (pk_filter p.p_kind)
                 (T.T_refine t r)
-                (T.Parse_refinement_with_action name p r (Some underscore_ident, a))
+                typename
+                fieldname
+                (T.Parse_refinement_with_action typename p r (Some underscore_ident, a))
     | Some (t, Some r, Some (Inr a), copt) ->
       let t = maybe_add_comment t copt in            
-      let p = parse_typ env name t in
+      let p = parse_typ env typename (extend_fieldname "base") t in
       mk_parser (pk_filter p.p_kind)
                 (T.T_refine t r)
-                (T.Parse_refinement_with_action name p r a)
+                typename
+                fieldname
+                (T.Parse_refinement_with_action typename p r a)
     end
   | T.T_with_comment t c ->
-    let p = parse_typ env name t in
+    let p = parse_typ env typename fieldname t in
     { p with p_parser = T.Parse_with_comment p c }
 
   | T.T_pointer _ ->
@@ -512,7 +552,7 @@ let rec parser_is_constant_size_without_actions
       then parser_is_constant_size_without_actions env tl
       else false
   | T.Parse_dep_pair _ parse_key (_, parse_value)
-  | T.Parse_dep_pair_with_refinement _ _ parse_key _ (_, parse_value)
+  | T.Parse_dep_pair_with_refinement _ parse_key _ (_, parse_value)
     -> (* the lambda identifier is not global, because the 3d syntax does not allow higher-order types *)
       if parser_is_constant_size_without_actions env parse_key
       then parser_is_constant_size_without_actions env parse_value
@@ -520,7 +560,7 @@ let rec parser_is_constant_size_without_actions
   | T.Parse_t_at_most _ _
   | T.Parse_t_exact _ _  
   | T.Parse_dep_pair_with_action _ _ _
-  | T.Parse_dep_pair_with_refinement_and_action _ _ _ _ _ _
+  | T.Parse_dep_pair_with_refinement_and_action _ _ _ _ _
   | T.Parse_refinement_with_action _ _ _ _
   | T.Parse_with_dep_action _ _ _
   | T.Parse_with_action _ _ _
@@ -531,97 +571,117 @@ let rec parser_is_constant_size_without_actions
   | T.Parse_refinement _ p _
   | T.Parse_weaken_left p _
   | T.Parse_weaken_right p _  
-  | T.Parse_with_error _ p
   | T.Parse_with_comment p _
     -> parser_is_constant_size_without_actions env p
 
+let unknown_type_ident = 
+  let open Ast in
+  let id = {
+    modul_name = None;
+    name = "<unknown>"
+  } in
+  with_range id dummy_range
+
 let rec make_validator (env:global_env) (p:T.parser) : ML T.validator =
   let open T in
+  let with_error_handler v =
+    pv v.v_allow_reading
+       v.v_parser
+       (Validate_with_error_handler p.p_typename p.p_fieldname v)
+  in
   match p.p_parser with
   | Parse_impos ->
-    pv true p Validate_impos
+    with_error_handler
+      (pv true p Validate_impos)
 
   | Parse_app hd args ->
-    pv (has_reader env hd) p (Validate_app hd args)
+    with_error_handler
+      (pv (has_reader env hd) p (Validate_app hd args))
 
   | Parse_nlist n p ->
-    if parser_is_constant_size_without_actions env p
-    then
-      pv false p (Validate_nlist_constant_size_without_actions n (make_validator env p))
-    else
-      pv false p (Validate_nlist n (make_validator env p))
+    with_error_handler
+      (if parser_is_constant_size_without_actions env p
+       then pv false p (Validate_nlist_constant_size_without_actions n (make_validator env p))
+       else pv false p (Validate_nlist n (make_validator env p)))
 
   | Parse_t_at_most n p ->
-    pv false p (Validate_t_at_most n (make_validator env p))  
+    with_error_handler
+      (pv false p (Validate_t_at_most n (make_validator env p)))
 
   | Parse_t_exact n p ->
-    pv false p (Validate_t_exact n (make_validator env p))  
+    with_error_handler
+      (pv false p (Validate_t_exact n (make_validator env p)))
 
   | Parse_return e ->
     pv true p Validate_return
 
   | Parse_pair n1 p1 p2 ->
-    pv false p (Validate_pair n1 (make_validator env p1) (make_validator env p2))
+     pv false p (Validate_pair n1 (make_validator env p1)
+                                  (make_validator env p2))
 
   | Parse_dep_pair n1 p1 k ->
-    pv false p (Validate_dep_pair
-            n1
-            (make_validator env p1)
-            (make_reader env p1.p_typ)
-            (map_lam k (make_validator env)))
+     pv false p (Validate_dep_pair
+                     n1
+                     (make_validator env p1)
+                     (make_reader env p1.p_typ)
+                     (map_lam k (make_validator env)))
 
-  | Parse_dep_pair_with_refinement n1 f1 p1 e k ->
+  | Parse_dep_pair_with_refinement n1 p1 e k ->
     let p1_is_constant_size_without_actions = parser_is_constant_size_without_actions env p1 in
-    let f1' = match B.lookup_field_num env.benv f1 with
-      | Some fn' -> fn'
-      | _ -> failwith (Printf.sprintf "Field `%d` not found" f1)
-    in
     pv false p (Validate_dep_pair_with_refinement
-                  p1_is_constant_size_without_actions
-                  n1
-                  f1'
-                  (make_validator env p1)
-                  (make_reader env p1.p_typ)
-                  e
-                  (map_lam k (make_validator env)))
+                      p1_is_constant_size_without_actions
+                      n1
+                      (make_validator env p1)
+                      (make_reader env p1.p_typ)
+                      e
+                      (map_lam k (make_validator env)))
 
   | Parse_dep_pair_with_action p1 a k ->
     pv false p (Validate_dep_pair_with_action
-                  (make_validator env p1)
-                  (make_reader env p1.p_typ)
-                  a
-                  (map_lam k (make_validator env)))
+                       (make_validator env p1)
+                       (make_reader env p1.p_typ)
+                       a
+                       (map_lam k (make_validator env)))
 
-  | Parse_dep_pair_with_refinement_and_action n1 f1 p1 e a k ->
+  | Parse_dep_pair_with_refinement_and_action n1 p1 e a k ->
     let p1_is_constant_size_without_actions = parser_is_constant_size_without_actions env p1 in
-    let f1' = match B.lookup_field_num env.benv f1 with
-      | Some fn' -> fn'
-      | _ -> failwith (Printf.sprintf "Field `%d` not found" f1)
-    in
     pv false p (Validate_dep_pair_with_refinement_and_action
-                   p1_is_constant_size_without_actions
-                   n1
-                   f1'
-                   (make_validator env p1)
-                   (make_reader env p1.p_typ)
-                   e
-                   a
-                   (map_lam k (make_validator env)))
+                     p1_is_constant_size_without_actions
+                     n1
+                     (make_validator env p1)
+                     (make_reader env p1.p_typ)
+                     e
+                     a
+                     (map_lam k (make_validator env)))
 
   | Parse_map p1 f ->
     pv false p (Validate_map (make_validator env p1) f)
 
   | Parse_refinement n1 p1 f ->
-    pv false p (Validate_refinement n1 (make_validator env p1) (make_reader env p1.p_typ) f)
+    with_error_handler 
+      (pv false p (Validate_refinement n1 
+                                       (make_validator env p1)
+                                       (make_reader env p1.p_typ)
+                                       f))
 
   | Parse_refinement_with_action n1 p1 f a ->
-    pv false p (Validate_refinement_with_action n1 (make_validator env p1) (make_reader env p1.p_typ) f a)
+    with_error_handler 
+      (pv false p (Validate_refinement_with_action n1 
+                                                   (make_validator env p1)
+                                                   (make_reader env p1.p_typ)
+                                                   f 
+                                                   a))
 
-  | Parse_with_action name p a ->
-    pv false p (Validate_with_action name (make_validator env p) a)
+  | Parse_with_action n1 p a ->
+    with_error_handler
+      (pv false p (Validate_with_action n1 (make_validator env p) a))
 
-  | Parse_with_dep_action name p a ->
-    pv false p (Validate_with_dep_action name (make_validator env p) (make_reader env p.p_typ) a)
+  | Parse_with_dep_action n1 p a ->
+    with_error_handler
+      (pv false p (Validate_with_dep_action n1 
+                     (make_validator env p)
+                     (make_reader env p.p_typ)
+                     a))
 
   | Parse_weaken_left p1 k ->
     let v1 = make_validator env p1 in
@@ -634,20 +694,13 @@ let rec make_validator (env:global_env) (p:T.parser) : ML T.validator =
   | Parse_if_else e p1 p2 ->
     pv false p (Validate_if_else e (make_validator env p1) (make_validator env p2))
 
-  | Parse_with_error f p ->
-    begin match B.lookup_field_num env.benv f with
-    | Some fn ->
-      let v = make_validator env p in
-      pv v.v_allow_reading p (Validate_with_error fn v)
-    | _ -> failwith (Printf.sprintf "Field `%d` not found" f)
-    end
-
   | Parse_with_comment p c ->
     let v = make_validator env p in
     pv v.v_allow_reading p (Validate_with_comment v c)
 
   | Parse_string elem zero ->
-    pv false p (Validate_string (make_validator env elem) (make_reader env elem.p_typ) zero)
+    with_error_handler
+      (pv false p (Validate_string (make_validator env elem) (make_reader env elem.p_typ) zero))
 
 // x:t1;
 // t2;
@@ -724,8 +777,7 @@ let translate_field (f:A.field) : ML T.struct_field =
     else
       T.({sf_dependence=sf.field_dependence;
           sf_ident=sf.field_ident;
-          sf_typ=t;
-          sf_field_number=sf.field_number})
+          sf_typ=t})
 
 let nondep_group = list T.field
 let grouped_fields = list (either T.field nondep_group)
@@ -776,16 +828,10 @@ let make_grouped_fields (fs:list T.field) : ML grouped_fields =
   gfs
 
 
-let parse_grouped_fields (env:global_env) (gfs:grouped_fields)
+let parse_grouped_fields (env:global_env) (typename:A.ident) (gfs:grouped_fields)
   : ML T.parser
   = let open T in
-    let parse_typ = parse_typ env in
-    let may_fail sf p =
-      match sf.sf_field_number with
-      | None -> p
-      | Some f ->
-        {p with p_parser = Parse_with_error f p}
-    in
+    let parse_typ (fieldname:A.ident) = parse_typ env typename Ast.(fieldname.v.name) in
     let rec aux (gfs:grouped_fields) : ML parser =
       match gfs with
       | [] ->
@@ -802,45 +848,33 @@ let parse_grouped_fields (env:global_env) (gfs:grouped_fields)
         | None ->
           dep_pair_parser
             sf.sf_ident
-            (may_fail sf (parse_typ sf.sf_ident sf.sf_typ))
+            (parse_typ sf.sf_ident sf.sf_typ)
             (sf.sf_ident, aux gfs)
             
         | Some (_, None, None, copt) ->
           dep_pair_parser
             sf.sf_ident
-            (may_fail sf (parse_typ sf.sf_ident (maybe_add_comment sf.sf_typ copt)))
+            (parse_typ sf.sf_ident (maybe_add_comment sf.sf_typ copt))
             (sf.sf_ident, aux gfs)
 
         | Some (t, Some e, None, copt) ->
-          let fn = match sf.sf_field_number with
-          | Some fn -> fn
-          | _ ->
-            failwith (Printf.sprintf "Field %s has no field number" (ident_to_string sf.sf_ident))
-          in
           dep_pair_with_refinement_parser
             sf.sf_ident
-            fn
-            (may_fail sf (parse_typ sf.sf_ident (maybe_add_comment t copt)))
+            (parse_typ sf.sf_ident (maybe_add_comment t copt))
             e
             (sf.sf_ident, aux gfs)
 
         | Some (t, Some e, Some a, copt) ->
-          let fn = match sf.sf_field_number with
-          | Some fn -> fn
-          | _ ->
-            failwith (Printf.sprintf "Field %s has no field number" (ident_to_string sf.sf_ident))
-          in
           dep_pair_with_refinement_and_action_parser
             sf.sf_ident
-            fn
-            (may_fail sf (parse_typ sf.sf_ident (maybe_add_comment t copt)))
+            (parse_typ sf.sf_ident (maybe_add_comment t copt))
             e
             (get_action a)
             (sf.sf_ident, aux gfs)
 
         | Some (t, None, Some a, copt) ->
           dep_pair_with_action_parser
-            (may_fail sf (parse_typ sf.sf_ident (maybe_add_comment t copt)))
+            (parse_typ sf.sf_ident (maybe_add_comment t copt))
             (get_action a)
             (sf.sf_ident, aux gfs)
         end
@@ -852,11 +886,11 @@ let parse_grouped_fields (env:global_env) (gfs:grouped_fields)
             | [] ->
               failwith "Unexpected empty non-dep group"
             | [sf] ->
-               may_fail sf (parse_typ sf.sf_ident sf.sf_typ)
+               parse_typ sf.sf_ident sf.sf_typ
             | sf::sfs ->
               pair_parser
                 sf.sf_ident
-                (may_fail sf (parse_typ sf.sf_ident sf.sf_typ))
+                (parse_typ sf.sf_ident sf.sf_typ)
                 (aux sfs)
         in
         aux gf
@@ -866,7 +900,7 @@ let parse_grouped_fields (env:global_env) (gfs:grouped_fields)
           (fun (sf:struct_field) (p_tl:parser) ->
             pair_parser
               sf.sf_ident
-              (may_fail sf (parse_typ sf.sf_ident sf.sf_typ))
+              (parse_typ sf.sf_ident sf.sf_typ)
               p_tl)
           gf
           (aux gfs)
@@ -883,7 +917,7 @@ let parse_fields (env:global_env) (tdn:T.typedef_name) (fs:list T.field)
   //     tdn.td_name.v 
   //     (List.map (fun x -> x.sf_ident.v) fs |> String.concat ", ")
   //     (print_grouped_fields gfs));
-  let p = parse_grouped_fields env gfs in
+  let p = parse_grouped_fields env tdn.td_name gfs in
   p
 
 let make_tdn (i:A.ident) =
@@ -1021,8 +1055,8 @@ let maybe_add_reader (genv:global_env)
     reader
 
 let hoist_one_type_definition (should_inline:bool)
-                              (genv:global_env) (env:env_t) (tdn:T.typedef_name)
-                              (prefix:string) (field_number:option field_num) (t:T.typ)
+                              (genv:global_env) (env:env_t) (orig_tdn:T.typedef_name)
+                              (prefix:string) (t:T.typ)
   : ML (T.decl & T.field_typ)
   =  let open T in
      let parse_typ = parse_typ genv in
@@ -1038,18 +1072,15 @@ let hoist_one_type_definition (should_inline:bool)
                              prefix]
       in
       let body = t in
-      let comment = Printf.sprintf "    Internal helper function:\n        Validator for field %s\n        of type %s" prefix (ident_to_string tdn.td_name) in
+      let comment = Printf.sprintf "    Internal helper function:\n        Validator for field %s\n        of type %s"
+                                   prefix
+                                   (ident_to_string orig_tdn.td_name) in
       let tdn = {
           td_name = id;
           td_params = List.rev env;
           td_entrypoint = false
       } in
-      let t_parser = parse_typ id body in
-      let t_parser =
-        match field_number with
-        | None -> t_parser
-        | Some fn -> { t_parser with p_parser = Parse_with_error fn t_parser }
-      in
+      let t_parser = parse_typ orig_tdn.td_name type_name body in
       add_parser_kind_nz genv tdn.td_name t_parser.p_kind.pk_nz t_parser.p_kind.pk_weak_kind;
       add_parser_kind_is_constant_size genv tdn.td_name (parser_is_constant_size_without_actions genv t_parser);
       let reader = maybe_add_reader genv tdn body in
@@ -1079,8 +1110,8 @@ let hoist_field (genv:global_env) (env:env_t) (tdn:T.typedef_name) (f:T.field)
     then let f = { f with sf_typ = t } in
          d, f
     else
-      let td, tdef = hoist_one_type_definition false genv env tdn field_name f.sf_field_number t in
-      let f = { f with sf_typ = tdef; sf_field_number = None } in
+      let td, tdef = hoist_one_type_definition false genv env tdn field_name t in
+      let f = { f with sf_typ = tdef } in
       d@[td], f
 
 let hoist_refinements (genv:global_env) (tdn:T.typedef_name) (fields:list T.field)
@@ -1139,7 +1170,7 @@ let translate_switch_case_type (genv:global_env) (tdn:T.typedef_name) (sw:Ast.sw
         let guard = T.mk_expr (App Eq [sc; translate_expr e]) in
         let t = T_if_else guard sf.sf_typ t_else in
         let field_name = Printf.sprintf "%s_ite_%d" (ident_name tdn.td_name) n in
-        let td, tdef = hoist_one_type_definition true genv env tdn field_name None t in
+        let td, tdef = hoist_one_type_definition true genv env tdn field_name t in
         tdef, decls@decls'@[td], n + 1)
     rest
     (default_t, decls, 0)
@@ -1161,7 +1192,7 @@ let translate_decl (env:global_env) (d:A.decl) : ML (list T.decl) =
     let tdn = make_tdn i in
     let t = translate_typ t in
     let tdn = translate_typedef_name tdn [] in
-    let p = parse_typ env i t in
+    let p = parse_typ env i "" t in
     let open T in
     add_parser_kind_nz env tdn.td_name p.p_kind.pk_nz p.p_kind.pk_weak_kind;
     add_parser_kind_is_constant_size env tdn.td_name (parser_is_constant_size_without_actions env p);
@@ -1181,7 +1212,7 @@ let translate_decl (env:global_env) (d:A.decl) : ML (list T.decl) =
     let typ = translate_typ t in
     let tdn = translate_typedef_name tdn [] in
     let refined_typ = make_enum_typ typ ids in
-    let p = parse_typ env i refined_typ in
+    let p = parse_typ env i "" refined_typ in
     let open T in
     add_parser_kind_nz env tdn.td_name p.p_kind.pk_nz p.p_kind.pk_weak_kind;
     add_parser_kind_is_constant_size env tdn.td_name (parser_is_constant_size_without_actions env p);
@@ -1217,7 +1248,7 @@ let translate_decl (env:global_env) (d:A.decl) : ML (list T.decl) =
   | CaseType tdn0 params switch_case ->
     let tdn = translate_typedef_name tdn0 params in
     let t, decls = translate_switch_case_type env tdn switch_case in
-    let p = parse_typ env tdn0.typedef_name t in
+    let p = parse_typ env tdn0.typedef_name "" t in
     let open T in
     add_parser_kind_nz env tdn.td_name p.p_kind.pk_nz p.p_kind.pk_weak_kind;
     add_parser_kind_is_constant_size env tdn.td_name (parser_is_constant_size_without_actions env p);
@@ -1254,6 +1285,7 @@ let translate_decls benv senv tenv ds =
     parser_weak_kind = tenv.t_parser_weak_kind;
     parser_kind_is_constant_size = tenv.t_parser_kind_is_constant_size;
   } in
+  Target.error_handler_decl ::
   List.collect (translate_decl env) ds,
   { tenv with t_has_reader = env.has_reader;
               t_parser_kind_nz = env.parser_kind_nz;

--- a/src/3d/TypeSizes.fst
+++ b/src/3d/TypeSizes.fst
@@ -214,7 +214,6 @@ let padding_field (env:env_t) (enclosing_struct:ident) (padding_msg:string) (n:i
   then []
   else (
     let field_name = gen_alignment_ident() in
-    let field_num = Binding.next_field_num enclosing_struct field_name (fst env) in
     let n_expr = with_range (Constant (Int UInt32 n)) dummy_range in
     FStar.IO.print_string
       (Printf.sprintf "Adding padding field in %s for %d bytes at %s\n"
@@ -227,7 +226,6 @@ let padding_field (env:env_t) (enclosing_struct:ident) (padding_msg:string) (n:i
       field_type = tuint8;
       field_array_opt=(if n = 1 then FieldScalar else FieldArrayQualified(n_expr, ByteArrayByteSize));
       field_constraint=None;
-      field_number=Some field_num;
       field_bitwidth=None;
       field_action=None
     } in
@@ -398,8 +396,7 @@ let size_of_decls (genv:B.global_env) (senv:size_env) (ds:list decl) =
     B.mk_env genv, senv in
     // {senv with sizes = H.create 10} in
   let ds = List.map (decl_size_with_alignment env) ds in
-  let ds' = Binding.add_field_error_code_decls (Binding.mk_env genv) in
-  ds'@ds, snd env
+  ds, snd env
 
 let finish_module en mname e_and_p =
   e_and_p |> snd |> List.iter (H.remove en);

--- a/src/3d/ocaml/parser.mly
+++ b/src/3d/ocaml/parser.mly
@@ -232,7 +232,6 @@ struct_field:
          field_type=t;
          field_array_opt=aopt;
          field_constraint=c;
-         field_number=None;
          field_bitwidth=bopt;
          field_action=a
         }

--- a/src/3d/prelude/Actions.fst
+++ b/src/3d/prelude/Actions.fst
@@ -1566,7 +1566,7 @@ let validate_list_up_to_inv
     True // (~ (valid q h0 (slice_of sl) pos0)) // we lost completeness because of actions
   end
 
-#push-options "--z3rlimit 16"
+#push-options "--z3rlimit 32"
 
 inline_for_extraction
 let validate_list_up_to_body

--- a/src/3d/prelude/Actions.fst
+++ b/src/3d/prelude/Actions.fst
@@ -438,7 +438,7 @@ let validate_dep_pair
 
 #pop-options
 
-#push-options "--z3rlimit 32"
+#push-options "--z3rlimit 64"
 
 inline_for_extraction noextract
 let validate_dep_pair_with_refinement_and_action'

--- a/src/3d/prelude/Actions.fst
+++ b/src/3d/prelude/Actions.fst
@@ -59,9 +59,15 @@ let action p inv l on_success a
         h1 `extends` h0 /\
         inv (LPL.slice_of sl).LPL.base h1)
 
+let error_handler = typename:string ->
+                    fieldname:string ->
+                    error_reason:string ->
+                    action (parse_impos()) true_inv eloc_none false unit
+
 inline_for_extraction
 let validate_with_action_t' (#k:LP.parser_kind) (#t:Type) (p:LP.parser k t) (inv:slice_inv) (l:eloc) (allow_reading:bool) =
   (ctxt: app_ctxt) ->
+  (err : error_handler) ->
   (#len: U32.t) ->
   (sl: input_buffer_t len) ->
   (pos: U64.t) ->
@@ -98,7 +104,7 @@ let validate_with_action_t p inv l allow_reading =
   validate_with_action_t' p inv l allow_reading
 
 let validate_eta v =
-  fun ctxt #inputLength input startPosition -> v ctxt input startPosition
+  fun ctxt err #inputLength input startPosition -> v ctxt err input startPosition
 
 inline_for_extraction noextract
 let act_with_comment
@@ -185,11 +191,12 @@ let validate_drop
 : Tot (validate_with_action_t p inv l false)
 = fun
   ctxt
+  err
   input
   (startPosition: U64.t) ->
     with_drop_if true inv input (LPL.uint64_to_uint32 startPosition)
                                 (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input)
-                                (v ctxt input startPosition)
+                                (v ctxt err input startPosition)
 
 inline_for_extraction
 noextract
@@ -209,10 +216,10 @@ let validate_with_success_action'
        #b
        (a:action p1 inv2 l2 b bool)
   : validate_with_action_t p1 (conj_inv inv1 inv2) (l1 `eloc_union` l2) ar
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let h0 = HST.get () in
     [@(rename_let ("positionAfter" ^ name))]
-    let pos1 = v1 ctxt input startPosition in
+    let pos1 = v1 ctxt err input startPosition in
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in h0 h1;
     if LPL.is_success pos1
@@ -231,12 +238,6 @@ let validate_with_success_action name v1 a
   = validate_drop (validate_with_success_action' name v1 a)
 
 module P = Prelude
-let p = P.parse_impos ()
-
-let error_handler = typename:string ->
-                    fieldname:string ->
-                    error_reason:string ->
-                    action (parse_impos()) true_inv eloc_none false unit
 
 let error_reason_of_result (code:U64.t) = 
   match LPL.get_validator_error_kind code with
@@ -262,12 +263,11 @@ let validate_with_error_handler (typename:string)
                                 (#l1:eloc)
                                 (#ar:_)
                                 (v1:validate_with_action_t p1 inv1 l1 ar)
-                                (err:error_handler)
   : validate_with_action_t p1 inv1 l1 ar
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let h0 = HST.get () in
     [@(rename_let ("positionAfter" ^ typename))]
-    let pos1 = v1 ctxt input startPosition in
+    let pos1 = v1 ctxt err input startPosition in
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in h0 h1;
     if LPL.is_success pos1
@@ -293,10 +293,10 @@ let validate_with_error_action'
       (#l2:eloc)
       (a:action p1 inv2 l2 false bool)
   : validate_with_action_t p1 (conj_inv inv1 inv2) (l1 `eloc_union` l2) ar
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let h0 = HST.get () in
     [@(rename_let ("positionAfter" ^ name))]
-    let pos1 = v1 ctxt input startPosition in
+    let pos1 = v1 ctxt err input startPosition in
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in h0 h1;
     if LPL.is_success pos1
@@ -313,7 +313,7 @@ let validate_with_error_action
 inline_for_extraction noextract
 let validate_ret
   : validate_with_action_t (parse_ret ()) true_inv eloc_none true
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let h = HST.get () in
     [@inline_let] let _ = LPL.valid_facts (parse_ret ()) h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
     startPosition
@@ -341,11 +341,11 @@ let validate_pair'
        (#ar2:_)
        (v2:validate_with_action_t p2 inv2 l2 ar2)
   : validate_with_action_t (p1 `parse_pair` p2) (conj_inv inv1 inv2) (l1 `eloc_union` l2) (ar1 && ar2)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let h = HST.get () in
     [@inline_let] let _ = LPLC.valid_nondep_then h p1 p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
     [@(rename_let ("positionAfter" ^ name1))]
-    let pos1 = v1 ctxt input startPosition in
+    let pos1 = v1 ctxt err input startPosition in
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in h h1;
     if LPL.is_error pos1
@@ -373,7 +373,7 @@ let validate_pair'
                    input 
                    (LPL.uint64_to_uint32 startPosition)
                    (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input)
-                   (v2 ctxt input pos1)
+                   (v2 ctxt err input pos1)
 
 let validate_pair
   name1 v1 v2
@@ -400,11 +400,11 @@ let validate_dep_pair
       #ar2
       (v2:(x:t1 -> validate_with_action_t (p2 x) inv2 l2 ar2))
   : Tot (validate_with_action_t (p1 `parse_dep_pair` p2) (conj_inv inv1 inv2) (l1 `eloc_union` l2) false)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
       let h = HST.get () in
       [@inline_let] let _ = LPLC.valid_dtuple2 h p1 p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
       [@(rename_let ("positionAfter" ^ name1))]
-      let pos1 = v1 ctxt input startPosition in
+      let pos1 = v1 ctxt err input startPosition in
       let h1 = HST.get() in
       if LPL.is_error pos1
       then begin
@@ -444,7 +444,7 @@ let validate_dep_pair
           input
           (LPL.uint64_to_uint32 startPosition)
           (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input)
-          (v2 x ctxt input pos1)
+          (v2 x ctxt err input pos1)
 
 #pop-options
 
@@ -480,7 +480,7 @@ let validate_dep_pair_with_refinement_and_action'
              (conj_inv inv1 (conj_inv inv1' inv2))
              (l1 `eloc_union` (l1' `eloc_union` l2))
              false)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
       let h0 = HST.get () in
       [@inline_let] 
       let _ =
@@ -492,7 +492,7 @@ let validate_dep_pair_with_refinement_and_action'
           (LPL.uint64_to_uint32 startPosition)
         in
       [@(rename_let ("positionAfter" ^ name1))]
-      let res = v1 ctxt input startPosition in
+      let res = v1 ctxt err input startPosition in
       let h1 = HST.get() in
       modifies_address_liveness_insensitive_unused_in h0 h1;
       if LPL.is_error res
@@ -574,7 +574,7 @@ let validate_dep_pair_with_refinement_and_action'
                  input
                  (LPL.uint64_to_uint32 startPosition)
                  (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input)
-                 (v2 field_value ctxt input res1)
+                 (v2 field_value ctxt err input res1)
              end
         end
 
@@ -614,7 +614,7 @@ let validate_dep_pair_with_refinement_and_action_total_zero_parser'
            k1.parser_kind_metadata == Some ParserKindMetadataTotal
          ))
          (ensures (fun _ -> True))
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
       let h0 = HST.get () in
       [@inline_let] 
       let _ =
@@ -696,7 +696,7 @@ let validate_dep_pair_with_refinement_and_action_total_zero_parser'
                  input
                  (LPL.uint64_to_uint32 startPosition)
                  (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input)
-                 (v2 field_value ctxt input res1)
+                 (v2 field_value ctxt err input res1)
              end
         end
 
@@ -726,11 +726,11 @@ let validate_dep_pair_with_refinement'
              (conj_inv inv1 inv2)
              (l1 `eloc_union` l2)
              false)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
       let h0 = HST.get () in
       [@inline_let] let _ = LPLC.valid_filter h0 p1 f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
       [@(rename_let ("positionAfter" ^ name1))]
-      let res = v1 ctxt input startPosition in
+      let res = v1 ctxt err input startPosition in
       let h1 = HST.get() in
       modifies_address_liveness_insensitive_unused_in h0 h1;
       if LPL.is_error res
@@ -759,7 +759,7 @@ let validate_dep_pair_with_refinement'
              let _ = modifies_address_liveness_insensitive_unused_in h0 h15 in
              [@inline_let] let _ = LPLC.valid_facts (p2 field_value) h0 (LPL.slice_of input) (LPL.uint64_to_uint32 res1) in
              [@inline_let] let _ = LPLC.valid_dtuple2 h0 (p1 `LPC.parse_filter` f) p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-             with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value ctxt input res1)
+             with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value ctxt err input res1)
         end
 
 inline_for_extraction noextract
@@ -781,7 +781,7 @@ let validate_dep_pair_with_refinement_total_zero_parser'
            k1.parser_kind_metadata == Some ParserKindMetadataTotal
          ))
          (ensures (fun _ -> True))
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
       let h0 = HST.get () in
       [@inline_let] let _ = LPLC.valid_filter h0 p1 f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
       [@inline_let] let _ = LPLC.valid_facts p1 h0 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
@@ -808,7 +808,7 @@ let validate_dep_pair_with_refinement_total_zero_parser'
              let _ = modifies_address_liveness_insensitive_unused_in h0 h15 in
              [@inline_let] let _ = LPLC.valid_facts (p2 field_value) h0 (LPL.slice_of input) (LPL.uint64_to_uint32 res1) in
              [@inline_let] let _ = LPLC.valid_dtuple2 h0 (p1 `LPC.parse_filter` f) p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-             with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value ctxt input res1)
+             with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value ctxt err input res1)
         end
 
 #pop-options
@@ -850,9 +850,9 @@ let validate_dep_pair_with_action
              (conj_inv inv1 (conj_inv inv1' inv2))
              (l1 `eloc_union` (l1' `eloc_union` l2))
              false)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
       let h0 = HST.get () in
-      let res = v1 ctxt input startPosition in
+      let res = v1 ctxt err input startPosition in
       let h1 = HST.get() in
       modifies_address_liveness_insensitive_unused_in h0 h1;
       if LPL.is_error res
@@ -872,7 +872,7 @@ let validate_dep_pair_with_action
                let h15 = HST.get () in
                let _ = modifies_address_liveness_insensitive_unused_in h0 h15 in
                [@inline_let] let _ = LPLC.valid_dtuple2 h0 p1 p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-               with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value ctxt input res)
+               with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value ctxt err input res)
              end
       end
 
@@ -905,11 +905,11 @@ let validate_filter' (name: string) #nz (#k:parser_kind nz _) (#t:_) (#p:parser 
                     #inv #l (v:validate_with_action_t p inv l true)
                     (r:leaf_reader p) (f:t -> bool) (cr:string) (cf:string)
   : Tot (validate_with_action_t #nz #WeakKindStrongPrefix (p `LPC.parse_filter` f) inv l false)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let h = HST.get () in
     [@inline_let] let _ = LPLC.valid_filter h p f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
     [@(rename_let ("positionAfter" ^ name))]
-    let res = v ctxt input startPosition in
+    let res = v ctxt err input startPosition in
     let h1 = HST.get () in
     if LPL.is_error res
     then with_drop_if true inv input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res
@@ -939,11 +939,11 @@ let validate_filter'_with_action
                     (r:leaf_reader p) (f:t -> bool) (cr:string) (cf:string)
                     (#b:bool) #inva (#la:eloc) (a: t -> action #nz #WeakKindStrongPrefix #(filter_kind k) #_ (p `LPC.parse_filter` f) inva la b bool)
   : Tot (validate_with_action_t #nz #WeakKindStrongPrefix (p `LPC.parse_filter` f) (conj_inv inv inva) (eloc_union l la) false)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let h = HST.get () in
     [@inline_let] let _ = LPLC.valid_filter h p f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
     [@(rename_let ("positionAfter" ^ name))]
-    let res = v ctxt input startPosition in
+    let res = v ctxt err input startPosition in
     let h1 = HST.get () in
     if LPL.is_error res
     then with_drop_if true (conj_inv inv inva) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res
@@ -982,10 +982,10 @@ let validate_with_dep_action
                     (r:leaf_reader p)
                     (#b:bool) #inva (#la:eloc) (a: t -> action p inva la b bool)
   : Tot (validate_with_action_t #nz p (conj_inv inv inva) (eloc_union l la) false)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let h = HST.get () in
     [@(rename_let ("positionAfter" ^ name))]
-    let res = v ctxt input startPosition in
+    let res = v ctxt err input startPosition in
     let h1 = HST.get () in
     if LPL.is_error res
     then with_drop_if true (conj_inv inv inva) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res
@@ -1005,12 +1005,12 @@ let validate_weaken #nz #wk (#k:parser_kind nz wk) #t (#p:parser k t)
                     #inv #l #ar (v:validate_with_action_t p inv l ar)
                     #nz' #wk' (k':parser_kind nz' wk'{k' `is_weaker_than` k})
   : Tot (validate_with_action_t (parse_weaken p k') inv l ar)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let open LPLC in
     let h = HST.get () in
     [@inline_let]
     let _ = valid_weaken k' p h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-    v ctxt input startPosition
+    v ctxt err input startPosition
 
 /// Parser: weakening kinds
 
@@ -1033,20 +1033,20 @@ let validate_weaken_right (#nz:_) #wk (#k:parser_kind nz wk) (#t:_) (#p:parser k
 inline_for_extraction noextract
 let validate_impos ()
   : Tot (validate_with_action_t (parse_impos ()) true_inv eloc_none true)
-  = fun _ _ _ -> validator_error_impossible
+  = fun _ _ _ _ -> validator_error_impossible
 
 inline_for_extraction noextract
 let validate_with_error
   c v
-  = fun ctxt input startPosition ->
-    let endPositionOrError = v ctxt input startPosition in
+  = fun ctxt err input startPosition ->
+    let endPositionOrError = v ctxt err input startPosition in
     LPL.maybe_set_error_code endPositionOrError startPosition c
 
 noextract inline_for_extraction
 let validate_ite
   e p1 v1 p2 v2
-  = fun ctxt input startPosition ->
-      if e then validate_drop (v1 ()) ctxt input startPosition else validate_drop (v2 ()) ctxt input startPosition
+  = fun ctxt err input startPosition ->
+      if e then validate_drop (v1 ()) ctxt err input startPosition else validate_drop (v2 ()) ctxt err input startPosition
 
 unfold
 let validate_list_inv
@@ -1109,6 +1109,7 @@ let validate_list_body
   (v: validate_with_action_t' p inv l ar)
   (g0 g1: Ghost.erased HS.mem)
   (ctxt:app_ctxt)
+  (err:error_handler)
   (#len: U32.t)
   (sl: input_buffer_t len)
   (pos0: LPL.pos_t)
@@ -1129,7 +1130,7 @@ let validate_list_body
     Classical.move_requires (LPLL.valid_list_elim_cons p (Ghost.reveal g0) (LPL.slice_of sl)) (LPL.uint64_to_uint32 elementStartPosition);
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in (Ghost.reveal g0) h1;
-    let elementEndPosition = v ctxt sl elementStartPosition in
+    let elementEndPosition = v ctxt err sl elementStartPosition in
     upd bpos 0ul elementEndPosition;
     (if LPL.is_success elementEndPosition then R.readable_split h1 (LPL.perm_of sl) (LPL.uint64_to_uint32 elementStartPosition) (LPL.uint64_to_uint32 elementEndPosition) (LPL.slice_length sl));
     LPL.is_error elementEndPosition
@@ -1147,6 +1148,7 @@ let validate_list'
   #inv #l #ar
   (v: validate_with_action_t' p inv l ar)
   (ctxt: app_ctxt)
+  (err: error_handler)
   (#len: U32.t)
   (sl: input_buffer_t len)
   (pos: U64.t)
@@ -1179,7 +1181,9 @@ let validate_list'
   let currentPosition = alloca pos 1ul in
   let h1 = HST.get () in
   let g1 = Ghost.hide h1 in
-  C.Loops.do_while (validate_list_inv p inv l g0 g1 ctxt sl (LPL.uint64_to_uint32 pos) currentPosition) (fun _ -> validate_list_body v g0 g1 ctxt sl pos currentPosition);
+  C.Loops.do_while 
+    (validate_list_inv p inv l g0 g1 ctxt sl (LPL.uint64_to_uint32 pos) currentPosition)
+    (fun _ -> validate_list_body v g0 g1 ctxt err sl pos currentPosition);
   LPLL.valid_list_intro_nil p h0 (LPL.slice_of sl) (LPL.slice_of sl).LPL.len;
   let finalPositionOrError = index currentPosition 0ul in
   let h2 = HST.get () in
@@ -1198,10 +1202,12 @@ let validate_list
   #inv #l #ar
   (v: validate_with_action_t' p inv l ar)
 : Tot (validate_with_action_t' (LowParse.Spec.List.parse_list p) inv l false)
-= fun ctxt input pos ->
+= fun ctxt err input pos ->
   let h = HST.get () in
   Classical.move_requires (LPL.valid_pos_consumes_all (LowParse.Spec.List.parse_list p) h (LPL.slice_of input)) (LPL.uint64_to_uint32 pos);
-  with_drop_if true inv input (LPL.uint64_to_uint32 pos) (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input) (validate_list' v ctxt input pos)
+  with_drop_if true inv input (LPL.uint64_to_uint32 pos)
+    (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input) 
+    (validate_list' v ctxt err input pos)
 
 #push-options "--z3rlimit 32"
 #restart-solver
@@ -1215,7 +1221,7 @@ let validate_fldata_consumes_all
   #inv #l #ar
   (v: validate_with_action_t' p inv l ar  { k.LP.parser_kind_subkind == Some LP.ParserConsumesAll })
 : Tot (validate_with_action_t' (LowParse.Spec.FLData.parse_fldata p (U32.v n)) inv l false)
-= fun ctxt input pos ->
+= fun ctxt err input pos ->
   let h = HST.get () in
   LPL.valid_facts (LowParse.Spec.FLData.parse_fldata p (U32.v n)) h (LPL.slice_of input) (LPL.uint64_to_uint32 pos);
   LPLF.parse_fldata_consumes_all_correct p (U32.v n) (LPL.bytes_of_slice_from h (LPL.slice_of input) (LPL.uint64_to_uint32 pos));
@@ -1225,7 +1231,9 @@ let validate_fldata_consumes_all
     let truncatedInput = LPL.truncate_input_buffer input (LPL.uint64_to_uint32 pos `U32.add` n) in
     LPL.valid_facts p h (LPL.slice_of truncatedInput) (LPL.uint64_to_uint32 pos);
     R.readable_split h (LPL.perm_of input) (LPL.uint64_to_uint32 pos) (LPL.slice_length truncatedInput) (LPL.slice_length input);
-    with_drop_if true inv input (LPL.uint64_to_uint32 pos) (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input) (v ctxt truncatedInput pos)
+    with_drop_if true inv input (LPL.uint64_to_uint32 pos)
+      (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input)
+      (v ctxt err truncatedInput pos)
   end
 #pop-options
 
@@ -1263,7 +1271,7 @@ let validate_nlist_constant_size_without_actions
     k.parser_kind_metadata = Some ParserKindMetadataTotal &&
     k.parser_kind_low < 4294967296
   then
-    (fun ctxt input startPosition ->
+    (fun ctxt err input startPosition ->
       let h = HST.get () in
       assert (forall h' . {:pattern (B.modifies B.loc_none h h')} (B.modifies B.loc_none h h' /\ inv (LPL.slice_of input).LPL.base h) ==> h' `extends` h);
       assert (forall h' . {:pattern (B.modifies B.loc_none h h')} (B.modifies B.loc_none h h' /\ inv (LPL.slice_of input).LPL.base h) ==> inv (LPL.slice_of input).LPL.base h');
@@ -1279,7 +1287,7 @@ noextract inline_for_extraction
 let validate_t_at_most' (n:U32.t) #nz #wk (#k:parser_kind nz wk) (#t:_) (#p:parser k t)
                        (#inv:_) (#l:_) (#ar:_) (v:validate_with_action_t p inv l ar)
   : Tot (validate_with_action_t (parse_t_at_most n p) inv l ar)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let h = HST.get () in
     let _ =
       LPL.valid_weaken kind_t_at_most (LowParse.Spec.FLData.parse_fldata (LPC.nondep_then p LowParse.Spec.Bytes.parse_all_bytes) (U32.v n)) h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition);
@@ -1296,7 +1304,7 @@ let validate_t_at_most' (n:U32.t) #nz #wk (#k:parser_kind nz wk) (#t:_) (#p:pars
         LPLC.valid_nondep_then h p LowParse.Spec.Bytes.parse_all_bytes (LPL.slice_of input') (LPL.uint64_to_uint32 startPosition)
       in
       // FIXME: I'd need a name here
-      let positionAfterContents = v ctxt input' startPosition in
+      let positionAfterContents = v ctxt err input' startPosition in
       let h1 = HST.get () in
       let _ = modifies_address_liveness_insensitive_unused_in h h1 in
       if LPL.is_error positionAfterContents
@@ -1319,7 +1327,7 @@ noextract inline_for_extraction
 let validate_t_exact' (n:U32.t) (#nz:bool) #wk (#k:parser_kind nz wk) (#t:_) (#p:parser k t)
                        (#inv:_) (#l:_) (#ar:_) (v:validate_with_action_t p inv l ar)
   : Tot (validate_with_action_t (parse_t_exact n p) inv l ar)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     let h = HST.get () in
     let _ =
       LPL.valid_weaken kind_t_at_most (LowParse.Spec.FLData.parse_fldata p (U32.v n)) h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition);
@@ -1335,7 +1343,7 @@ let validate_t_exact' (n:U32.t) (#nz:bool) #wk (#k:parser_kind nz wk) (#t:_) (#p
         LPL.valid_facts p h (LPL.slice_of input') (LPL.uint64_to_uint32 startPosition)
       in
       // FIXME: I'd need a name here
-      let positionAfterContents = v ctxt input' startPosition in
+      let positionAfterContents = v ctxt err input' startPosition in
       let h1 = HST.get () in
       let _ = modifies_address_liveness_insensitive_unused_in h h1 in
       if LPL.is_error positionAfterContents
@@ -1356,9 +1364,9 @@ let validate_with_comment (c:string)
                           #nz #wk (#k:parser_kind nz wk) #t (#p:parser k t)
                           #inv #l #ar (v:validate_with_action_t p inv l ar)
   : validate_with_action_t p inv l ar
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     LowParse.Low.Base.comment c;
-    v ctxt input startPosition
+    v ctxt err input startPosition
 
 inline_for_extraction noextract
 let validate_weaken_inv_loc #nz #wk (#k:parser_kind nz wk) #t (#p:parser k t)
@@ -1394,7 +1402,7 @@ let read_filter #nz
 inline_for_extraction noextract
 let validate____UINT8
   : validator parse____UINT8
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a UINT8, i.e., 1 byte";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT8 1uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1406,7 +1414,7 @@ let read____UINT8
 inline_for_extraction noextract
 let validate____UINT16BE
   : validator parse____UINT16BE
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a UINT16BE, i.e., 2 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT16BE 2uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1418,7 +1426,7 @@ let read____UINT16BE
 inline_for_extraction noextract
 let validate____UINT32BE
   : validator parse____UINT32BE
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a ULONG, i.e., 4 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT32BE 4uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1430,7 +1438,7 @@ let read____UINT32BE
 inline_for_extraction noextract
 let validate____UINT64BE
   : validator parse____UINT64BE
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a ULONG64BE, i.e., 8 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT64BE 8uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1442,7 +1450,7 @@ let read____UINT64BE
 inline_for_extraction noextract
 let validate____UINT16
   : validator parse____UINT16
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a UINT16, i.e., 2 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT16 2uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1455,7 +1463,7 @@ let read____UINT16
 inline_for_extraction noextract
 let validate____UINT32
   : validator parse____UINT32
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a ULONG, i.e., 4 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT32 4uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1467,7 +1475,7 @@ let read____UINT32
 inline_for_extraction noextract
 let validate____UINT64
   : validator parse____UINT64
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a ULONG64, i.e., 8 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT64 8uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1489,7 +1497,7 @@ let read_unit
 inline_for_extraction noextract
 let validate_unit_refinement' (f:unit -> bool) (cf:string)
   : Tot (validate_with_action_t #false #WeakKindStrongPrefix (parse_unit `LPC.parse_filter` f) true_inv eloc_none true)
-  = fun ctxt input startPosition ->
+  = fun ctxt err input startPosition ->
       let h = HST.get () in
       [@inline_let] let _ = LPLC.valid_facts (parse_unit) h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
       [@inline_let] let _ = LPLC.valid_filter h parse_unit f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
@@ -1578,6 +1586,7 @@ let validate_list_up_to_body
   (v: validator p)
   (r: leaf_reader p)
   (ctxt:app_ctxt)
+  (err:error_handler)
   (#len: U32.t)
   (sl: input_buffer_t len)
   (pos0: U32.t)
@@ -1599,7 +1608,7 @@ let validate_list_up_to_body
   valid_facts (parse_list_up_to (cond_string_up_to terminator) p prf) h0 (slice_of sl) (uint64_to_uint32 pos);
   parse_list_up_to_eq (cond_string_up_to terminator) p prf (bytes_of_slice_from h0 (slice_of sl) (uint64_to_uint32 pos));
   valid_facts p h0 (slice_of sl) (uint64_to_uint32 pos);
-  let pos1 = v ctxt sl pos in
+  let pos1 = v ctxt err sl pos in
   B.upd bpos 0ul pos1;
   if is_error pos1
   then begin
@@ -1629,14 +1638,14 @@ let validate_list_up_to
   (prf: LUT.consumes_if_not_cond (cond_string_up_to terminator) p)
 : Tot (validate_with_action_t #true #WeakKindStrongPrefix (LUT.parse_list_up_to (cond_string_up_to terminator) p prf) true_inv eloc_none false)
 =
-  fun ctxt sl pos ->
+  fun ctxt err sl pos ->
   HST.push_frame ();
   let bpos = B.alloca pos 1ul in
   let h2 = HST.get () in
   R.unreadable_empty h2 (LPL.perm_of sl) (LPL.uint64_to_uint32 pos);
   C.Loops.do_while
     (validate_list_up_to_inv p terminator prf ctxt sl (LPL.uint64_to_uint32 pos) h2 bpos)
-    (fun _ -> validate_list_up_to_body terminator prf v r ctxt sl (LPL.uint64_to_uint32 pos) h2 bpos)
+    (fun _ -> validate_list_up_to_body terminator prf v r ctxt err sl (LPL.uint64_to_uint32 pos) h2 bpos)
     ;
   let res = B.index bpos 0ul in
   HST.pop_frame ();
@@ -1654,7 +1663,7 @@ let validate_string
 
 inline_for_extraction noextract
 let validate_all_bytes2 : validate_with_action_t parse_all_bytes true_inv eloc_none true =
-  fun ctxt #inputLength input startPosition ->
+  fun ctxt err #inputLength input startPosition ->
     let h = HST.get () in
     LPL.valid_facts LowParse.Spec.Bytes.parse_all_bytes h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition);
     FStar.Int.Cast.uint32_to_uint64 inputLength

--- a/src/3d/prelude/Actions.fst
+++ b/src/3d/prelude/Actions.fst
@@ -59,6 +59,7 @@ let action p inv l on_success a
         h1 `extends` h0 /\
         inv (LPL.slice_of sl).LPL.base h1)
 
+inline_for_extraction
 let error_handler = typename:string ->
                     fieldname:string ->
                     error_reason:string ->
@@ -238,17 +239,6 @@ let validate_with_success_action name v1 a
   = validate_drop (validate_with_success_action' name v1 a)
 
 module P = Prelude
-
-let error_reason_of_result (code:U64.t) = 
-  match LPL.get_validator_error_kind code with
-  | 1uL -> "generic error"
-  | 2uL -> "not enough data"
-  | 3uL -> "impossible"
-  | 4uL -> "list size not multiple of element size"
-  | 5uL -> "action failed"
-  | 6uL -> "constraint failed"
-  | 7uL -> "unexpected padding"
-  | _ -> "unspecified"
   
 
 inline_for_extraction noextract
@@ -273,7 +263,7 @@ let validate_with_error_handler (typename:string)
     if LPL.is_success pos1
     then pos1
     else (
-         err typename fieldname (error_reason_of_result pos1) ctxt input startPosition pos1;
+         err typename fieldname (ResultOps.error_reason_of_result pos1) ctxt input startPosition pos1;
          pos1
     )
 

--- a/src/3d/prelude/Actions.fst
+++ b/src/3d/prelude/Actions.fst
@@ -453,7 +453,6 @@ let validate_dep_pair
 inline_for_extraction noextract
 let validate_dep_pair_with_refinement_and_action'
       (name1: string)
-      (id1: field_id)
       #nz1
       (#k1:parser_kind nz1 _)
       #t1
@@ -521,7 +520,7 @@ let validate_dep_pair_with_refinement_and_action'
         [@(rename_let (name1 ^ "ConstraintIsOk"))]
         let ok = f field_value in
         [@(rename_let ("pos_or_error_after_" ^ name1))]
-        let res1 = check_constraint_ok_with_field_id ok startPosition res id1 in
+        let res1 = check_constraint_ok_with_field_id ok startPosition res 1uL in
         if LPL.is_error res1
         then
           with_drop_if 
@@ -546,7 +545,7 @@ let validate_dep_pair_with_refinement_and_action'
                      input
                      (LPL.uint64_to_uint32 startPosition)
                      (fun _ -> LPL.slice_length input)
-                     (LPL.set_validator_error_pos_and_code validator_error_action_failed startPosition id1)
+                     (LPL.set_validator_error_pos_and_code validator_error_action_failed startPosition 1uL)
              else begin
                let open LPL in
                // assert (valid_pos (p1 `(LPC.parse_filter #k1 #t1)` f) h0 input (uint64_to_uint32 pos) (uint64_to_uint32 res));
@@ -582,7 +581,6 @@ let validate_dep_pair_with_refinement_and_action'
 inline_for_extraction noextract
 let validate_dep_pair_with_refinement_and_action_total_zero_parser'
       (name1: string)
-      (id1: field_id)
       #nz1
       (#k1:parser_kind nz1 _)
       #t1
@@ -644,7 +642,7 @@ let validate_dep_pair_with_refinement_and_action_total_zero_parser'
         [@(rename_let (name1 ^ "ConstraintIsOk"))]
         let ok = f field_value in
         [@(rename_let ("pos_or_error_after_" ^ name1))]
-        let res1 = check_constraint_ok_with_field_id ok startPosition startPosition id1 in
+        let res1 = check_constraint_ok_with_field_id ok startPosition startPosition 1uL in
         if LPL.is_error res1
         then
              with_drop_if
@@ -669,7 +667,7 @@ let validate_dep_pair_with_refinement_and_action_total_zero_parser'
                     input
                     (LPL.uint64_to_uint32 startPosition)
                     (fun _ -> LPL.slice_length input)
-                    (LPL.set_validator_error_pos_and_code validator_error_action_failed startPosition id1)
+                    (LPL.set_validator_error_pos_and_code validator_error_action_failed startPosition 1uL)
              else begin
                let open LPL in
                // assert (valid_pos (p1 `(LPC.parse_filter #k1 #t1)` f) h0 input (uint64_to_uint32 pos) (uint64_to_uint32 res));
@@ -705,7 +703,6 @@ let validate_dep_pair_with_refinement_and_action_total_zero_parser'
 inline_for_extraction noextract
 let validate_dep_pair_with_refinement'
       (name1: string)
-      (id1: field_id)
       #nz1
       (#k1:parser_kind nz1 _)
       #t1
@@ -747,7 +744,7 @@ let validate_dep_pair_with_refinement'
         [@(rename_let (name1 ^ "ConstraintIsOk"))]
         let ok = f field_value in
         [@(rename_let ("positionOrErrorAfter" ^ name1))]
-        let res1 = check_constraint_ok_with_field_id ok startPosition res id1 in
+        let res1 = check_constraint_ok_with_field_id ok startPosition res 1uL in
         if LPL.is_error res1
         then
              with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res1
@@ -768,7 +765,6 @@ let validate_dep_pair_with_refinement'
 inline_for_extraction noextract
 let validate_dep_pair_with_refinement_total_zero_parser'
       (name1: string)
-      (id1: field_id)
       #nz1 (#k1:parser_kind nz1 _) #t1 (#p1:parser k1 t1)
       #inv1 #l1 (v1:validate_with_action_t p1 inv1 l1 true) (r1: leaf_reader p1)
       (f: t1 -> bool)
@@ -798,7 +794,7 @@ let validate_dep_pair_with_refinement_total_zero_parser'
         [@(rename_let (name1 ^ "ConstraintIsOk"))]
         let ok = f field_value in
         [@(rename_let ("positionOrErrorAfter" ^ name1))]
-        let res1 = check_constraint_ok_with_field_id ok startPosition startPosition id1 in
+        let res1 = check_constraint_ok_with_field_id ok startPosition startPosition 1uL in
         if LPL.is_error res1
         then with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res1
         else let h2 = HST.get() in
@@ -821,7 +817,6 @@ inline_for_extraction noextract
 let validate_dep_pair_with_refinement_and_action
       (p1_is_constant_size_without_actions: bool)
       (name1: string)
-      (id1: field_id)
       #nz1 (#k1:parser_kind nz1 _) #t1 (#p1:parser k1 t1)
       #inv1 #l1 (v1:validate_with_action_t p1 inv1 l1 true) (r1: leaf_reader p1)
       (f: t1 -> bool)
@@ -837,9 +832,9 @@ let validate_dep_pair_with_refinement_and_action
       (k1.LP.parser_kind_high = Some 0) `LP.bool_and`
       (k1.LP.parser_kind_metadata = Some LP.ParserKindMetadataTotal)
     then
-      validate_dep_pair_with_refinement_and_action_total_zero_parser' name1 id1 v1 r1 f a v2
+      validate_dep_pair_with_refinement_and_action_total_zero_parser' name1 v1 r1 f a v2
     else
-      validate_dep_pair_with_refinement_and_action' name1 id1 v1 r1 f a v2
+      validate_dep_pair_with_refinement_and_action' name1 v1 r1 f a v2
 
 #push-options "--z3rlimit 32"
 
@@ -887,7 +882,6 @@ inline_for_extraction noextract
 let validate_dep_pair_with_refinement
       (p1_is_constant_size_without_actions: bool)
       (name1: string)
-      (id1: field_id)
       #nz1 (#k1:parser_kind nz1 _) #t1 (#p1:parser k1 t1)
       #inv1 #l1 (v1:validate_with_action_t p1 inv1 l1 true) (r1: leaf_reader p1)
       (f: t1 -> bool)
@@ -902,9 +896,9 @@ let validate_dep_pair_with_refinement
       (k1.LP.parser_kind_high = Some 0) `LP.bool_and`
       (k1.LP.parser_kind_metadata = Some LP.ParserKindMetadataTotal)
     then
-      validate_dep_pair_with_refinement_total_zero_parser' name1 id1 v1 r1 f v2
+      validate_dep_pair_with_refinement_total_zero_parser' name1 v1 r1 f v2
     else
-      validate_dep_pair_with_refinement' name1 id1 v1 r1 f v2
+      validate_dep_pair_with_refinement' name1 v1 r1 f v2
 
 inline_for_extraction noextract
 let validate_filter' (name: string) #nz (#k:parser_kind nz _) (#t:_) (#p:parser k t)

--- a/src/3d/prelude/Actions.fst
+++ b/src/3d/prelude/Actions.fst
@@ -28,10 +28,15 @@ open LowStar.Buffer
 friend Prelude
 open Prelude
 module B = LowStar.Buffer
+module U8 = FStar.UInt8
+
+let app_ctxt = B.pointer U8.t
+let app_loc (x:app_ctxt) (l:eloc) : eloc = B.loc_buffer x `loc_union` l
 
 inline_for_extraction
 let action p inv l on_success a
   = #len: U32.t ->
+    ctxt:app_ctxt ->
     sl: input_buffer_t len ->
     pos:LPL.pos_t ->
     res:U64.t ->
@@ -39,31 +44,36 @@ let action p inv l on_success a
       (requires fun h ->
         let open LPL in
         LPL.live_input_buffer h sl /\
+        B.live h ctxt  /\
         inv (LPL.slice_of sl).LPL.base h /\
-        loc_not_unused_in h `loc_includes` l /\
-        address_liveness_insensitive_locs `loc_includes` l /\
-        l `loc_disjoint` (loc_buffer (LPL.slice_of sl).base `loc_union` R.loc_perm (LPL.perm_of sl)) /\
+        loc_not_unused_in h `loc_includes` (app_loc ctxt l) /\
+        address_liveness_insensitive_locs `loc_includes` (app_loc ctxt l) /\
+        (app_loc ctxt l) `loc_disjoint` 
+        (loc_buffer (LPL.slice_of sl).base `loc_union` R.loc_perm (LPL.perm_of sl)) /\
         (U64.v res <= U64.v validator_max_length ==>
            valid_pos p h (LPL.slice_of sl) (uint64_to_uint32 pos) (uint64_to_uint32 res)) /\
         (on_success ==> U64.v res <= U64.v validator_max_length))
       (ensures fun h0 _ h1 ->
-        modifies l h0 h1 /\
+        modifies (app_loc ctxt l) h0 h1 /\
+        B.live h1 ctxt /\        
         h1 `extends` h0 /\
         inv (LPL.slice_of sl).LPL.base h1)
 
 inline_for_extraction
 let validate_with_action_t' (#k:LP.parser_kind) (#t:Type) (p:LP.parser k t) (inv:slice_inv) (l:eloc) (allow_reading:bool) =
   (#len: U32.t) ->
+  (ctxt: app_ctxt) ->
   (sl: input_buffer_t len) ->
   (pos: U64.t) ->
   Stack U64.t
   (requires fun h ->
     let open LPL in
     live_input_buffer h sl /\
+    B.live h ctxt /\
     inv (slice_of sl).base h /\
-    loc_not_unused_in h `loc_includes` l /\
-    address_liveness_insensitive_locs `loc_includes` l /\
-    l `loc_disjoint` (loc_buffer (slice_of sl).base `loc_union` R.loc_perm (perm_of sl)) /\
+    loc_not_unused_in h `loc_includes` (app_loc ctxt l) /\
+    address_liveness_insensitive_locs `loc_includes` (app_loc ctxt l) /\
+    (app_loc ctxt l) `loc_disjoint` (loc_buffer (slice_of sl).base `loc_union` R.loc_perm (perm_of sl)) /\
     U64.v pos <= U32.v (slice_of sl).len /\
     R.readable h (perm_of sl) (uint64_to_uint32 pos) (slice_of sl).len
   )
@@ -71,10 +81,14 @@ let validate_with_action_t' (#k:LP.parser_kind) (#t:Type) (p:LP.parser k t) (inv
     let open LPL in
     h' `extends` h /\
     live_input_buffer h' sl /\
+    B.live h ctxt /\    
     inv (slice_of sl).base h' /\
     (is_success res ==> valid_pos p h (slice_of sl) (uint64_to_uint32 pos) (uint64_to_uint32 res)) /\
     modifies
-      (if allow_reading then l else l `loc_union` (R.loc_perm_from_to (perm_of sl) (uint64_to_uint32 pos) (if is_success res then uint64_to_uint32 res else (slice_of sl).len)))
+      (if allow_reading
+       then (app_loc ctxt l)
+       else (app_loc ctxt l) `loc_union` 
+            (R.loc_perm_from_to (perm_of sl) (uint64_to_uint32 pos) (if is_success res then uint64_to_uint32 res else (slice_of sl).len)))
       h h' /\
     ((~ allow_reading) ==> R.unreadable h' (perm_of sl) (uint64_to_uint32 pos) (if is_success res then uint64_to_uint32 res else (slice_of sl).len))
   )
@@ -84,7 +98,7 @@ let validate_with_action_t p inv l allow_reading =
   validate_with_action_t' p inv l allow_reading
 
 let validate_eta v =
-  fun #inputLength input startPosition -> v input startPosition
+  fun #inputLength ctxt input startPosition -> v ctxt input startPosition
 
 inline_for_extraction noextract
 let act_with_comment
@@ -93,9 +107,9 @@ let act_with_comment
   (#inv:slice_inv) (#l:eloc) (#b:_) (res:Type)
   (a: action p inv l b res)
 : Tot (action p inv l b res)
-= fun #inputLength input startPosition endPosition ->
+= fun #inputLength ctxt input startPosition endPosition ->
   LPL.comment s;
-  a input startPosition endPosition
+  a ctxt input startPosition endPosition
 
 inline_for_extraction
 let leaf_reader
@@ -121,7 +135,12 @@ let leaf_reader
   ))
 
 inline_for_extraction noextract
-let lift_constant_size_leaf_reader #nz (#k: parser_kind nz WeakKindStrongPrefix) #t (#p:parser k t) (r:LPL.leaf_reader p) (sz: U32.t { k.LPL.parser_kind_high == Some k.LPL.parser_kind_low /\ k.LPL.parser_kind_low == U32.v sz })
+let lift_constant_size_leaf_reader #nz 
+                                   (#k: parser_kind nz WeakKindStrongPrefix)
+                                   #t
+                                   (#p:parser k t)
+                                   (r:LPL.leaf_reader p)
+                                   (sz: U32.t { k.LPL.parser_kind_high == Some k.LPL.parser_kind_low /\ k.LPL.parser_kind_low == U32.v sz })
   : leaf_reader p
   = fun #inputLength input startPosition ->
       LPL.read_with_perm r (LPL.jump_constant_size p sz ()) input startPosition
@@ -165,27 +184,41 @@ let validate_drop
    (v: validate_with_action_t p inv l allow_reading)
 : Tot (validate_with_action_t p inv l false)
 = fun
+  ctxt
   input
   (startPosition: U64.t) ->
-  with_drop_if true inv input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v input startPosition)
+    with_drop_if true inv input (LPL.uint64_to_uint32 startPosition)
+                                (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input)
+                                (v ctxt input startPosition)
 
 inline_for_extraction
 noextract
-let validate_with_success_action' (name: string) #nz #wk (#k1:parser_kind nz wk) #t1 (#p1:parser k1 t1) (#inv1:_) (#l1:eloc) (#ar:_)
-                         (v1:validate_with_action_t p1 inv1 l1 ar)
-                         (#inv2:_) (#l2:eloc) #b (a:action p1 inv2 l2 b bool)
+let validate_with_success_action' 
+       (name: string)
+       #nz
+       #wk
+       (#k1:parser_kind nz wk)
+       #t1
+       (#p1:parser k1 t1)
+       (#inv1:_)
+       (#l1:eloc)
+       (#ar:_)
+       (v1:validate_with_action_t p1 inv1 l1 ar)
+       (#inv2:_)
+       (#l2:eloc)
+       #b
+       (a:action p1 inv2 l2 b bool)
   : validate_with_action_t p1 (conj_inv inv1 inv2) (l1 `eloc_union` l2) ar
-  = fun #inputLength  input
-        startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let h0 = HST.get () in
     [@(rename_let ("positionAfter" ^ name))]
-    let pos1 = v1 input startPosition in
+    let pos1 = v1 ctxt input startPosition in
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in h0 h1;
     if LPL.is_success pos1
     then
          [@(rename_let ("action_success_" ^ name))]
-         let b = a input startPosition pos1 in
+         let b = a ctxt input startPosition pos1 in
          if not b
          then
            with_drop_if (not ar) (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) validator_error_action_failed
@@ -194,9 +227,8 @@ let validate_with_success_action' (name: string) #nz #wk (#k1:parser_kind nz wk)
     else
          pos1
 
-let validate_with_success_action
-  name v1 a
-= validate_drop (validate_with_success_action' name v1 a)
+let validate_with_success_action name v1 a
+  = validate_drop (validate_with_success_action' name v1 a)
 
 module P = Prelude
 let p = P.parse_impos ()
@@ -232,37 +264,46 @@ let validate_with_error_handler (typename:string)
                                 (v1:validate_with_action_t p1 inv1 l1 ar)
                                 (err:error_handler)
   : validate_with_action_t p1 inv1 l1 ar
-  = fun #inputLength  input
-        startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let h0 = HST.get () in
     [@(rename_let ("positionAfter" ^ typename))]
-    let pos1 = v1 input startPosition in
+    let pos1 = v1 ctxt input startPosition in
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in h0 h1;
     if LPL.is_success pos1
     then pos1
     else (
-         err typename fieldname (error_reason_of_result pos1) input startPosition pos1;
+         err typename fieldname (error_reason_of_result pos1) ctxt input startPosition pos1;
          pos1
     )
 
 inline_for_extraction noextract
-let validate_with_error_action' (name: string) #nz #wk (#k1:parser_kind nz wk) #t1 (#p1:parser k1 t1) (#inv1:_) (#l1:eloc) (#ar:_)
-                         (v1:validate_with_action_t p1 inv1 l1 ar)
-                         (#inv2:_) (#l2:eloc) (a:action p1 inv2 l2 false bool)
+let validate_with_error_action'
+      (name: string)
+      #nz
+      #wk
+      (#k1:parser_kind nz wk)
+      #t1
+      (#p1:parser k1 t1)
+      (#inv1:_)
+      (#l1:eloc)
+      (#ar:_)
+      (v1:validate_with_action_t p1 inv1 l1 ar)
+      (#inv2:_)
+      (#l2:eloc)
+      (a:action p1 inv2 l2 false bool)
   : validate_with_action_t p1 (conj_inv inv1 inv2) (l1 `eloc_union` l2) ar
-  = fun #inputLength  input
-        startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let h0 = HST.get () in
     [@(rename_let ("positionAfter" ^ name))]
-    let pos1 = v1 input startPosition in
+    let pos1 = v1 ctxt input startPosition in
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in h0 h1;
     if LPL.is_success pos1
     then pos1
     else
          [@(rename_let ("action_error_" ^ name))]
-         let b = a input startPosition pos1 in
+         let b = a ctxt input startPosition pos1 in
          if not b then validator_error_action_failed else pos1
 
 let validate_with_error_action
@@ -272,7 +313,7 @@ let validate_with_error_action
 inline_for_extraction noextract
 let validate_ret
   : validate_with_action_t (parse_ret ()) true_inv eloc_none true
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let h = HST.get () in
     [@inline_let] let _ = LPL.valid_facts (parse_ret ()) h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
     startPosition
@@ -282,27 +323,57 @@ let validate_ret
 inline_for_extraction noextract
 let validate_pair'
        (name1: string)
-       #nz1 (#k1:parser_kind nz1 WeakKindStrongPrefix) #t1 (#p1:parser k1 t1)
-       (#inv1:_) (#l1:eloc) (#ar1:_) (v1:validate_with_action_t p1 inv1 l1 ar1)
-       #nz2 #wk2 (#k2:parser_kind nz2 wk2) #t2 (#p2:parser k2 t2)
-       (#inv2:_) (#l2:eloc) (#ar2:_) (v2:validate_with_action_t p2 inv2 l2 ar2)
+       #nz1 
+       (#k1:parser_kind nz1 WeakKindStrongPrefix)
+       #t1
+       (#p1:parser k1 t1)
+       (#inv1:_) 
+       (#l1:eloc)
+       (#ar1:_)
+       (v1:validate_with_action_t p1 inv1 l1 ar1)
+       #nz2
+       #wk2
+       (#k2:parser_kind nz2 wk2)
+       #t2
+       (#p2:parser k2 t2)
+       (#inv2:_)
+       (#l2:eloc)
+       (#ar2:_)
+       (v2:validate_with_action_t p2 inv2 l2 ar2)
   : validate_with_action_t (p1 `parse_pair` p2) (conj_inv inv1 inv2) (l1 `eloc_union` l2) (ar1 && ar2)
-  = fun #inputLength  input
-        startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let h = HST.get () in
     [@inline_let] let _ = LPLC.valid_nondep_then h p1 p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
     [@(rename_let ("positionAfter" ^ name1))]
-    let pos1 = v1 input startPosition in
+    let pos1 = v1 ctxt input startPosition in
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in h h1;
     if LPL.is_error pos1
     then begin
-      with_drop_if (not (ar1 && ar2)) (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) pos1
+      with_drop_if (not (ar1 && ar2))
+                   (conj_inv inv1 inv2)
+                   input
+                   (LPL.uint64_to_uint32 startPosition)
+                   (fun _ -> LPL.slice_length input)
+                   pos1
     end
     else
-      [@inline_let] let _ = R.readable_split h (LPL.perm_of input) (LPL.uint64_to_uint32 startPosition) (LPL.uint64_to_uint32 pos1) (LPL.slice_length input) in
-      [@inline_let] let _ = LPL.valid_facts p2 h (LPL.slice_of input) (LPL.uint64_to_uint32 pos1) in
-      with_drop_if (not (ar1 && ar2)) (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input) (v2 input pos1)
+      [@inline_let] 
+      let _ = R.readable_split 
+                h
+                (LPL.perm_of input)
+                (LPL.uint64_to_uint32 startPosition)
+                (LPL.uint64_to_uint32 pos1)
+                (LPL.slice_length input)
+      in
+      [@inline_let]
+      let _ = LPL.valid_facts p2 h (LPL.slice_of input) (LPL.uint64_to_uint32 pos1) in
+      with_drop_if (not (ar1 && ar2))
+                   (conj_inv inv1 inv2)
+                   input 
+                   (LPL.uint64_to_uint32 startPosition)
+                   (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input)
+                   (v2 ctxt input pos1)
 
 let validate_pair
   name1 v1 v2
@@ -311,29 +382,69 @@ let validate_pair
 inline_for_extraction noextract
 let validate_dep_pair
       (name1: string)
-      #nz1 (#k1:parser_kind nz1 _) #t1 (#p1:parser k1 t1)
-      #inv1 #l1 (v1:validate_with_action_t p1 inv1 l1 true) (r1: leaf_reader p1)
-      #nz2 #wk2 (#k2:parser_kind nz2 wk2) (#t2:t1 -> Type) (#p2:(x:t1 -> parser k2 (t2 x)))
-      #inv2 #l2 #ar2 (v2:(x:t1 -> validate_with_action_t (p2 x) inv2 l2 ar2))
+      #nz1 
+      (#k1:parser_kind nz1 _)
+      #t1
+      (#p1:parser k1 t1)
+      #inv1
+      #l1
+      (v1:validate_with_action_t p1 inv1 l1 true)
+      (r1: leaf_reader p1)
+      #nz2
+      #wk2
+      (#k2:parser_kind nz2 wk2)
+      (#t2:t1 -> Type)
+      (#p2:(x:t1 -> parser k2 (t2 x)))
+      #inv2
+      #l2
+      #ar2
+      (v2:(x:t1 -> validate_with_action_t (p2 x) inv2 l2 ar2))
   : Tot (validate_with_action_t (p1 `parse_dep_pair` p2) (conj_inv inv1 inv2) (l1 `eloc_union` l2) false)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
       let h = HST.get () in
       [@inline_let] let _ = LPLC.valid_dtuple2 h p1 p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
       [@(rename_let ("positionAfter" ^ name1))]
-      let pos1 = v1 input startPosition in
+      let pos1 = v1 ctxt input startPosition in
       let h1 = HST.get() in
       if LPL.is_error pos1
       then begin
-        with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) pos1
+        with_drop_if 
+          true
+          (conj_inv inv1 inv2)
+          input
+          (LPL.uint64_to_uint32 startPosition)
+          (fun _ -> LPL.slice_length input)
+          pos1
       end
       else
-        [@inline_let] let _ = R.readable_split h (LPL.perm_of input) (LPL.uint64_to_uint32 startPosition) (LPL.uint64_to_uint32 pos1) (LPL.slice_length input) in
+        [@inline_let]
+        let _ = 
+          R.readable_split
+            h
+            (LPL.perm_of input)
+            (LPL.uint64_to_uint32 startPosition)
+            (LPL.uint64_to_uint32 pos1)
+            (LPL.slice_length input)
+        in
         [@(rename_let ("" ^ name1))]
         let x = r1 input (LPL.uint64_to_uint32 startPosition) in
         let h15 = HST.get () in
         let _ = modifies_address_liveness_insensitive_unused_in h h15 in
-        [@inline_let] let _ = LPLC.valid_facts (p2 x) h (LPL.slice_of input) (LPL.uint64_to_uint32 pos1) in
-        with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 x input pos1)
+        [@inline_let]
+        let _ = 
+          LPLC.valid_facts
+            (p2 x)
+            h
+            (LPL.slice_of input)
+            (LPL.uint64_to_uint32 pos1)
+        in
+        with_drop_if
+          true
+          (conj_inv inv1 inv2)
+          input
+          (LPL.uint64_to_uint32 startPosition)
+          (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input)
+          (v2 x ctxt input pos1)
 
 #pop-options
 
@@ -343,30 +454,68 @@ inline_for_extraction noextract
 let validate_dep_pair_with_refinement_and_action'
       (name1: string)
       (id1: field_id)
-      #nz1 (#k1:parser_kind nz1 _) #t1 (#p1:parser k1 t1)
-      #inv1 #l1 (v1:validate_with_action_t p1 inv1 l1 true) (r1: leaf_reader p1)
+      #nz1
+      (#k1:parser_kind nz1 _)
+      #t1
+      (#p1:parser k1 t1)
+      #inv1
+      #l1
+      (v1:validate_with_action_t p1 inv1 l1 true)
+      (r1: leaf_reader p1)
       (f: t1 -> bool)
-      #inv1' #l1' #b (a:t1 -> action p1 inv1' l1' b bool)
-      #nz2 #wk2 (#k2:parser_kind nz2 wk2) (#t2:refine _ f -> Type) (#p2:(x:refine _ f -> parser k2 (t2 x)))
-      #inv2 #l2 #ar2 (v2:(x:refine _ f -> validate_with_action_t (p2 x) inv2 l2 ar2))
+      #inv1'
+      #l1' 
+      #b
+      (a:t1 -> action p1 inv1' l1' b bool)
+      #nz2
+      #wk2
+      (#k2:parser_kind nz2 wk2)
+      (#t2:refine _ f -> Type)
+      (#p2:(x:refine _ f -> parser k2 (t2 x)))
+      #inv2
+      #l2
+      #ar2
+      (v2:(x:refine _ f -> validate_with_action_t (p2 x) inv2 l2 ar2))
   : Tot (validate_with_action_t
              ((p1 `LPC.parse_filter` f) `(parse_dep_pair #nz1)` p2)
              (conj_inv inv1 (conj_inv inv1' inv2))
              (l1 `eloc_union` (l1' `eloc_union` l2))
              false)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
       let h0 = HST.get () in
-      [@inline_let] let _ = LPLC.valid_filter h0 p1 f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
+      [@inline_let] 
+      let _ =
+        LPLC.valid_filter
+          h0
+          p1
+          f
+          (LPL.slice_of input)
+          (LPL.uint64_to_uint32 startPosition)
+        in
       [@(rename_let ("positionAfter" ^ name1))]
-      let res = v1 input startPosition in
+      let res = v1 ctxt input startPosition in
       let h1 = HST.get() in
       modifies_address_liveness_insensitive_unused_in h0 h1;
       if LPL.is_error res
       then begin
-        with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res
+        with_drop_if
+          true
+          (conj_inv inv1 (conj_inv inv1' inv2))
+          input
+          (LPL.uint64_to_uint32 startPosition)
+          (fun _ -> LPL.slice_length input)
+          res
       end
       else begin
-        [@inline_let] let _ = R.readable_split h0 (LPL.perm_of input) (LPL.uint64_to_uint32 startPosition) (LPL.uint64_to_uint32 res) (LPL.slice_length input) in
+        [@inline_let]
+        let _ = 
+          R.readable_split
+            h0
+            (LPL.perm_of input)
+            (LPL.uint64_to_uint32 startPosition) 
+            (LPL.uint64_to_uint32 res)
+            (LPL.slice_length input)
+        in
         [@(rename_let ("" ^ name1))]
         let field_value = r1 input (LPL.uint64_to_uint32 startPosition) in
         [@(rename_let (name1 ^ "ConstraintIsOk"))]
@@ -375,7 +524,13 @@ let validate_dep_pair_with_refinement_and_action'
         let res1 = check_constraint_ok_with_field_id ok startPosition res id1 in
         if LPL.is_error res1
         then
-          with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res1
+          with_drop_if 
+            true
+            (conj_inv inv1 (conj_inv inv1' inv2))
+            input
+            (LPL.uint64_to_uint32 startPosition)
+            (fun _ -> LPL.slice_length input)
+            res1
         else let h2 = HST.get() in
              // assert (B.modifies B.loc_none h1 h2);
              // assert (inv1' input.LPL.base h2);
@@ -383,16 +538,44 @@ let validate_dep_pair_with_refinement_and_action'
              // assert (loc_not_unused_in h2 `loc_includes` l1');
              // [@(rename_let ("action_" ^ name1))]
              // let action_result =  in
-             if not (a field_value input startPosition res)
-             then with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) (LPL.set_validator_error_pos_and_code validator_error_action_failed startPosition id1) //action failed
+             if not (a field_value ctxt input startPosition res)
+             then //action failed
+                  with_drop_if 
+                     true
+                     (conj_inv inv1 (conj_inv inv1' inv2))
+                     input
+                     (LPL.uint64_to_uint32 startPosition)
+                     (fun _ -> LPL.slice_length input)
+                     (LPL.set_validator_error_pos_and_code validator_error_action_failed startPosition id1)
              else begin
                let open LPL in
                // assert (valid_pos (p1 `(LPC.parse_filter #k1 #t1)` f) h0 input (uint64_to_uint32 pos) (uint64_to_uint32 res));
                let h15 = HST.get () in
                let _ = modifies_address_liveness_insensitive_unused_in h0 h15 in
-               [@inline_let] let _ = LPLC.valid_facts (p2 field_value) h0 (LPL.slice_of input) (LPL.uint64_to_uint32 res1) in
-               [@inline_let] let _ = LPLC.valid_dtuple2 h0 (p1 `LPC.parse_filter` f) p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-               with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input) (v2 field_value input res1)
+               [@inline_let] 
+               let _ = 
+                 LPLC.valid_facts
+                   (p2 field_value)
+                   h0
+                   (LPL.slice_of input)
+                   (LPL.uint64_to_uint32 res1)
+               in
+               [@inline_let]
+               let _ =
+                 LPLC.valid_dtuple2
+                   h0
+                   (p1 `LPC.parse_filter` f)
+                   p2
+                   (LPL.slice_of input)
+                   (LPL.uint64_to_uint32 startPosition)
+               in
+               with_drop_if
+                 true
+                 (conj_inv inv1 (conj_inv inv1' inv2))
+                 input
+                 (LPL.uint64_to_uint32 startPosition)
+                 (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input)
+                 (v2 field_value ctxt input res1)
              end
         end
 
@@ -400,12 +583,28 @@ inline_for_extraction noextract
 let validate_dep_pair_with_refinement_and_action_total_zero_parser'
       (name1: string)
       (id1: field_id)
-      #nz1 (#k1:parser_kind nz1 _) #t1 (#p1:parser k1 t1)
-      #inv1 #l1 (v1:validate_with_action_t p1 inv1 l1 true) (r1: leaf_reader p1)
+      #nz1
+      (#k1:parser_kind nz1 _)
+      #t1
+      (#p1:parser k1 t1)
+      #inv1
+      #l1
+      (v1:validate_with_action_t p1 inv1 l1 true)
+      (r1: leaf_reader p1)
       (f: t1 -> bool)
-      #inv1' #l1' #b (a:t1 -> action p1 inv1' l1' b bool)
-      #nz2 #wk2 (#k2:parser_kind nz2 wk2) (#t2:refine _ f -> Type) (#p2:(x:refine _ f -> parser k2 (t2 x)))
-      #inv2 #l2 #ar2 (v2:(x:refine _ f -> validate_with_action_t (p2 x) inv2 l2 ar2))
+      #inv1'
+      #l1'
+      #b
+      (a:t1 -> action p1 inv1' l1' b bool)
+      #nz2
+      #wk2
+      (#k2:parser_kind nz2 wk2)
+      (#t2:refine _ f -> Type)
+      (#p2:(x:refine _ f -> parser k2 (t2 x)))
+      #inv2
+      #l2
+      #ar2
+      (v2:(x:refine _ f -> validate_with_action_t (p2 x) inv2 l2 ar2))
   : Pure (validate_with_action_t
              ((p1 `LPC.parse_filter` f) `(parse_dep_pair #nz1)` p2)
              (conj_inv inv1 (conj_inv inv1' inv2))
@@ -417,14 +616,29 @@ let validate_dep_pair_with_refinement_and_action_total_zero_parser'
            k1.parser_kind_metadata == Some ParserKindMetadataTotal
          ))
          (ensures (fun _ -> True))
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
       let h0 = HST.get () in
-      [@inline_let] let _ = LPLC.valid_filter h0 p1 f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-      [@inline_let] let _ = LPLC.valid_facts p1 h0 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-      [@inline_let] let _ = LP.parser_kind_prop_equiv k1 p1 in
+      [@inline_let] 
+      let _ =
+        LPLC.valid_filter h0 p1 f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition)
+      in
+      [@inline_let]
+      let _ =
+        LPLC.valid_facts p1 h0 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) 
+      in
+      [@inline_let]
+      let _ = LP.parser_kind_prop_equiv k1 p1 in
       begin
         LowStar.Comment.comment ("Validating field " ^ name1);
-        [@inline_let] let _ = R.readable_split h0 (LPL.perm_of input) (LPL.uint64_to_uint32 startPosition) (LPL.uint64_to_uint32 startPosition) (LPL.slice_length input) in
+        [@inline_let]
+        let _ = 
+          R.readable_split
+            h0
+            (LPL.perm_of input)
+            (LPL.uint64_to_uint32 startPosition)
+            (LPL.uint64_to_uint32 startPosition)
+            (LPL.slice_length input) 
+        in
         [@(rename_let ("" ^ name1))]
         let field_value = r1 input (LPL.uint64_to_uint32 startPosition) in
         [@(rename_let (name1 ^ "ConstraintIsOk"))]
@@ -433,7 +647,13 @@ let validate_dep_pair_with_refinement_and_action_total_zero_parser'
         let res1 = check_constraint_ok_with_field_id ok startPosition startPosition id1 in
         if LPL.is_error res1
         then
-             with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res1
+             with_drop_if
+               true
+               (conj_inv inv1 (conj_inv inv1' inv2))
+               input
+               (LPL.uint64_to_uint32 startPosition)
+               (fun _ -> LPL.slice_length input)
+               res1
         else let h2 = HST.get() in
              // assert (B.modifies B.loc_none h1 h2);
              // assert (inv1' input.LPL.base h2);
@@ -441,16 +661,44 @@ let validate_dep_pair_with_refinement_and_action_total_zero_parser'
              // assert (loc_not_unused_in h2 `loc_includes` l1');
              // [@(rename_let ("action_" ^ name1))]
              // let action_result =  in
-             if not (a field_value input startPosition startPosition)
-             then with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) (LPL.set_validator_error_pos_and_code validator_error_action_failed startPosition id1) //action failed
+             if not (a field_value ctxt input startPosition startPosition)
+             then //action failed
+                  with_drop_if
+                    true
+                    (conj_inv inv1 (conj_inv inv1' inv2))
+                    input
+                    (LPL.uint64_to_uint32 startPosition)
+                    (fun _ -> LPL.slice_length input)
+                    (LPL.set_validator_error_pos_and_code validator_error_action_failed startPosition id1)
              else begin
                let open LPL in
                // assert (valid_pos (p1 `(LPC.parse_filter #k1 #t1)` f) h0 input (uint64_to_uint32 pos) (uint64_to_uint32 res));
                let h15 = HST.get () in
                let _ = modifies_address_liveness_insensitive_unused_in h0 h15 in
-               [@inline_let] let _ = LPLC.valid_facts (p2 field_value) h0 (LPL.slice_of input) (LPL.uint64_to_uint32 res1) in
-               [@inline_let] let _ = LPLC.valid_dtuple2 h0 (p1 `LPC.parse_filter` f) p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-               with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input) (v2 field_value input res1)
+               [@inline_let] 
+               let _ = 
+                 LPLC.valid_facts 
+                   (p2 field_value)
+                   h0
+                   (LPL.slice_of input)
+                   (LPL.uint64_to_uint32 res1) 
+               in
+               [@inline_let]
+               let _ = 
+                 LPLC.valid_dtuple2
+                   h0
+                   (p1 `LPC.parse_filter` f)
+                   p2
+                   (LPL.slice_of input)
+                   (LPL.uint64_to_uint32 startPosition)
+               in
+               with_drop_if
+                 true
+                 (conj_inv inv1 (conj_inv inv1' inv2))
+                 input
+                 (LPL.uint64_to_uint32 startPosition)
+                 (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input)
+                 (v2 field_value ctxt input res1)
              end
         end
 
@@ -458,21 +706,34 @@ inline_for_extraction noextract
 let validate_dep_pair_with_refinement'
       (name1: string)
       (id1: field_id)
-      #nz1 (#k1:parser_kind nz1 _) #t1 (#p1:parser k1 t1)
-      #inv1 #l1 (v1:validate_with_action_t p1 inv1 l1 true) (r1: leaf_reader p1)
+      #nz1
+      (#k1:parser_kind nz1 _)
+      #t1
+      (#p1:parser k1 t1)
+      #inv1
+      #l1
+      (v1:validate_with_action_t p1 inv1 l1 true)
+      (r1: leaf_reader p1)
       (f: t1 -> bool)
-      #nz2 #wk2 (#k2:parser_kind nz2 wk2) (#t2:refine _ f -> Type) (#p2:(x:refine _ f -> parser k2 (t2 x)))
-      #inv2 #l2 #ar2 (v2:(x:refine _ f -> validate_with_action_t (p2 x) inv2 l2 ar2))
+      #nz2
+      #wk2
+      (#k2:parser_kind nz2 wk2)
+      (#t2:refine _ f -> Type)
+      (#p2:(x:refine _ f -> parser k2 (t2 x)))
+      #inv2
+      #l2
+      #ar2
+      (v2:(x:refine _ f -> validate_with_action_t (p2 x) inv2 l2 ar2))
   : Tot (validate_with_action_t
              ((p1 `LPC.parse_filter` f) `(parse_dep_pair #nz1)` p2)
              (conj_inv inv1 inv2)
              (l1 `eloc_union` l2)
              false)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
       let h0 = HST.get () in
       [@inline_let] let _ = LPLC.valid_filter h0 p1 f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
       [@(rename_let ("positionAfter" ^ name1))]
-      let res = v1 input startPosition in
+      let res = v1 ctxt input startPosition in
       let h1 = HST.get() in
       modifies_address_liveness_insensitive_unused_in h0 h1;
       if LPL.is_error res
@@ -501,7 +762,7 @@ let validate_dep_pair_with_refinement'
              let _ = modifies_address_liveness_insensitive_unused_in h0 h15 in
              [@inline_let] let _ = LPLC.valid_facts (p2 field_value) h0 (LPL.slice_of input) (LPL.uint64_to_uint32 res1) in
              [@inline_let] let _ = LPLC.valid_dtuple2 h0 (p1 `LPC.parse_filter` f) p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-             with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value input res1)
+             with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value ctxt input res1)
         end
 
 inline_for_extraction noextract
@@ -524,7 +785,7 @@ let validate_dep_pair_with_refinement_total_zero_parser'
            k1.parser_kind_metadata == Some ParserKindMetadataTotal
          ))
          (ensures (fun _ -> True))
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
       let h0 = HST.get () in
       [@inline_let] let _ = LPLC.valid_filter h0 p1 f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
       [@inline_let] let _ = LPLC.valid_facts p1 h0 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
@@ -551,7 +812,7 @@ let validate_dep_pair_with_refinement_total_zero_parser'
              let _ = modifies_address_liveness_insensitive_unused_in h0 h15 in
              [@inline_let] let _ = LPLC.valid_facts (p2 field_value) h0 (LPL.slice_of input) (LPL.uint64_to_uint32 res1) in
              [@inline_let] let _ = LPLC.valid_dtuple2 h0 (p1 `LPC.parse_filter` f) p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-             with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value input res1)
+             with_drop_if true (conj_inv inv1 inv2) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value ctxt input res1)
         end
 
 #pop-options
@@ -594,9 +855,9 @@ let validate_dep_pair_with_action
              (conj_inv inv1 (conj_inv inv1' inv2))
              (l1 `eloc_union` (l1' `eloc_union` l2))
              false)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
       let h0 = HST.get () in
-      let res = v1 input startPosition in
+      let res = v1 ctxt input startPosition in
       let h1 = HST.get() in
       modifies_address_liveness_insensitive_unused_in h0 h1;
       if LPL.is_error res
@@ -608,7 +869,7 @@ let validate_dep_pair_with_action
         let field_value = r1 input (LPL.uint64_to_uint32 startPosition) in
         let h2 = HST.get() in
         modifies_address_liveness_insensitive_unused_in h1 h2;
-        let action_result = a field_value input startPosition res in
+        let action_result = a field_value ctxt input startPosition res in
         if not action_result
         then with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) validator_error_action_failed //action failed
         else begin
@@ -616,7 +877,7 @@ let validate_dep_pair_with_action
                let h15 = HST.get () in
                let _ = modifies_address_liveness_insensitive_unused_in h0 h15 in
                [@inline_let] let _ = LPLC.valid_dtuple2 h0 p1 p2 (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-               with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value input res)
+               with_drop_if true (conj_inv inv1 (conj_inv inv1' inv2)) input (LPL.uint64_to_uint32 startPosition) (fun (y: U64.t) -> if LPL.is_success y then LPL.uint64_to_uint32 y else LPL.slice_length input) (v2 field_value ctxt input res)
              end
       end
 
@@ -650,11 +911,11 @@ let validate_filter' (name: string) #nz (#k:parser_kind nz _) (#t:_) (#p:parser 
                     #inv #l (v:validate_with_action_t p inv l true)
                     (r:leaf_reader p) (f:t -> bool) (cr:string) (cf:string)
   : Tot (validate_with_action_t #nz #WeakKindStrongPrefix (p `LPC.parse_filter` f) inv l false)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let h = HST.get () in
     [@inline_let] let _ = LPLC.valid_filter h p f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
     [@(rename_let ("positionAfter" ^ name))]
-    let res = v input startPosition in
+    let res = v ctxt input startPosition in
     let h1 = HST.get () in
     if LPL.is_error res
     then with_drop_if true inv input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res
@@ -684,11 +945,11 @@ let validate_filter'_with_action
                     (r:leaf_reader p) (f:t -> bool) (cr:string) (cf:string)
                     (#b:bool) #inva (#la:eloc) (a: t -> action #nz #WeakKindStrongPrefix #(filter_kind k) #_ (p `LPC.parse_filter` f) inva la b bool)
   : Tot (validate_with_action_t #nz #WeakKindStrongPrefix (p `LPC.parse_filter` f) (conj_inv inv inva) (eloc_union l la) false)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let h = HST.get () in
     [@inline_let] let _ = LPLC.valid_filter h p f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
     [@(rename_let ("positionAfter" ^ name))]
-    let res = v input startPosition in
+    let res = v ctxt input startPosition in
     let h1 = HST.get () in
     if LPL.is_error res
     then with_drop_if true (conj_inv inv inva) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res
@@ -704,7 +965,7 @@ let validate_filter'_with_action
       if ok
         then let h15 = HST.get () in
              let _ = modifies_address_liveness_insensitive_unused_in h h15 in
-             if a field_value input startPosition res
+             if a field_value ctxt input startPosition res
              then res
              else with_drop_if true (conj_inv inv inva) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) validator_error_action_failed
       else with_drop_if true (conj_inv inv inva) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) validator_error_constraint_failed
@@ -727,10 +988,10 @@ let validate_with_dep_action
                     (r:leaf_reader p)
                     (#b:bool) #inva (#la:eloc) (a: t -> action p inva la b bool)
   : Tot (validate_with_action_t #nz p (conj_inv inv inva) (eloc_union l la) false)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let h = HST.get () in
     [@(rename_let ("positionAfter" ^ name))]
-    let res = v input startPosition in
+    let res = v ctxt input startPosition in
     let h1 = HST.get () in
     if LPL.is_error res
     then with_drop_if true (conj_inv inv inva) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) res
@@ -740,7 +1001,7 @@ let validate_with_dep_action
       let field_value = r input (LPL.uint64_to_uint32 startPosition) in
       let h15 = HST.get () in
       let _ = modifies_address_liveness_insensitive_unused_in h h15 in
-      if a field_value input startPosition res
+      if a field_value ctxt input startPosition res
       then res
       else with_drop_if true (conj_inv inv inva) input (LPL.uint64_to_uint32 startPosition) (fun _ -> LPL.slice_length input) validator_error_action_failed
     end
@@ -750,12 +1011,12 @@ let validate_weaken #nz #wk (#k:parser_kind nz wk) #t (#p:parser k t)
                     #inv #l #ar (v:validate_with_action_t p inv l ar)
                     #nz' #wk' (k':parser_kind nz' wk'{k' `is_weaker_than` k})
   : Tot (validate_with_action_t (parse_weaken p k') inv l ar)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let open LPLC in
     let h = HST.get () in
     [@inline_let]
     let _ = valid_weaken k' p h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
-    v input startPosition
+    v ctxt input startPosition
 
 /// Parser: weakening kinds
 
@@ -778,20 +1039,20 @@ let validate_weaken_right (#nz:_) #wk (#k:parser_kind nz wk) (#t:_) (#p:parser k
 inline_for_extraction noextract
 let validate_impos ()
   : Tot (validate_with_action_t (parse_impos ()) true_inv eloc_none true)
-  = fun #inputLength _ _ -> validator_error_impossible
+  = fun #inputLength _ _ _ -> validator_error_impossible
 
 inline_for_extraction noextract
 let validate_with_error
   c v
-  = fun #inputLength input startPosition ->
-    let endPositionOrError = v input startPosition in
+  = fun #inputLength ctxt input startPosition ->
+    let endPositionOrError = v ctxt input startPosition in
     LPL.maybe_set_error_code endPositionOrError startPosition c
 
 noextract inline_for_extraction
 let validate_ite
   e p1 v1 p2 v2
-  = fun #inputLength input startPosition ->
-      if e then validate_drop (v1 ()) input startPosition else validate_drop (v2 ()) input startPosition
+  = fun #inputLength ctxt input startPosition ->
+      if e then validate_drop (v1 ()) ctxt input startPosition else validate_drop (v2 ()) ctxt input startPosition
 
 unfold
 let validate_list_inv
@@ -802,6 +1063,7 @@ let validate_list_inv
   (l: loc)
   (g0 g1: Ghost.erased HS.mem)
   (#len: U32.t)
+  (ctxt:app_ctxt)
   (sl: input_buffer_t len)
   (pos0: U32.t)
   (bpos: pointer U64.t)
@@ -813,14 +1075,16 @@ let validate_list_inv
   let pos1 = Seq.index (as_seq h bpos) 0 in
   inv (LPL.slice_of sl).LPL.base h0 /\
   h `extends` h0 /\
-  loc_not_unused_in h0 `loc_includes` l /\
-  l `loc_disjoint` (loc_buffer (LPL.slice_of sl).LPL.base `B.loc_union` R.loc_perm (LPL.perm_of sl)) /\
-  l `loc_disjoint` loc_buffer bpos /\
-  address_liveness_insensitive_locs `loc_includes` l /\
+  loc_not_unused_in h0 `loc_includes` (app_loc ctxt l) /\
+  (app_loc ctxt l) `loc_disjoint` (loc_buffer (LPL.slice_of sl).LPL.base `B.loc_union` R.loc_perm (LPL.perm_of sl)) /\
+  (app_loc ctxt l) `loc_disjoint` loc_buffer bpos /\
+  address_liveness_insensitive_locs `loc_includes` (app_loc ctxt l) /\
   B.loc_buffer bpos `B.loc_disjoint` (B.loc_buffer (LPL.slice_of sl).LPL.base `B.loc_union` R.loc_perm (LPL.perm_of sl)) /\
   U32.v pos0 <= U32.v (LPL.slice_of sl).LPL.len /\
   LPL.live_input_buffer h0 sl /\
   LPL.live_input_buffer h sl /\
+  live h0 ctxt /\
+  live h ctxt /\
   live h1 bpos /\
   modifies loc_none h0 h1 /\ (
   if
@@ -835,7 +1099,9 @@ let validate_list_inv
      LPL.valid (LPLL.parse_list p) h0 (LPL.slice_of sl) (Cast.uint64_to_uint32 pos1)) /\
     (stop == true ==> U64.v pos1 == U32.v (LPL.slice_of sl).LPL.len)
   ) /\
-  modifies (l `loc_union` loc_buffer bpos `loc_union` R.loc_perm_from_to (LPL.perm_of sl) pos0 (if LPL.is_error pos1 then LPL.slice_length sl else LPL.uint64_to_uint32 pos1)) h1 h
+  modifies (app_loc ctxt l `loc_union`
+            loc_buffer bpos `loc_union`
+            R.loc_perm_from_to (LPL.perm_of sl) pos0 (if LPL.is_error pos1 then LPL.slice_length sl else LPL.uint64_to_uint32 pos1)) h1 h
 
 #push-options "--z3rlimit 128"
 
@@ -849,14 +1115,15 @@ let validate_list_body
   (v: validate_with_action_t' p inv l ar)
   (g0 g1: Ghost.erased HS.mem)
   (#len: U32.t)
+  (ctxt:app_ctxt)
   (sl: input_buffer_t len)
   (pos0: LPL.pos_t)
   (bpos: pointer U64.t)
 : HST.Stack bool
-  (requires (fun h -> validate_list_inv p inv l g0 g1 sl (LPL.uint64_to_uint32 pos0) bpos h false))
+  (requires (fun h -> validate_list_inv p inv l g0 g1 ctxt sl (LPL.uint64_to_uint32 pos0) bpos h false))
   (ensures (fun h res h' ->
-    validate_list_inv p inv l g0 g1 sl (LPL.uint64_to_uint32 pos0) bpos h false /\
-    validate_list_inv p inv l g0 g1 sl (LPL.uint64_to_uint32 pos0) bpos h' res
+    validate_list_inv p inv l g0 g1 ctxt sl (LPL.uint64_to_uint32 pos0) bpos h false /\
+    validate_list_inv p inv l g0 g1 ctxt sl (LPL.uint64_to_uint32 pos0) bpos h' res
   ))
 = let h = HST.get () in
   let elementStartPosition = index bpos 0ul in
@@ -868,7 +1135,7 @@ let validate_list_body
     Classical.move_requires (LPLL.valid_list_elim_cons p (Ghost.reveal g0) (LPL.slice_of sl)) (LPL.uint64_to_uint32 elementStartPosition);
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in (Ghost.reveal g0) h1;
-    let elementEndPosition = v sl elementStartPosition in
+    let elementEndPosition = v ctxt sl elementStartPosition in
     upd bpos 0ul elementEndPosition;
     (if LPL.is_success elementEndPosition then R.readable_split h1 (LPL.perm_of sl) (LPL.uint64_to_uint32 elementStartPosition) (LPL.uint64_to_uint32 elementEndPosition) (LPL.slice_length sl));
     LPL.is_error elementEndPosition
@@ -886,23 +1153,29 @@ let validate_list'
   #inv #l #ar
   (v: validate_with_action_t' p inv l ar)
   (#len: U32.t)
+  (ctxt: app_ctxt)
   (sl: input_buffer_t len)
   (pos: U64.t)
 : HST.Stack U64.t
   (requires (fun h ->
     U64.v pos <= U32.v (LPL.slice_of sl).LPL.len /\
     inv (LPL.slice_of sl).LPL.base h /\
-    loc_not_unused_in h `loc_includes` l /\
-    l `loc_disjoint` (loc_buffer (LPL.slice_of sl).LPL.base `B.loc_union` R.loc_perm (LPL.perm_of sl)) /\
-    address_liveness_insensitive_locs `loc_includes` l /\
+    loc_not_unused_in h `loc_includes` app_loc ctxt l /\
+    app_loc ctxt l `loc_disjoint` (loc_buffer (LPL.slice_of sl).LPL.base `B.loc_union` R.loc_perm (LPL.perm_of sl)) /\
+    address_liveness_insensitive_locs `loc_includes` app_loc ctxt l /\
     R.readable h (LPL.perm_of sl) (LPL.uint64_to_uint32 pos) (LPL.slice_of sl).LPL.len /\
-    LPL.live_slice h (LPL.slice_of sl)
+    LPL.live_slice h (LPL.slice_of sl) /\
+    B.live h ctxt
   ))
   (ensures (fun h res h' ->
     inv (LPL.slice_of sl).LPL.base h' /\
     (LPL.is_success res ==> (LPL.valid (LPLL.parse_list p) h (LPL.slice_of sl) (LPL.uint64_to_uint32 pos) /\ U64.v res == U32.v (LPL.slice_of sl).LPL.len)) /\
-    modifies (l `B.loc_union` R.loc_perm_from_to (LPL.perm_of sl) (LPL.uint64_to_uint32 pos) (if LPL.is_success res then LPL.uint64_to_uint32 res else LPL.slice_length sl)) h h' /\
-    LPL.live_input_buffer h' sl
+    modifies (app_loc ctxt l `B.loc_union`
+              R.loc_perm_from_to (LPL.perm_of sl) (LPL.uint64_to_uint32 pos)
+                                 (if LPL.is_success res then LPL.uint64_to_uint32 res else LPL.slice_length sl))
+                                 h h' /\
+    LPL.live_input_buffer h' sl /\
+    B.live h' ctxt
   ))
 = let h0 = HST.get () in
   let g0 = Ghost.hide h0 in
@@ -912,7 +1185,7 @@ let validate_list'
   let currentPosition = alloca pos 1ul in
   let h1 = HST.get () in
   let g1 = Ghost.hide h1 in
-  C.Loops.do_while (validate_list_inv p inv l g0 g1 sl (LPL.uint64_to_uint32 pos) currentPosition) (fun _ -> validate_list_body v g0 g1 sl pos currentPosition);
+  C.Loops.do_while (validate_list_inv p inv l g0 g1 ctxt sl (LPL.uint64_to_uint32 pos) currentPosition) (fun _ -> validate_list_body v g0 g1 ctxt sl pos currentPosition);
   LPLL.valid_list_intro_nil p h0 (LPL.slice_of sl) (LPL.slice_of sl).LPL.len;
   let finalPositionOrError = index currentPosition 0ul in
   let h2 = HST.get () in
@@ -931,10 +1204,10 @@ let validate_list
   #inv #l #ar
   (v: validate_with_action_t' p inv l ar)
 : Tot (validate_with_action_t' (LowParse.Spec.List.parse_list p) inv l false)
-= fun #len input pos ->
+= fun #len ctxt input pos ->
   let h = HST.get () in
   Classical.move_requires (LPL.valid_pos_consumes_all (LowParse.Spec.List.parse_list p) h (LPL.slice_of input)) (LPL.uint64_to_uint32 pos);
-  with_drop_if true inv input (LPL.uint64_to_uint32 pos) (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input) (validate_list' v input pos)
+  with_drop_if true inv input (LPL.uint64_to_uint32 pos) (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input) (validate_list' v ctxt input pos)
 
 #push-options "--z3rlimit 32"
 #restart-solver
@@ -948,7 +1221,7 @@ let validate_fldata_consumes_all
   #inv #l #ar
   (v: validate_with_action_t' p inv l ar  { k.LP.parser_kind_subkind == Some LP.ParserConsumesAll })
 : Tot (validate_with_action_t' (LowParse.Spec.FLData.parse_fldata p (U32.v n)) inv l false)
-= fun #inputLength input pos ->
+= fun #inputLength ctxt input pos ->
   let h = HST.get () in
   LPL.valid_facts (LowParse.Spec.FLData.parse_fldata p (U32.v n)) h (LPL.slice_of input) (LPL.uint64_to_uint32 pos);
   LPLF.parse_fldata_consumes_all_correct p (U32.v n) (LPL.bytes_of_slice_from h (LPL.slice_of input) (LPL.uint64_to_uint32 pos));
@@ -958,7 +1231,7 @@ let validate_fldata_consumes_all
     let truncatedInput = LPL.truncate_input_buffer input (LPL.uint64_to_uint32 pos `U32.add` n) in
     LPL.valid_facts p h (LPL.slice_of truncatedInput) (LPL.uint64_to_uint32 pos);
     R.readable_split h (LPL.perm_of input) (LPL.uint64_to_uint32 pos) (LPL.slice_length truncatedInput) (LPL.slice_length input);
-    with_drop_if true inv input (LPL.uint64_to_uint32 pos) (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input) (v truncatedInput pos)
+    with_drop_if true inv input (LPL.uint64_to_uint32 pos) (fun (x: U64.t) -> if LPL.is_success x then LPL.uint64_to_uint32 x else LPL.slice_length input) (v ctxt truncatedInput pos)
   end
 #pop-options
 
@@ -996,7 +1269,7 @@ let validate_nlist_constant_size_without_actions
     k.parser_kind_metadata = Some ParserKindMetadataTotal &&
     k.parser_kind_low < 4294967296
   then
-    (fun #inputLength input startPosition ->
+    (fun #inputLength ctxt input startPosition ->
       let h = HST.get () in
       assert (forall h' . {:pattern (B.modifies B.loc_none h h')} (B.modifies B.loc_none h h' /\ inv (LPL.slice_of input).LPL.base h) ==> h' `extends` h);
       assert (forall h' . {:pattern (B.modifies B.loc_none h h')} (B.modifies B.loc_none h h' /\ inv (LPL.slice_of input).LPL.base h) ==> inv (LPL.slice_of input).LPL.base h');
@@ -1012,7 +1285,7 @@ noextract inline_for_extraction
 let validate_t_at_most' (n:U32.t) #nz #wk (#k:parser_kind nz wk) (#t:_) (#p:parser k t)
                        (#inv:_) (#l:_) (#ar:_) (v:validate_with_action_t p inv l ar)
   : Tot (validate_with_action_t (parse_t_at_most n p) inv l ar)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let h = HST.get () in
     let _ =
       LPL.valid_weaken kind_t_at_most (LowParse.Spec.FLData.parse_fldata (LPC.nondep_then p LowParse.Spec.Bytes.parse_all_bytes) (U32.v n)) h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition);
@@ -1029,7 +1302,7 @@ let validate_t_at_most' (n:U32.t) #nz #wk (#k:parser_kind nz wk) (#t:_) (#p:pars
         LPLC.valid_nondep_then h p LowParse.Spec.Bytes.parse_all_bytes (LPL.slice_of input') (LPL.uint64_to_uint32 startPosition)
       in
       // FIXME: I'd need a name here
-      let positionAfterContents = v input' startPosition in
+      let positionAfterContents = v ctxt input' startPosition in
       let h1 = HST.get () in
       let _ = modifies_address_liveness_insensitive_unused_in h h1 in
       if LPL.is_error positionAfterContents
@@ -1052,7 +1325,7 @@ noextract inline_for_extraction
 let validate_t_exact' (n:U32.t) (#nz:bool) #wk (#k:parser_kind nz wk) (#t:_) (#p:parser k t)
                        (#inv:_) (#l:_) (#ar:_) (v:validate_with_action_t p inv l ar)
   : Tot (validate_with_action_t (parse_t_exact n p) inv l ar)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     let h = HST.get () in
     let _ =
       LPL.valid_weaken kind_t_at_most (LowParse.Spec.FLData.parse_fldata p (U32.v n)) h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition);
@@ -1068,7 +1341,7 @@ let validate_t_exact' (n:U32.t) (#nz:bool) #wk (#k:parser_kind nz wk) (#t:_) (#p
         LPL.valid_facts p h (LPL.slice_of input') (LPL.uint64_to_uint32 startPosition)
       in
       // FIXME: I'd need a name here
-      let positionAfterContents = v input' startPosition in
+      let positionAfterContents = v ctxt input' startPosition in
       let h1 = HST.get () in
       let _ = modifies_address_liveness_insensitive_unused_in h h1 in
       if LPL.is_error positionAfterContents
@@ -1089,9 +1362,9 @@ let validate_with_comment (c:string)
                           #nz #wk (#k:parser_kind nz wk) #t (#p:parser k t)
                           #inv #l #ar (v:validate_with_action_t p inv l ar)
   : validate_with_action_t p inv l ar
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     LowParse.Low.Base.comment c;
-    v input startPosition
+    v ctxt input startPosition
 
 inline_for_extraction noextract
 let validate_weaken_inv_loc #nz #wk (#k:parser_kind nz wk) #t (#p:parser k t)
@@ -1127,7 +1400,7 @@ let read_filter #nz
 inline_for_extraction noextract
 let validate____UINT8
   : validator parse____UINT8
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a UINT8, i.e., 1 byte";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT8 1uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1139,7 +1412,7 @@ let read____UINT8
 inline_for_extraction noextract
 let validate____UINT16BE
   : validator parse____UINT16BE
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a UINT16BE, i.e., 2 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT16BE 2uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1151,7 +1424,7 @@ let read____UINT16BE
 inline_for_extraction noextract
 let validate____UINT32BE
   : validator parse____UINT32BE
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a ULONG, i.e., 4 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT32BE 4uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1163,7 +1436,7 @@ let read____UINT32BE
 inline_for_extraction noextract
 let validate____UINT64BE
   : validator parse____UINT64BE
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a ULONG64BE, i.e., 8 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT64BE 8uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1175,7 +1448,7 @@ let read____UINT64BE
 inline_for_extraction noextract
 let validate____UINT16
   : validator parse____UINT16
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a UINT16, i.e., 2 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT16 2uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1188,7 +1461,7 @@ let read____UINT16
 inline_for_extraction noextract
 let validate____UINT32
   : validator parse____UINT32
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a ULONG, i.e., 4 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT32 4uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1200,7 +1473,7 @@ let read____UINT32
 inline_for_extraction noextract
 let validate____UINT64
   : validator parse____UINT64
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
     LowStar.Comment.comment "Checking that we have enough space for a ULONG64, i.e., 8 bytes";
     LowParse.Low.Base.validate_total_constant_size_no_read parse____UINT64 8uL () (Ghost.elift1 LPL.slice_of (Ghost.hide input)) (LPL.slice_length input) startPosition
 
@@ -1222,7 +1495,7 @@ let read_unit
 inline_for_extraction noextract
 let validate_unit_refinement' (f:unit -> bool) (cf:string)
   : Tot (validate_with_action_t #false #WeakKindStrongPrefix (parse_unit `LPC.parse_filter` f) true_inv eloc_none true)
-  = fun #inputLength input startPosition ->
+  = fun #inputLength ctxt input startPosition ->
       let h = HST.get () in
       [@inline_let] let _ = LPLC.valid_facts (parse_unit) h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
       [@inline_let] let _ = LPLC.valid_filter h parse_unit f (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition) in
@@ -1250,6 +1523,7 @@ let validate_list_up_to_inv
   (terminator: t)
   (prf: LUT.consumes_if_not_cond (cond_string_up_to terminator) p)
   (#len: U32.t)
+  (ctxt: app_ctxt)
   (sl: input_buffer_t len)
   (pos0: U32.t)
   (h0: HS.mem)
@@ -1263,13 +1537,20 @@ let validate_list_up_to_inv
   B.live h0 bpos /\
   live_input_buffer h0 sl /\
   live_input_buffer h sl /\
-  B.loc_disjoint (B.loc_buffer (slice_of sl).LPL.base `B.loc_union` R.loc_perm (perm_of sl)) (B.loc_buffer bpos) /\
+  B.loc_disjoint (B.loc_buffer (slice_of sl).LPL.base `B.loc_union` R.loc_perm (perm_of sl)) 
+                 (B.loc_buffer bpos `B.loc_union` (app_loc ctxt loc_none)) /\
+  B.loc_disjoint (B.loc_buffer bpos) (app_loc ctxt loc_none) /\
+  B.live h0 ctxt /\
+  B.live h ctxt /\  
+  address_liveness_insensitive_locs `loc_includes` (app_loc ctxt loc_none) /\
   U32.v pos0 <= U64.v pos /\
   begin if is_success pos
   then
     let pos = uint64_to_uint32 pos in
     U32.v pos <= U32.v (slice_of sl).len /\
-    B.modifies (B.loc_buffer bpos `B.loc_union` R.loc_perm_from_to (perm_of sl) pos0 pos) h0 h /\
+    B.modifies (app_loc ctxt loc_none `B.loc_union`
+                B.loc_buffer bpos `B.loc_union`
+                R.loc_perm_from_to (perm_of sl) pos0 pos) h0 h /\
     R.unreadable h (perm_of sl) pos0 pos /\
     R.readable h (perm_of sl) pos (slice_of sl).len /\
     begin if stop
@@ -1283,7 +1564,9 @@ let validate_list_up_to_inv
     end
   else
     U32.v pos0 <= U32.v (slice_of sl).len /\
-    B.modifies (B.loc_buffer bpos `B.loc_union` R.loc_perm_from_to (perm_of sl) pos0 (slice_of sl).len) h0 h /\
+    B.modifies (app_loc ctxt loc_none `B.loc_union`
+                B.loc_buffer bpos `B.loc_union`
+                R.loc_perm_from_to (perm_of sl) pos0 (slice_of sl).len) h0 h /\
     R.unreadable h (perm_of sl) pos0 (slice_of sl).len /\
     stop == true /\
     True // (~ (valid q h0 (slice_of sl) pos0)) // we lost completeness because of actions
@@ -1301,17 +1584,18 @@ let validate_list_up_to_body
   (v: validator p)
   (r: leaf_reader p)
   (#len: U32.t)
+  (ctxt:app_ctxt)
   (sl: input_buffer_t len)
   (pos0: U32.t)
   (h0: HS.mem)
   (bpos: B.pointer U64.t)
 : HST.Stack bool
   (requires (fun h ->
-    validate_list_up_to_inv p terminator prf sl pos0 h0 bpos h false
+    validate_list_up_to_inv p terminator prf ctxt sl pos0 h0 bpos h false
   ))
   (ensures (fun h stop h' ->
-    validate_list_up_to_inv p terminator prf sl pos0 h0 bpos h false /\
-    validate_list_up_to_inv p terminator prf sl pos0 h0 bpos h' stop
+    validate_list_up_to_inv p terminator prf ctxt sl pos0 h0 bpos h false /\
+    validate_list_up_to_inv p terminator prf ctxt sl pos0 h0 bpos h' stop
   ))
 =
   let open LPL in
@@ -1321,7 +1605,7 @@ let validate_list_up_to_body
   valid_facts (parse_list_up_to (cond_string_up_to terminator) p prf) h0 (slice_of sl) (uint64_to_uint32 pos);
   parse_list_up_to_eq (cond_string_up_to terminator) p prf (bytes_of_slice_from h0 (slice_of sl) (uint64_to_uint32 pos));
   valid_facts p h0 (slice_of sl) (uint64_to_uint32 pos);
-  let pos1 = v sl pos in
+  let pos1 = v ctxt sl pos in
   B.upd bpos 0ul pos1;
   if is_error pos1
   then begin
@@ -1351,14 +1635,14 @@ let validate_list_up_to
   (prf: LUT.consumes_if_not_cond (cond_string_up_to terminator) p)
 : Tot (validate_with_action_t #true #WeakKindStrongPrefix (LUT.parse_list_up_to (cond_string_up_to terminator) p prf) true_inv eloc_none false)
 =
-  fun sl pos ->
+  fun #input_length ctxt sl pos ->
   HST.push_frame ();
   let bpos = B.alloca pos 1ul in
   let h2 = HST.get () in
   R.unreadable_empty h2 (LPL.perm_of sl) (LPL.uint64_to_uint32 pos);
   C.Loops.do_while
-    (validate_list_up_to_inv p terminator prf sl (LPL.uint64_to_uint32 pos) h2 bpos)
-    (fun _ -> validate_list_up_to_body terminator prf v r sl (LPL.uint64_to_uint32 pos) h2 bpos)
+    (validate_list_up_to_inv p terminator prf ctxt sl (LPL.uint64_to_uint32 pos) h2 bpos)
+    (fun _ -> validate_list_up_to_body terminator prf v r ctxt sl (LPL.uint64_to_uint32 pos) h2 bpos)
     ;
   let res = B.index bpos 0ul in
   HST.pop_frame ();
@@ -1376,7 +1660,7 @@ let validate_string
 
 inline_for_extraction noextract
 let validate_all_bytes2 : validate_with_action_t parse_all_bytes true_inv eloc_none true =
-  fun #inputLength input startPosition ->
+  fun #inputLength ctxt input startPosition ->
     let h = HST.get () in
     LPL.valid_facts LowParse.Spec.Bytes.parse_all_bytes h (LPL.slice_of input) (LPL.uint64_to_uint32 startPosition);
     FStar.Int.Cast.uint32_to_uint64 inputLength
@@ -1394,7 +1678,7 @@ let action_return
       #nz #wk (#k:parser_kind nz wk) (#t:Type) (#p:parser k t)
       (#a:Type) (x:a)
   : action p true_inv eloc_none false a
-  = fun input startPosition endPosition -> x
+  = fun _ input startPosition endPosition -> x
 
 noextract
 inline_for_extraction
@@ -1406,13 +1690,13 @@ let action_bind
       (#invg:slice_inv) (#lg:eloc) #bg
       (#b:Type) (g: (a -> action p invg lg bg b))
   : Tot (action p (conj_inv invf invg) (eloc_union lf lg) (bf || bg) b)
-  = fun input startPosition endPosition ->
+  = fun ctxt input startPosition endPosition ->
     let h0 = HST.get () in
     [@(rename_let ("" ^ name))]
-    let x = f input startPosition endPosition in
+    let x = f ctxt input startPosition endPosition in
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in h0 h1;
-    g x input startPosition endPosition
+    g x ctxt input startPosition endPosition
 
 noextract
 inline_for_extraction
@@ -1423,12 +1707,12 @@ let action_seq
       (#invg:slice_inv) (#lg:eloc) #bg
       (#b:Type) (g: action p invg lg bg b)
   : Tot (action p (conj_inv invf invg) (eloc_union lf lg) (bf || bg) b)
-  = fun input startPosition endPosition ->
+  = fun ctxt input startPosition endPosition ->
     let h0 = HST.get () in
-    let _ = f input startPosition endPosition in
+    let _ = f ctxt input startPosition endPosition in
     let h1 = HST.get () in
     modifies_address_liveness_insensitive_unused_in h0 h1;
-    g input startPosition endPosition
+    g ctxt input startPosition endPosition
 
 noextract
 inline_for_extraction
@@ -1440,24 +1724,24 @@ let action_ite
       (#invg:slice_inv) (#lg:eloc) #bg
       (else_: squash (not guard) -> action p invg lg bg a)
   : action p (conj_inv invf invg) (eloc_union lf lg) (bf || bg) a
-  = fun input startPosition endPosition ->
+  = fun ctxt input startPosition endPosition ->
       if guard 
-      then then_ () input startPosition endPosition 
-      else else_ () input startPosition endPosition
+      then then_ () ctxt input startPosition endPosition 
+      else else_ () ctxt input startPosition endPosition
 
 noextract
 inline_for_extraction
 let action_abort
       #nz #wk (#k:parser_kind nz wk) (#t:Type) (#p:parser k t)
   : action p true_inv eloc_none false bool
-  = fun input startPosition endPosition -> false
+  = fun _ input startPosition endPosition -> false
 
 noextract
 inline_for_extraction
 let action_field_pos
       #nz #wk (#k:parser_kind nz wk) (#t:Type) (#p:parser k t) (u:unit)
    : action p true_inv eloc_none false U32.t
-   = fun _ startPosition _ -> LPL.uint64_to_uint32 startPosition
+   = fun _ _ startPosition _ -> LPL.uint64_to_uint32 startPosition
 
 
 noextract
@@ -1465,7 +1749,7 @@ inline_for_extraction
 let action_field_ptr
       #nz #wk (#k:parser_kind nz wk) (#t:Type) (#p:parser k t) (u:unit)
    : action p true_inv eloc_none true LPL.puint8
-   = fun input startPosition _ ->
+   = fun _ input startPosition _ ->
        let open LowParse.Slice in
        LPL.offset input (LPL.uint64_to_uint32 startPosition)
 
@@ -1475,7 +1759,7 @@ let action_deref
       #nz #wk (#k:parser_kind nz wk) (#t:Type) (#p:parser k t)
       (#a:_) (x:B.pointer a)
    : action p (ptr_inv x) loc_none false a
-   = fun _ _ _ -> !*x
+   = fun _ _ _ _ -> !*x
 
 noextract
 inline_for_extraction
@@ -1483,7 +1767,7 @@ let action_assignment
       #nz #wk (#k:parser_kind nz wk) (#t:Type) (#p:parser k t)
       (#a:_) (x:B.pointer a) (v:a)
    : action p (ptr_inv x) (ptr_loc x) false unit
-   = fun _ _ _ -> x *= v
+   = fun _ _ _ _ -> x *= v
 
 (* FIXME: This is now unsound.
 noextract

--- a/src/3d/prelude/Actions.fsti
+++ b/src/3d/prelude/Actions.fsti
@@ -134,6 +134,23 @@ val validate_with_success_action
       (a:action p1 inv2 l2 b bool)
   : validate_with_action_t p1 (conj_inv inv1 inv2) (l1 `eloc_union` l2) false
 
+val error_handler : Type0
+
+inline_for_extraction noextract
+val validate_with_error_handler (typename: string)
+                                (fieldname: string)
+                                (#nz: _)
+                                (#wk: _)
+                                (#k1:parser_kind nz wk)
+                                (#t1: _)
+                                (#p1:parser k1 t1)
+                                (#inv1:_)
+                                (#l1:eloc)
+                                (#ar:_)
+                                (v1:validate_with_action_t p1 inv1 l1 ar)
+                                (err:error_handler)
+  : validate_with_action_t p1 inv1 l1 ar
+
 inline_for_extraction noextract
 val validate_with_error_action
       (name: string)

--- a/src/3d/prelude/Actions.fsti
+++ b/src/3d/prelude/Actions.fsti
@@ -67,9 +67,6 @@ val action
     : Type0
 
 inline_for_extraction
-val error_handler : Type0
-
-inline_for_extraction
 val validate_with_action_t
       (#nz:bool)
       (#wk: _)

--- a/src/3d/prelude/Actions.fsti
+++ b/src/3d/prelude/Actions.fsti
@@ -194,7 +194,6 @@ inline_for_extraction noextract
 val validate_dep_pair_with_refinement_and_action
       (p1_is_constant_size_without_actions: bool)
       (name1: string)
-      (id1: field_id)
       (#nz1:_) (#k1:parser_kind nz1 WeakKindStrongPrefix) (#t1:_) (#p1:parser k1 t1)
       (#inv1:_) (#l1:_) (v1:validate_with_action_t p1 inv1 l1 true) (r1: leaf_reader p1)
       (f: t1 -> bool)
@@ -223,7 +222,6 @@ inline_for_extraction noextract
 val validate_dep_pair_with_refinement
       (p1_is_constant_size_without_actions: bool)
       (name1: string)
-      (id1: field_id)
       (#nz1:_) (#k1:parser_kind nz1 WeakKindStrongPrefix) (#t1:_) (#p1:parser k1 t1)
       (#inv1:_) (#l1:_) (v1:validate_with_action_t p1 inv1 l1 true) (r1: leaf_reader p1)
       (f: t1 -> bool)
@@ -271,11 +269,6 @@ val validate_weaken_right (#nz:_) (#wk: _) (#k:parser_kind nz wk) (#t:_) (#p:par
 inline_for_extraction noextract
 val validate_impos (_:unit)
   : validate_with_action_t (parse_impos ()) true_inv eloc_none true
-
-inline_for_extraction noextract
-val validate_with_error (#nz:_) (#wk: _) (#k:parser_kind nz wk) (#t:_) (#p:parser k t)
-                        (#inv:_) (#l:_) (#allow_reading:bool) (c:field_id) (v:validate_with_action_t p inv l allow_reading)
-  : validate_with_action_t p inv l allow_reading
 
 noextract inline_for_extraction
 val validate_ite (#nz:_) (#wk: _) (#k:parser_kind nz wk) (#a:Type) (#b:Type)

--- a/src/3d/prelude/Actions.fsti
+++ b/src/3d/prelude/Actions.fsti
@@ -66,6 +66,7 @@ val action
       (a:Type)
     : Type0
 
+inline_for_extraction
 val error_handler : Type0
 
 inline_for_extraction

--- a/src/3d/prelude/Actions.fsti
+++ b/src/3d/prelude/Actions.fsti
@@ -66,6 +66,8 @@ val action
       (a:Type)
     : Type0
 
+val error_handler : Type0
+
 inline_for_extraction
 val validate_with_action_t
       (#nz:bool)
@@ -134,7 +136,6 @@ val validate_with_success_action
       (a:action p1 inv2 l2 b bool)
   : validate_with_action_t p1 (conj_inv inv1 inv2) (l1 `eloc_union` l2) false
 
-val error_handler : Type0
 
 inline_for_extraction noextract
 val validate_with_error_handler (typename: string)
@@ -148,7 +149,6 @@ val validate_with_error_handler (typename: string)
                                 (#l1:eloc)
                                 (#ar:_)
                                 (v1:validate_with_action_t p1 inv1 l1 ar)
-                                (err:error_handler)
   : validate_with_action_t p1 inv1 l1 ar
 
 inline_for_extraction noextract

--- a/src/3d/prelude/Makefile
+++ b/src/3d/prelude/Makefile
@@ -5,7 +5,7 @@ KREMLIN_HOME?=$(realpath ../../../../kremlin)
 OTHERFLAGS?=
 EVERPARSE_HOME=../../..
 
-FSTAR_OPTIONS=$(addprefix --include , $(EVERPARSE_HOME)/src/lowparse $(KREMLIN_HOME)/kremlib $(KREMLIN_HOME)/kremlib/obj) --z3rlimit_factor 8 --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=100'
+FSTAR_OPTIONS=$(addprefix --include , $(EVERPARSE_HOME)/src/lowparse $(KREMLIN_HOME)/kremlib $(KREMLIN_HOME)/kremlib/obj) --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=10'
 FSTAR=$(FSTAR_HOME)/bin/fstar.exe $(FSTAR_OPTIONS) $(OTHERFLAGS) --cmi
 
 ROOT=$(wildcard *.fst)

--- a/src/3d/tests/ErrorHandling.3d
+++ b/src/3d/tests/ErrorHandling.3d
@@ -1,0 +1,17 @@
+typedef struct _T
+{
+   UINT32 x
+   {
+       x >= 17
+   };
+   UINT32 y
+   {
+       y >= x
+   };
+} T;
+
+entrypoint
+typedef struct _S {
+  T t1;
+  T t2;
+} S;


### PR DESCRIPTION
# The problem

Consider the following example

```
typedef struct _T
{
   UINT32 x
   {
       x >= 17
   };
   UINT32 y
   {
       y >= x
   };
} T;
```

When defining a validator for this type, we generate:

1. field codes: Every field in every type of a 3d file has a unique
   code, e.g.,  `T.x = 1` and `T.x = 2`.

2. Error codes: EverParse has a fixed set of error codes,
   corresponding to its different failure modes, including codes for:

```
    1, "generic error";
    2, "not enough data";
    3, "impossible";
    4, "list size not multiple of element size";
    5, "action failed";
    6, "constraint failed";
    7, "unexpected padding";
    8+, "unspecified";
```

If we fail when validating, say, `T.x`, we encode in the return value
from EverParse three things:

 1. The position in the input buffer where the failure occurred
 2. The code of the field on which the error occurred.
 3. The error code

At the top-level, we decode this information and pass it to a
top-level user-provided error handler, whose signature is

```
void
EverParseError(char *structName,
               char *fieldName,
               char *errorReason);
```

Some limitation of this scheme is that it is not context sensitive

We call back a single error handler at the top-level. It is hard to
fully reconstruct the failure from this error. For example, consider
this:

```
typedef struct _S {
  T t1;
  T t2;
} S;
```

A failure in `S.t1.x` cannot be distinguished from `S.t2.x`.

Some additional drawbacks:

 * The position in the input buffer at which the error occurred is not
   passed to the callback.

# The solution: on-error callbacks

Rather than encoding the error and field in the result code and
propagating it to the top-level callback, we will instead allow the
user to specify an error callback to be invoked repeatedly at every
level of the validation stack.

There are a few elements to the solution:

1. The type actions and validators are revised to take an additional `app_ctxt` parameter, representing some application chosen context type (e.g., some void* that the context passes in). The revised type of actions is:

```
let action p inv l on_success a
  = ctxt:app_ctxt -> //<---new
    #len: U32.t ->
    sl: input_buffer_t len ->
    pos:LPL.pos_t ->
    res:U64.t ->
    Stack a
      (requires fun h ->
        let open LPL in
        LPL.live_input_buffer h sl /\
        B.live h ctxt  /\ <-- context is initially live
        inv (LPL.slice_of sl).LPL.base h /\
        loc_not_unused_in h `loc_includes` (app_loc ctxt l) /\
        address_liveness_insensitive_locs `loc_includes` (app_loc ctxt l) /\ //<--- it cannot be freed by us
        (app_loc ctxt l) `loc_disjoint`  //<-- it's disjoint from the validation buffers
        (loc_buffer (LPL.slice_of sl).base `loc_union` R.loc_perm (LPL.perm_of sl)) /\
        (U64.v res <= U64.v validator_max_length ==>
           valid_pos p h (LPL.slice_of sl) (uint64_to_uint32 pos) (uint64_to_uint32 res)) /\
        (on_success ==> U64.v res <= U64.v validator_max_length))
      (ensures fun h0 _ h1 ->
        modifies (app_loc ctxt l) h0 h1 /\ //we may modify it 
        B.live h1 ctxt /\         //it remains live
        h1 `extends` h0 /\
        inv (LPL.slice_of sl).LPL.base h1)
```

2. Every 3D validator is now additionally parameterized by an error handler of type:

```
let error_handler = typename:string ->
                    fieldname:string ->
                    error_reason:string ->
                    action (parse_impos()) true_inv eloc_none false unit
```
and a ``app_ctxt``

3. Every validator is wrapped with a call to validate_with_error_handler, that calls the user-provided call back in case a validator fails, passing in the typename, fieldname, error reason, context, position, etc.

4. At the top-level, the user can instantiate the context parameter as
   they wish and link it with their implementation of the extern. 

By instantiating error callback extern appropriately, the user can
effectively reconstruct the entire validation call stack when an error
occurs, or a stack up to a bound.

For example, the caller can

1. Stack allocate a context up to some bound

```
typedef struct _ErrorFrame
{
    uint32 position;
    char *typename;
    char *fieldname;
    error_reason_enum_t code;
} ErrorFrame;

typedef struct _Frames {
    UINT8 ctr;
    UINT8 nframes;
    ErrorFrame frames[0];
} Frames;

void OnErrorCallback (Frames *frames,
                      uint32 position,
                      const char *fieldname,
                      const char *typename,
                      error_reason_enum_t code)
{
   if (frames->ctr < frames->nframes)
   {
       frames->frames[frames->ctr] =
        ((ErrorFrame)
          {
             .position = position;
             .typename = typename;
             ...
          });
       frames->ctr++;
   }
}
```



And to call into a validator instantiating the context like so:

```
{
   ErrorFrame frames[10];
   Frames ctxt =
    {
       ctr = 0;
       nframes = 10;
       .frames = frames;
    };

   validateT(&ctxt, ...)
}

```

# Top-level wrapper

To maintain backwards compat, and to provide a default error handler, the top-level wrapper provides something like this, which only tracks a single error frame and can report the error using the same user-provided error reporting function as before.


```
void ErrorHandlingEverParseError(char *StructName, char *FieldName, char *Reason);

typedef struct _ErrorFrame
{
	BOOLEAN filled;
	uint32_t start_pos;
	uint32_t end_pos;
	char *typename;
	char *fieldname;
	char *reason;
} ErrorFrame;

void DefaultErrorHandler(
	EverParseString typename,
	EverParseString fieldname,
	EverParseString reason,
	uint8_t *context,
	uint32_t len,
	uint8_t *base,
	uint64_t start_pos,
	uint64_t end_pos)
{
	ErrorFrame *frame = (ErrorFrame*)context;
	if (!frame->filled)
	{
		frame->filled = TRUE;
		frame->start_pos = start_pos;
		frame->end_pos = end_pos;
		frame->typename = typename;
		frame->fieldname = fieldname;
		frame->reason = reason;
	}
}

BOOLEAN ErrorHandlingCheckS(uint8_t *base, uint32_t len) {
	ErrorFrame frame;
	frame.filled = FALSE;
	uint64_t result = ErrorHandlingValidateS((uint8_t*)&frame,  &DefaultErrorHandler, len, base, 0);
	if (EverParseResultIsError(result))
	{
		if (frame.filled)
		{
			ErrorHandlingEverParseError(frame.typename, frame.fieldname, frame.reason);
		}
		return FALSE;
	}
	return TRUE;
}
```



# Some final remarks

One might be concerned about performance.

In case of ill-formed packets, for deep packet formats, we may call
the callback many times as we pop the validation stack.

This may impose some overhead, but the cost of it, only on the error
path, should be bounded by the static nesting depth of the format
specification.

Besides, even in the case of denial-of-service attacks from attackers
sending many malformed packets, the cost of rejecting many packets
even with elaborated error reporting will be usually far negligible
compared to the total processing cost (post-validation and
post-actions) of one valid packet.

At the very worst, in case this is a concern, we could even limit such
advanced reporting to debug builds only.
