### PR TITLE
Fail if input file name does not start with a capital letter, end with .3d

### DIFF
--- a/doc/3d.rst
+++ b/doc/3d.rst
@@ -189,11 +189,15 @@ right-most options. Thus, any ``--no_clang_format`` will override any
 occurrence of ``--clang_format`` or ``--clang_format_executable`` to
 its left, and vice-versa.
 
-You can provide one or more ``input_files`` to EverParse. They must
-all bear the ``.3d`` file name extension, and their names must start
-with a capital letter. Then, ``EverParse.h`` and
-``EverParseEndianness.h`` will be shared across ``.c`` and ``.h``
-files produced for all the ``.3d`` files that you provided.
+You can provide one or more ``input_files`` to EverParse. Then,
+``EverParse.h`` and ``EverParseEndianness.h`` will be shared across
+``.c`` and ``.h`` files produced for all the ``.3d`` files that you
+provided.
+
+.. note::
+
+  EverParse input files must all bear the ``.3d`` file name extension,
+  and their names must start with a capital letter.
 
 Alternate mode: generating a Makefile
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/3d/Options.fst
+++ b/src/3d/Options.fst
@@ -345,10 +345,19 @@ let split_3d_file_name fn =
 
 let get_file_name mname = mname ^ ".3d"
 
+let starts_with_capital (s: string) : Tot bool =
+  String.length s >= 1 &&
+  begin let first = String.sub s 0 1 in
+    String.compare first "A" >= 0 && String.compare first "Z" <= 0
+  end
+
 let get_module_name (file: string) =
     match split_3d_file_name file with
-    | Some nm -> nm
-    | None -> "DEFAULT"
+    | Some nm ->
+      if starts_with_capital nm
+      then nm
+      else failwith (Printf.sprintf "Input file name %s must start with a capital letter" file)
+    | None -> failwith (Printf.sprintf "Input file name %s must end with .3d" file)
 
 let get_output_dir () =
   match !output_dir with


### PR DESCRIPTION
This PR resolves #68 , by clarifying the behavior of EverParse for the following example (expected to fail):
```
$ cat test1.3d
entrypoint typedef struct _point {
  UINT16 x;
  UINT16 y;
} point;
$ everparse.sh test1.3d
```
Previously, this failed with an obscure error message coming from the underlying call to F*. Now, with this PR, the example fails with a clearer error message:

```
Fatal error: exception (Failure "Input file name test1.3d must start with a capital letter")
```

Similarly, I also check that an input file name ends with `.3d`

I also made these points more prominent in the online documentation for command-line options: a highlighted note mandates input file names to start with a capital letter and end with `.3d`

