### PR TITLE
Some changes to the EverParse nuget package

### DIFF
--- a/src/package/EverParse.nuspec
+++ b/src/package/EverParse.nuspec
@@ -14,6 +14,7 @@
 		<tags>native everparse</tags>
 	</metadata>
 	<files>
-		<file src="content\**" target="lib"/>
+		<file src="content\win-x86_64\README" target="README"/>
+		<file src="content\**" target="lib\native"/>
 	</files>
 </package>

--- a/src/package/EverParse.nuspec
+++ b/src/package/EverParse.nuspec
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package >
-  <metadata>
-    <id>EverParse</id>
-    <version>1.0.0</version>
-    <authors>aseemr</authors>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <license type="expression">MIT</license>
-    <projectUrl>https://project-everest.github.io/everparse/</projectUrl>
-    <description>EverParse: verified parsing for binary data formats</description>
-    <releaseNotes>Nuget package for EverParse</releaseNotes>
-    <copyright>Microsoft Research</copyright>
-    <tags>native</tags>
-  </metadata>
+<package>
+	<metadata>
+		<title>EverParse</title>
+		<id>EverParse</id>
+		<version>1.0.0</version>
+		<authors>EverParse Contributors</authors>
+		<requireLicenseAcceptance>false</requireLicenseAcceptance>
+		<license type="expression">MIT</license>
+		<projectUrl>https://project-everest.github.io/everparse/</projectUrl>
+		<description>EverParse: verified parsing for binary data formats</description>
+		<releaseNotes>Nuget package for EverParse</releaseNotes>
+		<copyright>Microsoft Research</copyright>
+		<tags>native everparse</tags>
+	</metadata>
+	<files>
+		<file src="content\**" target="lib"/>
+	</files>
 </package>

--- a/src/package/package.sh
+++ b/src/package/package.sh
@@ -367,17 +367,14 @@ zip_everparse() {
         # Run the pack command
         pushd $nuget_base
 
-        if [[ $everparse_commit != $everparse_last_version ]] ; then
-            # If no tag was set, then skip nuget package version
-            everparse_nuget_version=
-        else
-	    # Strip off the first v
-	    everparse_nuget_version="-Version ${everparse_version:1}"
-        fi
+
+	if [[ -z "$everparse_nuget_version" ]] ; then
+		everparse_nuget_version=1.0.0
+	fi
 	# NoDefaultExcludes for .clang-format file that nuget pack excludes
-        ../nuget.exe pack -OutputFileNamesWithoutVersion -NoDefaultExcludes $everparse_nuget_version ./EverParse.nuspec
+        ../nuget.exe pack -OutputFileNamesWithoutVersion -NoDefaultExcludes -Version $everparse_nuget_version ./EverParse.nuspec
         cp EverParse.nupkg ..
-        if $with_version ; then mv ../EverParse.nupkg ../EverParse_"$everparse_version"_"$OS"_"$platform".nupkg ; fi
+        if $with_version ; then mv ../EverParse.nupkg ../EverParse."$everparse_nuget_version".nupkg ; fi
         popd
     fi
     # Not doing any cleanup in the spirit of existing package

--- a/src/package/release.sh
+++ b/src/package/release.sh
@@ -35,12 +35,15 @@ git pull $remote $branchname --ff-only
 everparse_version=$(cat $EVERPARSE_HOME/version.txt)
 everparse_last_version=$(git show --no-patch --format=%h $everparse_version || true)
 everparse_commit=$(git show --no-patch --format=%h)
+everparse_nuget_version=1.0.0
 if [[ $everparse_commit != $everparse_last_version ]] ; then
     everparse_version=$($DATE '+v%Y.%m.%d')
     echo $everparse_version > $EVERPARSE_HOME/version.txt
     git add $EVERPARSE_HOME/version.txt
     git commit -m "Release $everparse_version"
     git tag $everparse_version
+    #strip the v
+    everparse_nuget_version=${everparse_version:1}
 fi
 
 src/package/package.sh -zip
@@ -73,5 +76,5 @@ upload_archive everparse_"$everparse_version"_"$OS"_"$platform""$ext"
 
 if $is_windows ; then
     # Also upload the NuGet package to GitHub releases
-    upload_archive EverParse_"$everparse_version"_"$OS"_"$platform".nupkg
+    upload_archive EverParse."$everparse_nuget_version".nupkg
 fi


### PR DESCRIPTION
- Packaging it in a `lib` directory to avoid copying the files in the VS solution.
- Renaming the package EverParse.<version#>.nupkg
- 