### PR TITLE
Fix for a change to term_eq in F*

### DIFF
--- a/doc/3d-snapshot/Color.h
+++ b/doc/3d-snapshot/Color.h
@@ -12,17 +12,17 @@ extern "C" {
 
 
 #include "EverParse.h"
-/*
+/**
 Enum constant
 */
 #define COLOR_RED ((uint32_t)1U)
 
-/*
+/**
 Enum constant
 */
 #define COLOR_GREEN ((uint32_t)2U)
 
-/*
+/**
 Enum constant
 */
 #define COLOR_BLUE ((uint32_t)42U)

--- a/doc/3d-snapshot/EnumConstraint.h
+++ b/doc/3d-snapshot/EnumConstraint.h
@@ -12,17 +12,17 @@ extern "C" {
 
 
 #include "EverParse.h"
-/*
+/**
 Enum constant
 */
 #define ENUMCONSTRAINT_RED ((uint32_t)1U)
 
-/*
+/**
 Enum constant
 */
 #define ENUMCONSTRAINT_GREEN ((uint32_t)2U)
 
-/*
+/**
 Enum constant
 */
 #define ENUMCONSTRAINT_BLUE ((uint32_t)42U)

--- a/src/lowparse/LowParse.Spec.Tac.Sum.fst
+++ b/src/lowparse/LowParse.Spec.Tac.Sum.fst
@@ -68,15 +68,15 @@ let synth_case_recip_pre_tac
 noextract
 let rec dep_enum_destr_tac () : T.Tac unit =
   let (goal_fun, goal_arg) = T.app_head_tail (T.cur_goal ()) in
-  let _ = T.tassert (goal_fun `T.term_eq` (`dep_enum_destr)) in
+  let _ = T.tassert (goal_fun `T.is_fvar` (`%dep_enum_destr)) in
   match goal_arg with
   | [_; _; (te, _); _] ->
     let (te_fun, te_arg) = T.app_head_tail (T.norm_term [delta; iota; zeta] te) in
-    let _ = T.tassert (te_fun `T.term_eq` (`Cons)) in
+    let _ = T.tassert (te_fun `T.is_fvar` (`%Cons)) in
     begin match te_arg with
     | [_; _; (tl, _)] ->
       let (tl_fun, _) = T.app_head_tail tl in
-      if tl_fun `T.term_eq` (`Cons)
+      if tl_fun `T.is_fvar` (`%Cons)
       then begin
         T.apply (`dep_enum_destr_cons);
         T.iseq [
@@ -85,7 +85,7 @@ let rec dep_enum_destr_tac () : T.Tac unit =
         ];
         T.qed ()
       end
-      else if tl_fun `T.term_eq` (`Nil)
+      else if tl_fun `T.is_fvar` (`%Nil)
       then begin
         T.apply (`dep_enum_destr_cons_nil);
         T.trivial ();
@@ -99,16 +99,16 @@ let rec dep_enum_destr_tac () : T.Tac unit =
 noextract
 let rec maybe_enum_destr_t'_tac () : T.Tac unit =
   let (goal_fun, goal_arg) = T.app_head_tail (T.cur_goal ()) in
-  let _ = T.tassert (goal_fun `T.term_eq` (`maybe_enum_destr_t')) in
+  let _ = T.tassert (goal_fun `T.is_fvar` (`%maybe_enum_destr_t')) in
   match goal_arg with
   | [_; _; _; _; (tl1, _); (tl2, _); _] ->
     let (tl2_fun, _) = T.app_head_tail (T.norm_term [delta; iota; zeta] tl2) in
-    if tl2_fun `T.term_eq` (`Cons)
+    if tl2_fun `T.is_fvar` (`%Cons)
     then begin
       T.apply (`maybe_enum_destr_cons);
       maybe_enum_destr_t'_tac ()
     end else
-    if tl2_fun `T.term_eq` (`Nil)
+    if tl2_fun `T.is_fvar` (`%Nil)
     then begin
       T.apply (`maybe_enum_destr_nil);
       T.qed ()
@@ -119,23 +119,23 @@ let rec maybe_enum_destr_t'_tac () : T.Tac unit =
 noextract
 let maybe_enum_destr_t_tac () : T.Tac unit =
   let (goal_fun, _) = T.app_head_tail (T.cur_goal ()) in
-  let _ = T.tassert (goal_fun `T.term_eq` (`maybe_enum_destr_t)) in
+  let _ = T.tassert (goal_fun `T.is_fvar` (`%maybe_enum_destr_t)) in
   T.apply (`maybe_enum_destr_t_intro);
   maybe_enum_destr_t'_tac ()
 
 noextract
 let rec dep_maybe_enum_destr_t'_tac () : T.Tac unit =
   let (goal_fun, goal_arg) = T.app_head_tail (T.cur_goal ()) in
-  let _ = T.tassert (goal_fun `T.term_eq` (`dep_maybe_enum_destr_t')) in
+  let _ = T.tassert (goal_fun `T.is_fvar` (`%dep_maybe_enum_destr_t')) in
   match goal_arg with
   | [_; _; _; _; (tl1, _); (tl2, _); _] ->
     let (tl2_fun, _) = T.app_head_tail (T.norm_term [delta; iota; zeta] tl2) in
-    if tl2_fun `T.term_eq` (`Cons)
+    if tl2_fun `T.is_fvar` (`%Cons)
     then begin
       T.apply (`dep_maybe_enum_destr_cons);
       dep_maybe_enum_destr_t'_tac ()
     end else
-    if tl2_fun `T.term_eq` (`Nil)
+    if tl2_fun `T.is_fvar` (`%Nil)
     then begin
       T.apply (`dep_maybe_enum_destr_nil);
       T.qed ()
@@ -146,7 +146,7 @@ let rec dep_maybe_enum_destr_t'_tac () : T.Tac unit =
 noextract
 let dep_maybe_enum_destr_t_tac () : T.Tac unit =
   let (goal_fun, _) = T.app_head_tail (T.cur_goal ()) in
-  let _ = T.tassert (goal_fun `T.term_eq` (`dep_maybe_enum_destr_t)) in
+  let _ = T.tassert (goal_fun `T.is_fvar` (`%dep_maybe_enum_destr_t)) in
   T.apply (`dep_maybe_enum_destr_t_intro);
   dep_maybe_enum_destr_t'_tac ()
 

--- a/src/lowparse/LowParse.TacLib.fst
+++ b/src/lowparse/LowParse.TacLib.fst
@@ -26,23 +26,9 @@ let solve_vc ()
 = exact_guard (quote ()); conclude ()
 
 [@@ noextract_to "krml"]
-let rec app_head_rev_tail (t: term) :
-  Tac (term * list argv)
-=
-  let ins = inspect t in
-  if Tv_App? ins
-  then
-    let (Tv_App u v) = ins in
-    let (x, l) = app_head_rev_tail u in
-    (x, v :: l)
-  else
-    (t, [])
-
-[@@ noextract_to "krml"]
 let app_head_tail (t: term) :
     Tac (term * list argv)
-= let (x, l) = app_head_rev_tail t in
-  (x, L.rev l)
+= collect_app t
 
 [@@ noextract_to "krml"]
 let tassert (b: bool) : Tac (squash b) =

--- a/src/lowparse/LowParse.TacLib.fst
+++ b/src/lowparse/LowParse.TacLib.fst
@@ -65,7 +65,7 @@ let rec intros_until_squash
 : Tac binder
 = let i = intro () in
   let (tm, _) = app_head_tail (cur_goal ()) in
-  if tm `term_eq` (`squash)
+  if tm `is_fvar` (`%squash)
   then i
   else intros_until_squash ()
 
@@ -76,11 +76,11 @@ let rec intros_until_eq_hyp
 = let i = intro () in
   let (sq, ar) = app_head_tail (type_of_binder i) in
   let cond =
-    if sq `term_eq` (`squash) then
+    if sq `is_fvar` (`%squash) then
       match ar with
       | (ar1, _) :: _ ->
         let (eq, _) = app_head_tail ar1 in
-        eq `term_eq` (`eq2)
+        eq `is_fvar` (`%eq2)
       | _ -> false
     else false
   in


### PR DESCRIPTION
When FStarLang/FStar#2730 is merged, `term_eq` will have some slight differences in behavior. In particular it will not ignore universes any more so I believe most calls here will fail. Since these calls are meant to check if a term is equal to some particular top-level name, replace them with `is_fvar`.

**Note**: this function does not currently exist in F* (it is added by that same PR), so this should only be merged after that.

I got a local everest green with the updated F* and the patched everparse (no changes needed to other projects).

------

LowParse: tactics: remove calls to term_eq, use is_fvar instead

`term_eq` received some fixes in F* (such as honoring universes) that cause some failures here. The old behavior is accessible via a (Tac) primitive `term_eq_old`. but these calls are meant to decide if a term is equal to some given top-level name, so just use `is_fvar` instead.
