### PR TITLE
Support for extern types and actions in 3d

### DIFF
--- a/src/3d/Binding.fst
+++ b/src/3d/Binding.fst
@@ -72,6 +72,8 @@ noeq
 type global_env = {
   ge_h: global_hash_t;
   ge_out_t: H.t ident' decl;  //a table for output types declarations
+  ge_extern_t: H.t ident' decl;  //a table for extern type declarations
+  ge_extern_fn: H.t ident' decl;  //a table for extern function declarations
 }
 
 /// Maps locally bound names, i.e., a field name to its type
@@ -107,6 +109,8 @@ let params_of_decl (d:decl) : list param =
   | Record _ params _ _
   | CaseType _ params _ -> params
   | OutputType _ -> []
+  | ExternType _ -> []
+  | ExternFn _ _ ps -> ps
 
 let check_shadow (e:H.t ident' 'a) (i:ident) (r:range) =
   match H.try_find e i.v with
@@ -192,15 +196,18 @@ let remove_local (e:env) (i:ident) : ML unit =
     H.remove e.locals j
   | _ -> ()
 
-let resolve_record_case_outputtype_name (env:env) (i:ident) =
+let resolve_record_case_output_extern_type_name (env:env) (i:ident) =
   match H.try_find (global_env_of_env env).ge_out_t i.v with
   | Some ({d_decl={v=OutputType ({out_typ_names=names})}}) -> names.typedef_name
   | _ ->
-    match lookup env i with
-    | Inr ({d_decl={v=Record names _ _ _}}, _)
-    | Inr ({d_decl={v=CaseType names _ _}}, _) ->
-      names.typedef_name
-    | _ -> i
+    (match H.try_find (global_env_of_env env).ge_extern_t i.v with
+     | Some ({d_decl={v=ExternType td_names}}) -> td_names.typedef_name
+     | _ ->
+       (match lookup env i with
+        | Inr ({d_decl={v=Record names _ _ _}}, _)
+        | Inr ({d_decl={v=CaseType names _ _}}, _) ->
+          names.typedef_name
+        | _ -> i))
 
 let lookup_expr_name (e:env) (i:ident) : ML typ =
   match lookup e i with
@@ -236,7 +243,7 @@ let lookup_enum_cases (e:env) (i:ident)
 
 let is_enum (e:env) (t:typ) =
   match t.v with
-  | Type_app i false [] ->
+  | Type_app i KindSpec [] ->
     Some? (try_lookup_enum_cases e i)
   | _ -> false
 
@@ -449,12 +456,33 @@ let try_retype_arith_exprs (env:env) e1 e2 rng : ML (option (expr & expr & typ))
 
 (*
  * Add output type to the environment
+ *
+ * TODO: check_shadow
  *)
 let add_output_type (ge:global_env) (i:ident) (d:decl{OutputType? d.d_decl.v}) : ML unit =
   let insert i = H.insert ge.ge_out_t i d in
   insert i.v;
   let td_abbrev = (OutputType?._0 d.d_decl.v).out_typ_names.typedef_abbrev in
   insert td_abbrev.v
+
+(*
+ * Add extern type to the environment
+ *
+ * TODO: check shadow
+ *)
+let add_extern_type (ge:global_env) (i:ident) (d:decl{ExternType? d.d_decl.v}) : ML unit =
+  let insert i = H.insert ge.ge_extern_t i d in
+  insert i.v;
+  let td_abbrev = (ExternType?._0 d.d_decl.v).typedef_abbrev in
+  insert td_abbrev.v
+
+(*
+ * Add extern function to the environment
+ *
+ * TODO: check shadow
+ *)
+let add_extern_fn (ge:global_env) (i:ident) (d:decl{ExternFn? d.d_decl.v}) : ML unit =
+  H.insert ge.ge_extern_fn i.v d
 
 let lookup_output_type (ge:global_env) (i:ident) : ML out_typ =
   match H.try_find ge.ge_out_t i.v with
@@ -478,11 +506,21 @@ let lookup_output_type_field (ge:global_env) (i f:ident) : ML typ =
   | None ->
     error (Printf.sprintf "Cannot find output field %s:%s" (ident_to_string i) (ident_to_string f)) f.range
 
+let lookup_extern_type (ge:global_env) (i:ident) : ML unit =
+  match H.try_find ge.ge_extern_t i.v with
+  | Some ({d_decl={v=ExternType _}}) -> ()
+  | _ -> error (Printf.sprintf "Cannot find declaration for extern type %s" (ident_to_string i)) i.range
+
+let lookup_extern_fn (ge:global_env) (f:ident) : ML (typ & list param) =
+  match H.try_find ge.ge_extern_fn f.v with
+  | Some ({d_decl={v=ExternFn _ ret ps}}) -> ret, ps
+  | _ -> error (Printf.sprintf "Cannot find declaration for extern function %s" (ident_to_string f)) f.range
+
 let check_output_type (ge:global_env) (t:typ) : ML ident =
   let err () : ML ident =
     error (Printf.sprintf "Type %s is not an output type" (print_typ t)) t.range in
   match t.v with
-  | Type_app i b [] -> if b then i else err ()
+  | Type_app i KindOutput [] -> i
   | _ -> err ()
 
 
@@ -547,36 +585,42 @@ let rec check_typ (pointer_ok:bool) (env:env) (t:typ)
       then { t with v = Pointer (check_typ pointer_ok env t0) }
       else error (Printf.sprintf "Pointer types are not permissible here; got %s" (print_typ t)) t.range
 
-    | Type_app _ true _ ->
-      error "Impossible, check_typ is not supposed to typecheck output types!" t.range
-    | Type_app s false ps ->
-      match lookup env s with
-      | Inl _ ->
-        error (Printf.sprintf "%s is not a type" (ident_to_string s)) s.range
+    | Type_app s KindSpec ps ->
+      (match lookup env s with
+       | Inl _ ->
+         error (Printf.sprintf "%s is not a type" (ident_to_string s)) s.range
 
-      | Inr (d, _) ->
-        let params = params_of_decl d in
-        if List.length params <> List.length ps
-        then error (Printf.sprintf "Not enough arguments to %s" (ident_to_string s)) s.range;
-        let ps =
-          List.map2 (fun (t, _, _) p ->
-            let p, t' = check_typ_param env p in
-            if not (eq_typ env t t')
-            then begin
-              match p with
-              | Inl e -> (match try_cast_integer env (e, t') t with
-                         | Some e -> Inl e
-                         | _ -> error "Argument type mismatch after trying integer cast" (range_of_typ_param p))
-              | _ ->
-                error (Printf.sprintf
-                         "Argument type mismatch (%s vs %s)"
-                         (Ast.print_typ t) (Ast.print_typ t')) (range_of_typ_param p)
-            end
-            else p)
-            params
-            ps
-        in
-        {t with v = Type_app s false ps}
+       | Inr (d, _) ->
+         let params = params_of_decl d in
+         if List.length params <> List.length ps
+         then error (Printf.sprintf "Not enough arguments to %s" (ident_to_string s)) s.range;
+         let ps =
+           List.map2 (fun (t, _, _) p ->
+             let p, t' = check_typ_param env p in
+             if not (eq_typ env t t')
+             then begin
+               match p with
+               | Inl e -> (match try_cast_integer env (e, t') t with
+                          | Some e -> Inl e
+                          | _ -> error "Argument type mismatch after trying integer cast" (range_of_typ_param p))
+               | _ ->
+                 error (Printf.sprintf
+                          "Argument type mismatch (%s vs %s)"
+                          (Ast.print_typ t) (Ast.print_typ t')) (range_of_typ_param p)
+             end
+             else p)
+             params
+             ps
+         in
+         {t with v = Type_app s KindSpec ps})
+
+    | Type_app i KindExtern args ->
+      if List.length args <> 0
+      then error (Printf.sprintf "Cannot apply the extern type %s" (ident_to_string i)) i.range
+      else t
+
+    | Type_app _ KindOutput _ ->
+      error "Impossible, check_typ is not supposed to typecheck output types!" t.range
 
 and check_expr (env:env) (e:expr)
   : ML (expr & typ)
@@ -619,7 +663,7 @@ and check_expr (env:env) (e:expr)
       then error (Printf.sprintf "Casts are only supported on integral types; %s is not integral"
                     (print_typ from)) e.range
       else match from.v with
-           | Type_app i false _ ->
+           | Type_app i KindSpec _ ->
              let from_t = as_integer_typ i in
              if integer_type_lub to from_t <> to
              then error (Printf.sprintf "Only widening casts are supported; casting %s to %s loses precision"
@@ -898,7 +942,18 @@ let rec check_field_action (env:env) (f:field) (a:action)
           Action_assignment lhs rhs, tunit
 
         | Action_call f args ->
-          error "Extern calls are not yet supported" r
+          let ret_t, params = lookup_extern_fn (global_env_of_env env) f in
+          if List.length params <> List.length args
+          then error (Printf.sprintf "Insufficient arguments to extern function %s" (ident_to_string f)) f.range
+          else let args = List.map2 (fun (t, _, _) arg ->
+                 let arg, t_arg = check_expr env arg in
+                 if not (eq_typ env t t_arg)
+                 then error (Printf.sprintf "Argument type mismatch, expected %s whereas %s has type %s"
+                               (Ast.print_typ t)
+                               (Ast.print_expr arg)
+                               (Ast.print_typ t_arg)) arg.range
+                 else arg) params args in
+               Action_call f args, tunit
     in
     match a.v with
     | Atomic_action aa ->
@@ -1029,13 +1084,13 @@ let check_switch (env:env) (s:switch_case)
     let tags_t_opt =
       match scrutinee_t.v with
       | Pointer _ -> fail_non_equality_type ()
-      | Type_app _ true _ ->
-        error "Impossible, check_typ is not supposed to typecheck output types!" head.range
+      | Type_app hd KindSpec es ->
+        (match try_lookup_enum_cases env hd with
+         | Some enum -> Some enum
+         | _ -> fail_non_equality_type ())
+      | Type_app _ _ _ ->
+        error "Impossible, check_switch is not supposed to typecheck output/extern types!" head.range
 
-      | Type_app hd false es ->
-        match try_lookup_enum_cases env hd with
-        | Some enum -> Some enum
-        | _ -> fail_non_equality_type ()
     in
     let check_case (c:case{Case? c}) : ML case =
       let Case pat f = c in
@@ -1210,12 +1265,24 @@ let allowed_base_types_as_output_types = [
   "Bool"
 ]
 
+let rec check_mutable_param_type (ge:global_env) (t:typ) : ML unit =
+  let err () : ML unit =
+    error (Printf.sprintf "%s is not an integer or output or extern type" (print_typ t)) t.range in
+  match t.v with
+  | Type_app i k [] ->
+    if k = KindOutput || k = KindExtern ||
+       (i.v.modul_name = None && List.Tot.mem i.v.name allowed_base_types_as_output_types)
+    then ()
+    else err ()
+  | Pointer t -> check_mutable_param_type ge t
+  | _ -> err ()
+    
 let rec check_integer_or_output_type (ge:global_env) (t:typ) : ML unit =
   match t.v with
-  | Type_app i is_out [] ->  //either it should be a base type, or an output type
+  | Type_app i k [] ->  //either it should be a base type, or an output type
     if i.v.modul_name = None && List.Tot.mem i.v.name allowed_base_types_as_output_types
     then ()
-    else if not is_out then error (Printf.sprintf "%s is not an integer or output type" (print_typ t)) t.range
+    else if not (k = KindOutput) then error (Printf.sprintf "%s is not an integer or output type" (print_typ t)) t.range
   | Pointer t -> check_integer_or_output_type ge t
   | _ -> error (Printf.sprintf "%s is not an integer or output type" (print_typ t)) t.range
 
@@ -1225,7 +1292,7 @@ let check_mutable_param (env:env) (p:param) : ML unit =
   let t, _, _ = p in
   match t.v with
   | Pointer bt ->
-    check_integer_or_output_type (global_env_of_env env) bt
+    check_mutable_param_type (global_env_of_env env) bt
   | _ ->
     error (Printf.sprintf "%s is not a valid mutable parameter type, it is not a pointer type" (print_typ t)) t.range
 
@@ -1432,6 +1499,18 @@ let bind_decl (e:global_env) (d:decl) : ML decl =
     add_output_type e out_t.out_typ_names.typedef_name d;
     d
 
+  | ExternType tdnames ->
+    add_extern_type e tdnames.typedef_name d;
+    d
+
+  | ExternFn f ret params ->
+    let env = mk_env e in
+    let ret = check_typ true env ret in
+    check_params env params;
+    let d = mk_decl (ExternFn f ret params) d.d_decl.range d.d_decl.comments d.d_exported in
+    add_extern_fn e f d;
+    d
+
 let bind_decls (g:global_env) (p:list decl) : ML (list decl & global_env) =
   List.map (bind_decl g) p, g
 
@@ -1439,6 +1518,8 @@ let initial_global_env () =
   let e = {
     ge_h = H.create 10;
     ge_out_t = H.create 10;
+    ge_extern_t = H.create 10;
+    ge_extern_fn = H.create 10;
   }
   in
   let nullary_decl i =
@@ -1474,6 +1555,15 @@ let initial_global_env () =
     |> List.iter (fun (i, d) ->
         let i = with_dummy_range (to_ident' i) in
         add_global e i (nullary_decl i) (Inr d))
+  in
+  let _void =
+    let void_ident = with_dummy_range (to_ident' "void") in
+    add_extern_type e void_ident (mk_decl (ExternType ({
+      typedef_name = void_ident;
+      typedef_abbrev = void_ident;
+      typedef_ptr_abbrev = void_ident;
+      typedef_attributes = []
+    })) dummy_range [] false)
   in
   e
 

--- a/src/3d/Binding.fsti
+++ b/src/3d/Binding.fsti
@@ -23,7 +23,7 @@ val env : Type0
 val mk_env (g:global_env) : ML env
 val global_env_of_env (e:env) : ML global_env
 
-val resolve_record_case_outputtype_name (_:env) (_:ident): ML ident
+val resolve_record_case_output_extern_type_name (_:env) (_:ident): ML ident
 val lookup_expr_name (_:env) (_:ident) : ML typ
 val lookup_macro_definition (_:env) (_:ident) : ML (option expr)
 val has_reader (_:global_env) (_:ident) : ML bool

--- a/src/3d/Deps.fst
+++ b/src/3d/Deps.fst
@@ -14,7 +14,9 @@ type dep_graph = {
   graph: dep_graph';
   modules_with_entrypoint: list string;
   modules_with_static_assertions: list string;
-  modules_with_output_types: list string
+  modules_with_output_types: list string;
+  modules_with_extern_types: list string;
+  modules_with_extern_functions: list string
 }
 
 let all_edges_from (g:dep_graph') (node:string) : Tot (list edge) =
@@ -57,7 +59,9 @@ type scan_deps_t = {
   sd_deps: list string;
   sd_has_entrypoint: bool;
   sd_has_static_assertions: bool;
-  sd_has_output_types: bool
+  sd_has_output_types: bool;
+  sd_has_extern_types: bool;
+  sd_has_extern_functions: bool
 }
 
 let scan_deps (fn:string) : ML scan_deps_t =
@@ -177,17 +181,27 @@ let scan_deps (fn:string) : ML scan_deps_t =
     | CaseType _ params sc ->
       (deps_of_params params)@
       (deps_of_switch_case sc)
-    | OutputType _ -> []  //AR: no dependencies from the output types yet
+    | OutputType _
+    | ExternType _
+    | ExternFn _ _ _ -> []  //AR: no dependencies from the output/extern types yet
   in
 
   let has_output_types (ds:list decl) : bool =
     List.Tot.existsb (fun d -> OutputType? d.d_decl.v) ds in
 
+  let has_extern_types (ds:list decl) : bool =
+    List.Tot.existsb (fun d -> ExternType? d.d_decl.v) ds in
+
+  let has_extern_functions (ds:list decl) : bool =
+    List.Tot.existsb (fun d -> ExternFn? d.d_decl.v) ds in
+
   {
     sd_deps = List.collect deps_of_decl decls;
     sd_has_entrypoint = has_entrypoint;
     sd_has_static_assertions = has_static_assertions;
-    sd_has_output_types = has_output_types decls
+    sd_has_output_types = has_output_types decls;
+    sd_has_extern_types = has_extern_types decls;
+    sd_has_extern_functions = has_extern_functions decls;
   }
 
 let rec build_dep_graph_aux (dirname:string) (mname:string) (acc:dep_graph & list string)
@@ -199,7 +213,9 @@ let rec build_dep_graph_aux (dirname:string) (mname:string) (acc:dep_graph & lis
     let {sd_has_entrypoint = has_entrypoint;
          sd_deps = deps;
          sd_has_static_assertions = has_static_assertions;
-         sd_has_output_types = has_output_types} =
+         sd_has_output_types = has_output_types;
+         sd_has_extern_types = has_extern_types;
+         sd_has_extern_functions = has_extern_functions} =
       scan_deps (Options.get_file_name (OS.concat dirname mname))
     in
     let edges = List.fold_left (fun edges dep ->
@@ -211,6 +227,8 @@ let rec build_dep_graph_aux (dirname:string) (mname:string) (acc:dep_graph & lis
       modules_with_entrypoint = (if has_entrypoint then mname :: g.modules_with_entrypoint else g.modules_with_entrypoint);
       modules_with_static_assertions = (if has_static_assertions then mname :: g.modules_with_static_assertions else g.modules_with_static_assertions);
       modules_with_output_types = (if has_output_types then mname::g.modules_with_output_types else g.modules_with_output_types);
+      modules_with_extern_types = (if has_extern_types then mname::g.modules_with_extern_types else g.modules_with_extern_types);
+      modules_with_extern_functions = (if has_extern_functions then mname::g.modules_with_extern_functions else g.modules_with_extern_functions);
     }
     in
     List.fold_left (fun acc dep -> build_dep_graph_aux dirname dep acc)
@@ -222,6 +240,8 @@ let build_dep_graph_from_list files =
     modules_with_entrypoint = [];
     modules_with_static_assertions = [];
     modules_with_output_types = [];
+    modules_with_extern_types = [];
+    modules_with_extern_functions = []
   }
   in
   let g1 = List.fold_left (fun acc fn -> build_dep_graph_aux (OS.dirname fn) (Options.get_module_name fn) acc) (g0, []) files
@@ -256,3 +276,8 @@ let has_entrypoint g m = List.Tot.mem m g.modules_with_entrypoint
 let has_static_assertions g m = List.Tot.mem m g.modules_with_static_assertions
 
 let has_output_types g m = List.Tot.mem m g.modules_with_output_types
+
+let has_extern_types g m = List.Tot.mem m g.modules_with_extern_types
+
+let has_extern_functions g m = List.Tot.mem m g.modules_with_extern_functions
+

--- a/src/3d/Deps.fsti
+++ b/src/3d/Deps.fsti
@@ -18,3 +18,7 @@ val has_entrypoint (g: dep_graph) (modul: string) : Tot bool
 val has_static_assertions (g: dep_graph) (modul: string) : Tot bool
 
 val has_output_types (g:dep_graph) (modul:string) : bool
+
+val has_extern_types (g:dep_graph) (modul:string) : bool
+
+val has_extern_functions (g:dep_graph) (modul:string) : bool

--- a/src/3d/GenMakefile.fst
+++ b/src/3d/GenMakefile.fst
@@ -59,19 +59,21 @@ let produce_types_checked_rule
     args = Printf.sprintf "--__micro_step verify %s" types_fst;
   }
 
-let produce_output_types_fsti_checked_rule
+let produce_external_api_fsti_checked_rule
   (g: Deps.dep_graph)
   (skip_interface: bool)
   (modul: string)
 : list rule_t
-= if not (Deps.has_output_types g modul) then []
+= if not (Deps.has_output_types g modul ||
+          Deps.has_extern_types g modul ||
+          Deps.has_extern_functions g modul) then []
   else
-    let output_types_fsti = mk_filename modul "OutputTypes.fsti" in 
+    let external_api_fsti = mk_filename modul "ExternalAPI.fsti" in 
     [{
        ty = EverParse;
-       from = output_types_fsti :: List.Tot.map (fun m -> mk_filename m (if skip_interface then "fst.checked" else "fsti.checked")) (Deps.dependencies g modul);
-       to = mk_filename modul "OutputTypes.fsti.checked";
-       args = Printf.sprintf "--__micro_step verify %s" output_types_fsti;
+       from = external_api_fsti :: List.Tot.map (fun m -> mk_filename m (if skip_interface then "fst.checked" else "fsti.checked")) (Deps.dependencies g modul);
+       to = mk_filename modul "ExternalAPI.fsti.checked";
+       args = Printf.sprintf "--__micro_step verify %s" external_api_fsti;
      }]
 
 let produce_fsti_checked_rule
@@ -111,18 +113,20 @@ let produce_types_krml_rule
     args = Printf.sprintf "--__micro_step extract %s" (mk_filename modul "Types.fst");
   }
 
-let produce_output_types_krml_rule
+let produce_external_api_krml_rule
   (g: Deps.dep_graph)
   (modul: string)
 : list rule_t
-= if not (Deps.has_output_types g modul) then []
+= if not (Deps.has_output_types g modul ||
+          Deps.has_extern_types g modul ||
+          Deps.has_extern_functions g modul) then []
   else
-    let output_types_fsti_checked = mk_filename modul "OutputTypes.fsti.checked" in 
+    let external_api_fsti_checked = mk_filename modul "ExternalAPI.fsti.checked" in 
     [{
        ty = EverParse;
-       from = output_types_fsti_checked :: List.Tot.map (fun m -> mk_filename m "fst.checked") (Deps.dependencies g modul);
-       to = mk_filename (Printf.sprintf "%s_OutputTypes" modul) "krml";
-       args = Printf.sprintf "--__micro_step extract %s" (mk_filename modul "OutputTypes.fsti");
+       from = external_api_fsti_checked :: List.Tot.map (fun m -> mk_filename m "fst.checked") (Deps.dependencies g modul);
+       to = mk_filename (Printf.sprintf "%s_ExternalAPI" modul) "krml";
+       args = Printf.sprintf "--__micro_step extract %s" (mk_filename modul "ExternalAPI.fsti");
      }]
 
 let produce_krml_rule
@@ -170,8 +174,10 @@ let produce_fst_rules
     args = Printf.sprintf "--no_batch %s" (mk_input_filename file);
   } ::
   List.Tot.map (produce_nop_rule [to])
-    ((if Deps.has_output_types g modul
-      then [mk_filename modul "OutputTypes.fsti"]
+    ((if Deps.has_output_types g modul ||
+         Deps.has_extern_types g modul ||
+         Deps.has_extern_functions g modul
+      then [mk_filename modul "ExternalAPI.fsti"]
       else []) `List.Tot.append` (
         if skip_types then [] else [
           mk_filename modul "fsti";
@@ -224,8 +230,10 @@ let produce_h_rules
       (if skip_types then [] else List.map (fun f -> mk_filename (Printf.sprintf "%s_Types" (Options.get_module_name f)) "krml") all_files) `List.Tot.append`
       List.concatMap (fun f ->
         let m = Options.get_module_name f in
-        if Deps.has_output_types g m
-        then [mk_filename (Printf.sprintf "%s_OutputTypes" m) "krml"]
+        if Deps.has_output_types g m ||
+           Deps.has_extern_types g m ||
+           Deps.has_extern_functions g m
+        then [mk_filename (Printf.sprintf "%s_ExternalAPI" m) "krml"]
         else []) all_files
       ;
     to = to; (* IMPORTANT: relies on the fact that kremlin generates .c files BEFORE .h files *)
@@ -243,7 +251,7 @@ let produce_output_types_o_rule
     let h = mk_filename (Printf.sprintf "%s_OutputTypes" modul) "h" in
     let c = mk_filename (Printf.sprintf "%s_OutputTypes" modul) "c" in
     let o = mk_filename (Printf.sprintf "%s_OutputTypes" modul) "o" in
-    let defs = mk_filename (Printf.sprintf "%s_OutputTypesDefs" modul) "h" in
+    let defs = mk_filename (Printf.sprintf "%s_ExternalTypedefs" modul) "h" in
     [{
       ty = CC;
       from = [c; h; defs];
@@ -338,11 +346,11 @@ let produce_makefile
     ) `List.Tot.append`
     List.concatMap (produce_fst_rules g skip_types clang_format) all_files `List.Tot.append`
     (if skip_types then [] else List.Tot.map (produce_types_checked_rule g) all_modules) `List.Tot.append`
-    List.concatMap (produce_output_types_fsti_checked_rule g skip_types) all_modules `List.Tot.append`
+    List.concatMap (produce_external_api_fsti_checked_rule g skip_types) all_modules `List.Tot.append`
     (if skip_types then [] else List.Tot.map (produce_fsti_checked_rule g) all_modules) `List.Tot.append`
     List.Tot.map (produce_fst_checked_rule g skip_types) all_modules `List.Tot.append`
     (if skip_types then [] else List.Tot.map (produce_types_krml_rule g) all_modules) `List.Tot.append`
-    List.Tot.concatMap (produce_output_types_krml_rule g) all_modules `List.Tot.append`
+    List.Tot.concatMap (produce_external_api_krml_rule g) all_modules `List.Tot.append`
     List.Tot.map (produce_krml_rule g) all_modules `List.Tot.append`
     List.concatMap (produce_h_rules g skip_types clang_format) all_files
   in {

--- a/src/3d/InlineSingletonRecords.fst
+++ b/src/3d/InlineSingletonRecords.fst
@@ -177,7 +177,9 @@ let simplify_decl (env:env) (d:decl) : ML decl =
                          cases in
     decl_with_v d (CaseType tdnames params (hd, cases))
 
-  | OutputType _ -> d
+  | OutputType _
+  | ExternType _
+  | ExternFn _ _ _ -> d
 
 let simplify_prog (p:list decl) =
   let env = H.create 10 in

--- a/src/3d/Simplify.fst
+++ b/src/3d/Simplify.fst
@@ -59,7 +59,7 @@ and simplify_typ (env:T.env_t) (t:typ)
     | Pointer t -> {t with v=Pointer (simplify_typ env t)}
     | Type_app s b ps ->
       let ps = List.map (simplify_typ_param env) ps in
-      let s = B.resolve_record_case_outputtype_name (fst env) s in
+      let s = B.resolve_record_case_output_extern_type_name (fst env) s in
       let t = { t with v = Type_app s b ps } in
       if Options.get_interpret()
       then B.unfold_typ_abbrev_only (fst env) t
@@ -163,6 +163,13 @@ let simplify_decl (env:T.env_t) (d:decl) : ML decl =
 
   | OutputType out_t ->
     decl_with_v d (OutputType ({out_t with out_typ_fields=simplify_out_fields env out_t.out_typ_fields}))
+
+  | ExternType tdnames -> d
+
+  | ExternFn f ret params ->
+    let ret = simplify_typ env ret in
+    let params = List.map (fun (t, i, q) -> simplify_typ env t, i, q) params in
+    decl_with_v d (ExternFn f ret params)
 
 let simplify_prog benv senv (p:list decl) =
   List.map (simplify_decl (B.mk_env benv, senv)) p

--- a/src/3d/StaticAssertions.fst
+++ b/src/3d/StaticAssertions.fst
@@ -52,7 +52,7 @@ let compute_static_asserts (benv:B.global_env)
               | None -> i
               | Some j -> j
             in
-            let t_j = with_dummy_range (Type_app j false []) in
+            let t_j = with_dummy_range (Type_app j KindSpec []) in
             match TypeSizes.size_of_typ env t_j with
             | TypeSizes.Fixed n
             | TypeSizes.WithVariableSuffix n ->

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -78,7 +78,7 @@ let error_handler_decl =
     name = "error_handler"
   } in
   let error_handler_id = with_range error_handler_id' dummy_range in
-  let typ = T_app error_handler_id false [] in
+  let typ = T_app error_handler_id KindSpec [] in
   let a = Assumption (error_handler_name, typ) in
   a, default_attrs
 
@@ -310,8 +310,14 @@ let print_expr_lam (mname:string) (x:lam expr) : ML string =
 
 let rec is_output_type (t:typ) : bool =
   match t with
-  | T_app _ true [] -> true
+  | T_app _ A.KindOutput [] -> true
   | T_pointer t -> is_output_type t
+  | _ -> false
+
+let rec is_extern_type (t:typ) : bool =
+  match t with
+  | T_app _ A.KindExtern [] -> true
+  | T_pointer t -> is_extern_type t
   | _ -> false
 
 (*
@@ -681,9 +687,9 @@ let print_typedef_actions_inv_and_fp (td:type_decl) =
     //we need to add output loc to the modifies locs
     //if there is an output type type parameter
     let should_add_output_loc =
-      List.Tot.existsb (fun (_, t) -> is_output_type t) td.decl_name.td_params in
+      List.Tot.existsb (fun (_, t) -> is_output_type t || is_extern_type t) td.decl_name.td_params in
     let pointers =  //get only non output type pointers
-      List.Tot.filter (fun (x, t) -> T_pointer? t && not (is_output_type t)) td.decl_name.td_params
+      List.Tot.filter (fun (x, t) -> T_pointer? t && not (is_output_type t || is_extern_type t)) td.decl_name.td_params
     in
     let inv =
       List.Tot.fold_right
@@ -796,7 +802,11 @@ let print_decl_for_types (mname:string) (d:decl) : ML string =
 
   | Output_type _
 
-  | Output_type_expr _ _ -> ""
+  | Output_type_expr _ _
+
+  | Extern_type _
+
+  | Extern_fn _ _ _ -> ""
 
 /// Print a decl for M.fst
 ///
@@ -860,7 +870,9 @@ let print_decl_for_validators (mname:string) (d:decl) : ML string =
          (print_reader mname r))
   
   | Output_type _
-  | Output_type_expr _ _ -> ""
+  | Output_type_expr _ _
+  | Extern_type _
+  | Extern_fn _ _ _ -> ""
 
 let print_type_decl_signature (mname:string) (d:decl{Type_decl? (fst d)}) : ML string =
   match fst d with
@@ -914,16 +926,25 @@ let print_decl_signature (mname:string) (d:decl) : ML string =
     then ""
     else print_type_decl_signature mname d
   | Output_type _
-  | Output_type_expr _ _ -> ""
+  | Output_type_expr _ _
+  | Extern_type _
+  | Extern_fn _ _ _ -> ""
 
 let has_output_types (ds:list decl) : bool =
   List.Tot.existsb (fun (d, _) -> Output_type_expr? d) ds
 
+let has_extern_types (ds:list decl) : bool =
+  List.Tot.existsb (fun (d, _) -> Extern_type? d) ds
+
+let has_extern_functions (ds:list decl) : bool =
+  List.Tot.existsb (fun (d, _) -> Extern_fn? d) ds
+
+let external_api_include (modul:string) (ds:list decl) : string =
+  if has_output_types ds || has_extern_types ds || has_extern_functions ds
+  then Printf.sprintf "open %s.ExternalAPI\n\n" modul
+  else ""
+
 let print_decls (modul: string) (ds:list decl) =
-  let output_types_include =
-    if has_output_types ds
-    then Printf.sprintf "open %s.OutputTypes\n\n" modul
-    else "" in
   let decls =
   Printf.sprintf
     "module %s\n\
@@ -936,7 +957,7 @@ let print_decls (modul: string) (ds:list decl) =
      #set-options \"--using_facts_from '* FStar Prelude -FStar.Tactics -FStar.Reflection -LowParse -WeakenTac'\"\n\
      %s"
      modul
-     output_types_include
+     (external_api_include modul ds)
      modul
      (String.concat "\n////////////////////////////////////////////////////////////////////////////////\n"
        (ds |> List.map (print_decl_for_validators modul)
@@ -945,10 +966,6 @@ let print_decls (modul: string) (ds:list decl) =
   decls
 
 let print_types_decls (modul:string) (ds:list decl) =
-  let output_types_include =
-    if has_output_types ds
-    then Printf.sprintf "open %s.OutputTypes\n\n" modul
-    else "" in
   let decls =
   Printf.sprintf
     "module %s.Types\n\
@@ -959,7 +976,7 @@ let print_types_decls (modul:string) (ds:list decl) =
      #set-options \"--fuel 0 --ifuel 0 --using_facts_from '* -FStar.Tactics -FStar.Reflection -LowParse'\"\n\n\
      %s"
      modul
-     output_types_include
+     (external_api_include modul ds)
      (String.concat "\n////////////////////////////////////////////////////////////////////////////////\n" 
        (ds |> List.map (print_decl_for_types modul)
            |> List.filter (fun s -> s <> "")))
@@ -967,10 +984,6 @@ let print_types_decls (modul:string) (ds:list decl) =
   decls
 
 let print_decls_signature (mname: string) (ds:list decl) =
-  let output_types_include =
-    if has_output_types ds
-    then Printf.sprintf "open %s.OutputTypes\n\n" mname
-    else "" in
   let decls =
     Printf.sprintf
     "module %s\n\
@@ -981,7 +994,7 @@ let print_decls_signature (mname: string) (ds:list decl) =
      include %s.Types\n\n\
      %s"
      mname
-     output_types_include
+     (external_api_include mname ds)
      mname
      (String.concat "\n" (ds |> List.map (print_decl_signature mname) |> List.filter (fun s -> s <> "")))
   in
@@ -1040,9 +1053,9 @@ let rec print_as_c_type (t:typ) : ML string =
           "uint64_t"
     | T_app {v={name="PUINT8"}} _ [] ->
           "uint8_t*"
-    | T_app {v={name=x}} false [] ->
+    | T_app {v={name=x}} KindSpec [] ->
           x
-    | T_app {v={name=x}} true [] ->
+    | T_app {v={name=x}} _ [] ->
           pascal_case x
     | _ ->
          "__UNKNOWN__"
@@ -1185,7 +1198,9 @@ let print_c_entry (modul: string)
        #ifdef __cplusplus\n\
        }\n\
        #endif\n"
-      (if has_output_types ds then Printf.sprintf "#include \"%s_OutputTypesDefs.h\"\n" modul else "")
+      (if has_output_types ds || has_extern_types ds
+       then Printf.sprintf "#include \"%s_ExternalTypedefs.h\"\n" modul
+       else "")
       (signatures |> String.concat "\n\n")
   in
   let input_stream_include = HashingOptions.input_stream_include input_stream_binding in
@@ -1263,7 +1278,7 @@ type set = H.t string unit
 
 let rec base_output_type (t:typ) : ML A.ident =
   match t with
-  | T_app id true [] -> id
+  | T_app id A.KindOutput [] -> id
   | T_pointer t -> base_output_type t
   | _ -> failwith "Target.base_output_type called with a non-output type"
 
@@ -1274,7 +1289,7 @@ let rec print_output_type_val (tbl:set) (t:typ) : ML string =
        if H.try_find tbl s <> None then ""
        else let _ = H.insert tbl s () in
             match t with
-            | T_app id true [] ->
+            | T_app id KindOutput [] ->
               Printf.sprintf "\n\nval %s : Type0\n\n" s
             | T_pointer bt ->
               let bs = print_output_type_val tbl bt in
@@ -1397,7 +1412,7 @@ let output_setter_name lhs = Printf.sprintf "set_%s" (out_fn_name lhs)
 let output_getter_name lhs = Printf.sprintf "get_%s" (out_fn_name lhs)
 let output_base_var lhs = base_id_of_output_expr lhs
 
-let print_out_exprs_fstar (modul:string) (ds:decls) : ML string =
+let print_external_api_fstar (modul:string) (ds:decls) : ML string =
   let tbl = H.create 10 in
   let s = String.concat "" (ds |> List.map (fun d ->
     match fst d with
@@ -1407,9 +1422,17 @@ let print_out_exprs_fstar (modul:string) (ds:decls) : ML string =
         (print_output_type_val tbl oe.oe_t)
         (if not is_get then print_out_expr_set_fstar tbl modul oe
          else print_out_expr_get_fstar tbl modul oe)
+    | Extern_type i ->
+      Printf.sprintf "\n\nval %s : Type0\n\n" (print_ident i)
+    | Extern_fn f ret params ->
+      Printf.sprintf "\n\nval %s %s (_:unit) : Stack unit (fun _ -> True) (fun h0 _ h1 -> B.modifies output_loc h0 h1)\n\n"
+        (print_ident f)
+        (String.concat " " (params |> List.map (fun (i, t) -> Printf.sprintf "(%s:%s)"
+          (print_ident i)
+          (print_typ modul t))))
     | _ -> "")) in
    Printf.sprintf
-    "module %s.OutputTypes\n\n\
+    "module %s.ExternalAPI\n\n\
      open FStar.HyperStack.ST\n\
      open Prelude\n\
      open EverParse3d.Actions.All\n\
@@ -1422,7 +1445,7 @@ let print_out_exprs_c modul (ds:decls) : ML string =
   let tbl = H.create 10 in
   (Printf.sprintf
      "#include<stdint.h>\n\n\
-      #include \"%s_OutputTypesDefs.h\"\n\n\
+      #include \"%s_ExternalTypedefs.h\"\n\n\
       #if defined(__cplusplus)\n\
       extern \"C\" {\n\
       #endif\n\n"

--- a/src/3d/Target.fsti
+++ b/src/3d/Target.fsti
@@ -87,7 +87,7 @@ type action =
 noeq
 type typ =
   | T_false    : typ
-  | T_app      : hd:A.ident -> is_out:bool -> args:list index -> typ  //the bool is true if the hd is an output type ident
+  | T_app      : hd:A.ident -> A.t_kind -> args:list index -> typ
   | T_dep_pair : dfst:typ -> dsnd:(A.ident & typ) -> typ
   | T_refine   : base:typ -> refinement:lam expr -> typ
   | T_if_else  : e:expr -> t:typ -> f:typ -> typ
@@ -394,6 +394,9 @@ type decl' =
 
   | Output_type_expr : output_expr -> is_get:bool -> decl'  //is_get boolean indicates that the output expression appears in a getter position, i.e. in a type parameter, it is false when the output expression is an assignment action lhs
 
+  | Extern_type : A.ident -> decl'
+  | Extern_fn : A.ident -> typ -> list param -> decl'
+
 type decl = decl' * decl_attributes
 
 type decls = list decl
@@ -429,6 +432,6 @@ val output_base_var (lhs:output_expr) : ML A.ident
  * Used by Main
  *)
  
-val print_out_exprs_fstar (modul:string) (ds:decls) : ML string
+val print_external_api_fstar (modul:string) (ds:decls) : ML string
 val print_out_exprs_c (modul:string) (ds:decls) : ML string
 val print_output_types_defs (modul:string) (ds:decls) : ML string

--- a/src/3d/TranslateForInterpreter.fst
+++ b/src/3d/TranslateForInterpreter.fst
@@ -166,14 +166,14 @@ let pk_glb k1 k2 = T.({
 
 let false_typ = T.T_false
 let unit_typ =
-    T.T_app (with_dummy_range (to_ident' "unit")) false []
+    T.T_app (with_dummy_range (to_ident' "unit")) KindSpec []
 let unit_val =
     T.(mk_expr (App (Ext "()") []))
 let unit_parser =
     let unit_id = with_dummy_range (to_ident' "unit") in
     mk_parser pk_return unit_typ unit_id "none" (T.Parse_return unit_val)
 let pair_typ t1 t2 =
-    T.T_app (with_dummy_range (to_ident' "tuple2")) false [Inl t1; Inl t2]
+    T.T_app (with_dummy_range (to_ident' "tuple2")) KindSpec [Inl t1; Inl t2]
 let pair_value x y =
     T.Record (with_dummy_range (to_ident' "tuple2"))
              [(with_dummy_range (to_ident' "fst"), T.mk_expr (T.Identifier x));
@@ -435,10 +435,11 @@ let rec parse_typ (env:global_env)
   | T_false ->
     mk_parser pk_impos T_false typename fieldname Parse_impos
 
-  | T.T_app _ true _ ->
-    failwith "Impossible, did not expect parse_typ to be called with an output type!"
+  | T.T_app _ A.KindOutput _
+  | T.T_app _ A.KindExtern _ ->
+    failwith "Impossible, did not expect parse_typ to be called with an output/extern type!"
 
-  | T.T_app {v={name="nlist"}} false [Inr e; Inl t] ->
+  | T.T_app {v={name="nlist"}} KindSpec [Inr e; Inl t] ->
     let pt = parse_typ env typename (extend_fieldname "element") t in
     mk_parser pk_list
               t
@@ -446,7 +447,7 @@ let rec parse_typ (env:global_env)
               fieldname
               (T.Parse_nlist e pt)
 
-  | T.T_app {v={name="t_at_most"}} false [Inr e; Inl t] ->
+  | T.T_app {v={name="t_at_most"}} KindSpec [Inr e; Inl t] ->
     let pt = parse_typ env typename (extend_fieldname "element") t in
     mk_parser pk_t_at_most
               t
@@ -454,7 +455,7 @@ let rec parse_typ (env:global_env)
               fieldname
               (T.Parse_t_at_most e pt)
 
-  | T.T_app {v={name="t_exact"}} false [Inr e; Inl t] ->
+  | T.T_app {v={name="t_exact"}} KindSpec [Inr e; Inl t] ->
     let pt = parse_typ env typename (extend_fieldname "element") t in
     mk_parser pk_t_exact
               t
@@ -462,7 +463,7 @@ let rec parse_typ (env:global_env)
               fieldname
               (T.Parse_t_exact e pt)
 
-  | T.T_app {v={name="cstring"}} false [Inl t; Inr e] ->
+  | T.T_app {v={name="cstring"}} KindSpec [Inl t; Inr e] ->
     let pt = parse_typ env typename (extend_fieldname "element") t in
     mk_parser pk_string
               t
@@ -470,7 +471,7 @@ let rec parse_typ (env:global_env)
               fieldname
               (T.Parse_string pt e)
 
-  | T.T_app hd false args ->
+  | T.T_app hd KindSpec args ->
     mk_parser (pk_base hd (parser_kind_nz env hd) (parser_weak_kind env hd))
               t
               typename
@@ -551,7 +552,7 @@ let rec read_typ (env:global_env) (t:T.typ) : ML (option T.reader) =
   | T_app ({v={name="UINT8"}}) _ [] -> Some Read_u8
   | T_app ({v={name="UINT16"}}) _ [] -> Some Read_u16
   | T_app ({v={name="UINT32"}}) _ [] -> Some Read_u32
-  | T.T_app hd false args ->
+  | T.T_app hd KindSpec args ->
     if has_reader env hd
     then Some (T.Read_app hd args)
     else None
@@ -833,22 +834,22 @@ let translate_field (f:A.field) : ML (T.struct_field & T.decls) =
     let t =
         let mk_at_most t e : ML T.typ =
           let e = translate_expr e in
-          T.T_app (with_range (to_ident' "t_at_most") sf.field_type.range) false [Inr e; Inl t]
+          T.T_app (with_range (to_ident' "t_at_most") sf.field_type.range) KindSpec [Inr e; Inl t]
         in
         match sf.field_array_opt with
         | FieldScalar -> t
         | FieldArrayQualified (e, ByteArrayByteSize)
         | FieldArrayQualified (e, ArrayByteSize) ->
           let e = translate_expr e in
-          T.T_app (with_range (to_ident' "nlist") sf.field_type.range) false [Inr e; Inl t]
+          T.T_app (with_range (to_ident' "nlist") sf.field_type.range) KindSpec [Inr e; Inl t]
         | FieldArrayQualified (e, ArrayByteSizeAtMost) ->
           mk_at_most t e
         | FieldArrayQualified (e, ArrayByteSizeSingleElementArray) ->
           let e = translate_expr e in
-          T.T_app (with_range (to_ident' "t_exact") sf.field_type.range) false [Inr e; Inl t]
+          T.T_app (with_range (to_ident' "t_exact") sf.field_type.range) KindSpec [Inr e; Inl t]
         | FieldString sz ->
           let r = sf.field_type.range in
-          let str = T.T_app (with_range (to_ident' "cstring") r) false [Inl t; Inr (make_zero r sf.field_type)] in
+          let str = T.T_app (with_range (to_ident' "cstring") r) KindSpec [Inl t; Inr (make_zero r sf.field_type)] in
           begin match sz with
           | None -> str
           | Some e -> mk_at_most str e
@@ -1105,7 +1106,7 @@ let rec hoist_typ
         let args = args in //@ [Identifier x] in
         let filter_name = fn ^ "_filter" in
         let id = maybe_gen_ident genv filter_name in
-        let result_type = T_app (with_dummy_range (to_ident' "bool")) false [] in
+        let result_type = T_app (with_dummy_range (to_ident' "bool")) KindSpec [] in
         let body = e in
         let app = App (Ext id.A.v.name) (List.Tot.map (fun arg -> T.mk_expr arg) args) in
         (id, params, result_type, body),
@@ -1172,7 +1173,7 @@ let hoist_one_type_definition (should_inline:bool)
      let type_name = prefix in //^ "_type" in
      let id = maybe_gen_ident genv type_name in
      let args = List.map (fun (x, _) -> Inr (T.mk_expr (Identifier x))) (List.rev env) in
-     let tdef = T_app id false args in
+     let tdef = T_app id KindSpec args in
      let tdef =
        if should_inline
        then tdef
@@ -1370,6 +1371,15 @@ let translate_decl (env:global_env) (d:A.decl) : ML (list T.decl) =
     ds1 @ ds2 @ [with_comments (Type_decl td) d.d_exported A.(d.d_decl.comments)]
 
   | OutputType out_t -> [with_comments (T.Output_type out_t) false []]  //No decl for output type specifications
+
+  | ExternType tdnames -> [with_comments (T.Extern_type tdnames.typedef_name) false []]
+
+  | ExternFn f ret params ->
+    let ret, ds = translate_typ ret in
+    let params, ds = List.fold_left (fun (params, ds) (t, i, _) ->
+      let t, ds_t = translate_typ t in
+      params@[i, t],ds@ds_t) ([], ds) params in
+    [with_comments (T.Extern_fn f ret params) false []]
 
 noeq
 type translate_env = {

--- a/src/3d/TypeSizes.fst
+++ b/src/3d/TypeSizes.fst
@@ -134,7 +134,7 @@ let rec value_of_const_expr (env:env_t) (e:expr)
   | App SizeOf [{v=Identifier t}] ->
     begin
     try
-      match size_of_typ env (with_range (Type_app t false []) t.range) with
+      match size_of_typ env (with_range (Type_app t KindSpec []) t.range) with
       | Fixed n
       | WithVariableSuffix n -> Some (Inr (UInt32, n))
       | _ -> None
@@ -390,7 +390,9 @@ let decl_size_with_alignment (env:env_t) (d:decl)
       );
       extend_with_size_of_typedef_names env names size alignment;
       d
-    | OutputType _ -> d
+    | OutputType _
+    | ExternType _
+    | ExternFn _ _ _ -> d
 
 let size_of_decls (genv:B.global_env) (senv:size_env) (ds:list decl) =
   let env =
@@ -401,5 +403,3 @@ let size_of_decls (genv:B.global_env) (senv:size_env) (ds:list decl) =
 
 let finish_module en mname e_and_p =
   e_and_p |> snd |> List.iter (H.remove en)
-
-  

--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -115,12 +115,12 @@ let pretty_print_source_module
       (file, modul)
     : unit
   =
-  let output_types_fsti_file = filename_concat out_dir (Printf.sprintf "%s.OutputTypes.fsti" modul) in
+  let external_api_fsti_file = filename_concat out_dir (Printf.sprintf "%s.ExternalAPI.fsti" modul) in
   let fst_file = filename_concat out_dir (Printf.sprintf "%s.fst" modul) in
   let types_fst_file = filename_concat out_dir (Printf.sprintf "%s.Types.fst" modul) in
   let fsti_file = Printf.sprintf "%si" fst_file in
   let all_files =
-    List.filter file_exists [output_types_fsti_file; types_fst_file; fsti_file; fst_file] in
+    List.filter file_exists [external_api_fsti_file; types_fst_file; fsti_file; fst_file] in
   List.iter (pretty_print_source_file input_stream_binding out_dir) all_files
 
 let pretty_print_source_modules
@@ -136,8 +136,8 @@ let verify_and_extract_module
       (file, modul)
     : unit
   =
-  let output_types_fsti_file =
-    filename_concat out_dir (Printf.sprintf "%s.OutputTypes.fsti" modul)
+  let external_api_fsti_file =
+    filename_concat out_dir (Printf.sprintf "%s.ExternalAPI.fsti" modul)
   in
   let fst_file = 
       filename_concat out_dir (Printf.sprintf "%s.fst" modul)
@@ -148,8 +148,8 @@ let verify_and_extract_module
   let fsti_file = 
       Printf.sprintf "%si" fst_file
   in
-  let all_files = List.filter file_exists [output_types_fsti_file; types_fst_file; fsti_file; fst_file] in
-  let all_extract_files = List.filter file_exists [output_types_fsti_file; types_fst_file; fst_file] in  
+  let all_files = List.filter file_exists [external_api_fsti_file; types_fst_file; fsti_file; fst_file] in
+  let all_extract_files = List.filter file_exists [external_api_fsti_file; types_fst_file; fst_file] in  
   List.iter (verify_fst_file input_stream_binding out_dir) all_files;
   List.iter (extract_fst_file input_stream_binding out_dir) all_extract_files
 
@@ -190,11 +190,11 @@ let remove_fst_and_krml_files
   =
   let root_name = filename_concat out_dir modul in
   List.iter remove_if_exists [
-      Printf.sprintf "%s.OutputTypes.fsti" root_name;
+      Printf.sprintf "%s.ExternalAPI.fsti" root_name;
       Printf.sprintf "%s.Types.fst" root_name;
       Printf.sprintf "%s.fst" root_name;
       Printf.sprintf "%s.fsti" root_name;
-      Printf.sprintf "%s.OutputTypes.fsti.checked" root_name;
+      Printf.sprintf "%s.ExternalAPI.fsti.checked" root_name;
       Printf.sprintf "%s.Types.fst.checked" root_name;
       Printf.sprintf "%s.fst.checked" root_name;
       Printf.sprintf "%s.fsti.checked" root_name;
@@ -207,8 +207,8 @@ let everparse_only_bundle = "Prims,LowParse.\\*,EverParse3d.\\*,Prelude.\\*,Prel
 let fstar_kremlib_bundle = "FStar.\\*,LowStar.\\*,C.\\*"
 
 let krml_args input_stream_binding skip_c_makefiles out_dir files_and_modules =
-  let has_output_types modul =
-    file_exists (filename_concat out_dir (Printf.sprintf "%s.OutputTypes.fsti" modul)) in
+  let has_external_api modul =
+    file_exists (filename_concat out_dir (Printf.sprintf "%s.ExternalAPI.fsti" modul)) in
 
   let has_types modul =
     file_exists (filename_concat out_dir (Printf.sprintf "%s.Types.fst" modul))
@@ -220,31 +220,31 @@ let krml_args input_stream_binding skip_c_makefiles out_dir files_and_modules =
     else []
   in
 
-  let output_types_krml modul =
-    if has_output_types modul
-    then [filename_concat out_dir (Printf.sprintf "%s_OutputTypes.krml" modul)]
+  let external_api_krml modul =
+    if has_external_api modul
+    then [filename_concat out_dir (Printf.sprintf "%s_ExternalAPI.krml" modul)]
     else [] in
 
-  let output_types_lib_args modul =  
-    if has_output_types modul
-    then ["-library"; Printf.sprintf "%s.OutputTypes" modul]
+  let external_api_lib_args modul =  
+    if has_external_api modul
+    then ["-library"; Printf.sprintf "%s.ExternalAPI" modul]
     else [] in
 
-  let output_types_prefix_args modul =
-    if has_output_types modul
-    then ["-no-prefix"; Printf.sprintf "%s.OutputTypes" modul]
+  let external_api_prefix_args modul =
+    if has_external_api modul
+    then ["-no-prefix"; Printf.sprintf "%s.ExternalAPI" modul]
     else [] in
 
-  let output_types_include_args modul =
-    if has_output_types modul
-    then ["-add-include"; Printf.sprintf "\"%s_OutputTypesDefs.h\"" modul]
+  let external_typedefs_include_args modul =
+    if has_external_api modul
+    then ["-add-include"; Printf.sprintf "\"%s_ExternalTypedefs.h\"" modul]
     else [] in
 
   let krml_files = List.fold_left
                      (fun accu (_, modul) ->
                        let l =
                          (types_krml modul)@
-			 (output_types_krml modul)@(filename_concat out_dir (Printf.sprintf "%s.krml" modul) ::
+			 (external_api_krml modul)@(filename_concat out_dir (Printf.sprintf "%s.krml" modul) ::
                                                     accu)
                        in
 
@@ -264,12 +264,12 @@ let krml_args input_stream_binding skip_c_makefiles out_dir files_and_modules =
                      (all_everparse_krmls input_stream_binding)
                      files_and_modules
   in
-  let output_files_lib_args = List.fold_left (fun accu (_, modul) ->
-                                  accu @ (output_types_lib_args modul)) [] files_and_modules in
-  let output_files_no_prefix_args = List.fold_left (fun accu (_, modul) ->
-                                  accu @ (output_types_prefix_args modul)) [] files_and_modules in
-  let output_files_include_args = List.fold_left (fun accu (_, modul) ->
-                                  accu @ (output_types_include_args modul)) [] files_and_modules in
+  let external_api_lib_args = List.fold_left (fun accu (_, modul) ->
+                                  accu @ (external_api_lib_args modul)) [] files_and_modules in
+  let external_api_no_prefix_args = List.fold_left (fun accu (_, modul) ->
+                                  accu @ (external_api_prefix_args modul)) [] files_and_modules in
+  let external_typedefs_include_args = List.fold_left (fun accu (_, modul) ->
+                                           accu @ (external_typedefs_include_args modul)) [] files_and_modules in
 
   let krml_files = List.rev krml_files in
   let krml_args =
@@ -288,7 +288,7 @@ let krml_args input_stream_binding skip_c_makefiles out_dir files_and_modules =
                               "-minimal" ::
                                 "-add-include" :: "\"EverParse.h\"" ::
                                   "-fextern-c" ::
-                                  output_files_lib_args @ output_files_no_prefix_args @ output_files_include_args @ krml_args0 @ krml_files
+                                    external_api_lib_args @ external_api_no_prefix_args @ external_typedefs_include_args @ krml_args0 @ krml_files
     in
     let input_stream_include = HashingOptions.input_stream_include input_stream_binding in
     let krml_args =

--- a/src/3d/ocaml/lexer.mll
+++ b/src/3d/ocaml/lexer.mll
@@ -62,7 +62,8 @@ let () =
   H.add keywords "module" MODULE;
   H.add keywords "export" EXPORT;
   H.add keywords "output" OUTPUT;
-  H.add keywords "union" UNION
+  H.add keywords "union" UNION;
+  H.add keywords "extern" EXTERN
 
 let unsigned_int_of_string s = int_of_string (String.sub s 0 (String.length s - 2))
 

--- a/src/3d/ocaml/parser.mly
+++ b/src/3d/ocaml/parser.mly
@@ -57,7 +57,7 @@
 %token          LBRACK_STRING LBRACK_STRING_AT_MOST
 %token          MUTABLE LBRACE_ONSUCCESS FIELD_POS_64 FIELD_POS_32 FIELD_PTR VAR ABORT RETURN
 %token          REM SHIFT_LEFT SHIFT_RIGHT BITWISE_AND BITWISE_OR BITWISE_XOR BITWISE_NOT AS
-%token          MODULE EXPORT OUTPUT UNION
+%token          MODULE EXPORT OUTPUT UNION EXTERN
 %token          ENTRYPOINT REFINING ALIGNED
 (* LBRACE_ONERROR CHECK  *)
 %start <Ast.prog> prog
@@ -198,12 +198,12 @@ qident:
   | m=IDENT COLON_COLON n=IDENT    { with_range ({modul_name=Some m.v.name; name=n.v.name}) $startpos }
 
 (*
- * Note that the is_output field is being set to false in the parser
+ * NOTE that the kind is being set to KindSpec here
  *   It is set properly in the desugaring phase
  *)
 typ_no_range:
-  | i=qident { Type_app(i, false, []) }
-  | hd=qident LPAREN a=right_flexible_nonempty_list(COMMA, typ_param) RPAREN { Type_app(hd, false, a) }
+  | i=qident { Type_app(i, KindSpec, []) }
+  | hd=qident LPAREN a=right_flexible_nonempty_list(COMMA, typ_param) RPAREN { Type_app(hd, KindSpec, a) }
 
 typ:
   | t=typ_no_range { with_range t $startpos }
@@ -372,7 +372,7 @@ decl_no_range:
   | MODULE i=IDENT EQ m=IDENT { ModuleAbbrev (i, m) }
   | DEFINE i=IDENT c=constant { Define (i, None, c) }
   | t=IDENT ENUM i=IDENT LBRACE es=right_flexible_nonempty_list(COMMA, enum_case) RBRACE maybe_semi
-    { Enum(with_range (Type_app (t, false, [])) ($startpos(t)), i, es) }
+    { Enum(with_range (Type_app (t, KindSpec, [])) ($startpos(t)), i, es) }
   | b=attributes TYPEDEF t=typ i=IDENT SEMICOLON
     { TypeAbbrev (t, i) }
   | b=attributes TYPEDEF STRUCT i=IDENT ps=parameters w=where_opt
@@ -391,12 +391,22 @@ decl_no_range:
         let td = mk_td b i j k in
         CaseType(td, ps, (with_range (Identifier e) ($startpos(i)), cs))
     }
+
   | OUTPUT TYPEDEF STRUCT i=IDENT
     LBRACE out_flds=right_flexible_nonempty_list(SEMICOLON, out_field) RBRACE
     j=IDENT p=typedef_pointer_name_opt SEMICOLON
     {  let k = pointer_name j p in
        let td = mk_td [] i j k in       
        OutputType ({out_typ_names=td; out_typ_fields=out_flds; out_typ_is_union=false}) }
+
+  | EXTERN TYPEDEF STRUCT i=IDENT j=IDENT
+    {  let k = pointer_name j None in
+       let td = mk_td [] i j k in
+       ExternType td
+    }
+
+  | EXTERN ret=typ i=IDENT ps=parameters
+    { ExternFn (i, ret, ps) }
 
 block_comment_opt:
   |                 { None }

--- a/src/3d/tests/output_types/ExternVector.3d
+++ b/src/3d/tests/output_types/ExternVector.3d
@@ -1,0 +1,17 @@
+extern typedef struct _Vec Vec
+
+extern void Push(mutable Vec *vec, UINT32 x, UINT32 y)
+
+typedef struct _POINT (mutable Vec *vec) {
+  UINT32 x;
+  UINT32 y
+    {:on-success
+	Push (vec, x, y);
+        return true;};
+} POINT;  
+  
+entrypoint
+typedef struct _T(mutable Vec *vec) {
+  UINT8       len;
+  POINT(vec)  arr[:byte-size (UINT32) len * sizeof(POINT)];
+} T;

--- a/src/3d/tests/output_types/ExternVectorDriver.c
+++ b/src/3d/tests/output_types/ExternVectorDriver.c
@@ -1,0 +1,59 @@
+#include<stdio.h>
+#include<stdlib.h>
+
+#include "ExternVector_ExternalTypedefs.h"
+#include "ExternVectorWrapper.h"
+
+void ExternVectorEverParseError(const char *StructName, const char *FieldName, const char *Reason)
+{
+  return;
+}
+
+void Push (Vec *vec, uint32_t x, uint32_t y)
+{
+  if(vec->max == vec->cur) {
+    return;
+  } else {
+    (vec->arr[vec->cur]).x = x;
+    (vec->arr[vec->cur]).y = y;
+    vec->cur = vec->cur+1;    
+  }
+}
+
+Vec *Alloc ()
+{
+  Vec *vec = (Vec *) malloc(sizeof(Vec));
+  vec->max = 2;
+  vec->cur = 0;
+  vec->arr = (Point *) malloc(sizeof(Point) * 2);
+  return vec;
+}
+
+int main ()
+{
+  uint8_t *data = malloc(sizeof(uint8_t) + sizeof(uint32_t) * 6);
+  data[0] = 3;
+  uint32_t *arr = (uint32_t *) (data + 1);
+  arr[0] = 0;
+  arr[1] = 1;
+  arr[2] = 2;
+  arr[3] = 3;
+  arr[4] = 4;
+  arr[5] = 5;
+
+  Vec *vec = Alloc();
+  
+  BOOLEAN b = ExternVectorCheckT(vec, (uint8_t *) data, sizeof(uint8_t) + sizeof(uint32_t) * 6);
+  if(b &&
+     vec->cur == 2      &&
+     vec->arr[0].x == 0 &&
+     vec->arr[0].y == 1 &&
+     vec->arr[1].x == 2 &&
+     vec->arr[1].y == 3) {
+    printf("%s\n", "Validation succeeded");
+    return 0;
+  } else {
+    printf("%s\n", "Validation failed");
+    return 1;
+  }
+}

--- a/src/3d/tests/output_types/ExternVectorDriver.c
+++ b/src/3d/tests/output_types/ExternVectorDriver.c
@@ -50,10 +50,10 @@ int main ()
      vec->arr[0].y == 1 &&
      vec->arr[1].x == 2 &&
      vec->arr[1].y == 3) {
-    printf("%s\n", "Validation succeeded");
+    printf("%s\n", "Validation succeeded for extern vector");
     return 0;
   } else {
-    printf("%s\n", "Validation failed");
+    printf("%s\n", "Validation failed for extern vector");
     return 1;
   }
 }

--- a/src/3d/tests/output_types/ExternVector_ExternalTypedefs.h
+++ b/src/3d/tests/output_types/ExternVector_ExternalTypedefs.h
@@ -1,0 +1,18 @@
+#ifndef _ExternVector_ExternalTypedefs_H
+#define _ExternVector_ExternalTypedefs_H
+
+#include<stdint.h>
+
+typedef struct _Point {
+  uint32_t x;
+  uint32_t y;
+} Point;
+
+
+typedef struct _Vec {
+  uint8_t max;
+  uint8_t cur;
+  Point   *arr;
+} Vec;
+
+#endif

--- a/src/3d/tests/output_types/Makefile
+++ b/src/3d/tests/output_types/Makefile
@@ -10,19 +10,25 @@ basic: $(SOURCE_FILES) basic.out
 	$(EVERPARSE_CMD) --batch TPoint.3d --odir basic.out
 	$(EVERPARSE_CMD) --batch AnonUnion.3d --odir basic.out
 	$(EVERPARSE_CMD) --batch AnonStruct.3d --odir basic.out
+	$(EVERPARSE_CMD) --batch ExternVector.3d --odir basic.out
 	g++ -o basic.out/test1 -I basic.out $(addprefix basic.out/, AnonStruct_OutputTypes.c AnonStruct.c AnonStructWrapper.c) TestAnonStruct.cpp
 	./basic.out/test1
 	g++ -o basic.out/test2 -I basic.out $(addprefix basic.out/, TPoint_OutputTypes.c TPoint.c TPointWrapper.c) TestTPoint.cpp
 	./basic.out/test2
+	gcc -o basic.out/test3 -I basic.out -I . $(addprefix basic.out/, ExternVector.c ExternVectorWrapper.c) ExternVectorDriver.c
+	./basic.out/test3
 
 interpret: $(SOURCE_FILES) interpret.out
 	$(EVERPARSE_CMD) --batch TPoint.3d --interpret --odir interpret.out
 	$(EVERPARSE_CMD) --batch AnonUnion.3d --interpret --odir interpret.out
 	$(EVERPARSE_CMD) --batch AnonStruct.3d --interpret --odir interpret.out
+	$(EVERPARSE_CMD) --batch ExternVector.3d --interpret --odir interpret.out
 	g++ -o interpret.out/test1 -I interpret.out $(addprefix interpret.out/, AnonStruct_OutputTypes.c AnonStruct.c AnonStructWrapper.c) TestAnonStruct.cpp
 	./interpret.out/test1
 	g++ -o interpret.out/test2 -I interpret.out $(addprefix interpret.out/, TPoint_OutputTypes.c TPoint.c TPointWrapper.c) TestTPoint.cpp
 	./interpret.out/test2
+	gcc -o interpret.out/test3 -I interpret.out -I . $(addprefix interpret.out/, ExternVector.c ExternVectorWrapper.c) ExternVectorDriver.c
+	./interpret.out/test3
 
 FSTAR_HOME ?= $(realpath ../../../../../FStar)
 export FSTAR_HOME


### PR DESCRIPTION
## Overview

This PR adds support for extern types and and actions in 3d, see here for a testcase: https://github.com/project-everest/everparse/commit/f8d4a460f0b65272c7cde42a3e2f44c746fd15c8.

With extern types, a 3d specification may contain uninterpreted typedefs and function declarations that can be used in the parsing actions. The 3d toolchain translates uses of these typedefs and function declarations as is to the C code, where they are linked with their programmer specified C implementations. This enables following kind of examples, where the programmer may parse a variable length array of `Point` structs to a `vector`:

```
extern typedef struct _Vec Vec

extern void Push(mutable Vec *vec, UINT32 x, UINT32 y)

typedef struct _POINT (mutable Vec *vec) {
  UINT32 x;
  UINT32 y
    {:on-success
	Push (vec, x, y);
        return true;};
} POINT;  

entrypoint
typedef struct _T(mutable Vec *vec) {
  UINT8       len;
  POINT(vec)  arr[:byte-size (UINT32) len * sizeof(POINT)];
} T;
```

## Syntax for extern declarations

The PR adds to 3d syntax two kinds of extern declarations: extern types and extern functions. Both follow the corresponding C syntax.

## Providing C implementations of extern declarations

The PR unifies the handling of external API between output types and extern types, both of which are quite similar features.

The following applies only when the 3d spec uses extern or output types; if it doesn't, the files/includes mentioned below are not generated.

### F* interface for external API

If a 3d module `M` uses extern or output types, 3d generates an `M_ExternalAPI.fsti` containing F* declarations for them.

### C header for external types (extern and output)

If a 3d module `M` uses extern or output types, 3d adds a `#include "M_ExternalTypedefs.h"` in the generated C code. Programmer is expected to provide the C types for their extern and output types in this file.

For output types, if the `--emit_output_typedefs` flag is set, then 3d generates output types definitions in the `M_OutputTypesDefs.h` file.

There are a few cases when 3d will automatically generate `M_ExternTypedefs.h` too:

- When the 3d spec uses extern functions, no extern types, and no output types, 3d generates an empty `M_ExternTypedefs.h`, since there are no type definitions expected from the programmer.
- When the programmer uses output types, no extern types, maybe extern functions, with the flag `--emit_output_typedefs true`, then 3d generates `M_ExternalTypedefs.h` that only includes `M_OutputTypesDefs.h`.

For cases where the programmer uses both output types and extern types, with `--emit_output_typedefs` flag, programmer may manually include `M_OutputTypesDefs.h` in the `M_ExternalTypedefs.h`.