### PR TITLE
A flag to workaround a heisenbug; investigating that separately

### DIFF
--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -22,7 +22,7 @@ FSTAR_OPTIONS = --odir krml --cache_dir $(CACHE_DIR) $(LAX_OPT) --cache_checked_
 		--already_cached +Prims,+FStar,+LowStar,+C,+Spec.Loops,+LowParse \
 		--include $(LOWPARSE_HOME) --include $(KRML_HOME)/krmllib --include $(KRML_HOME)/krmllib/obj --include .. --cmi
 
-FSTAR = $(FSTAR_HOME)/bin/fstar.exe --trace_error $(FSTAR_OPTIONS)
+FSTAR = $(FSTAR_HOME)/bin/fstar.exe --trace_error --ugly $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 


### PR DESCRIPTION
This is a patch to work around a weird bug, likely due to some small discrepancies in evaluation order, that we have been trying to isolate. 

This is needed to get an Everest green on F* PR  2827

Heads up at @mtzguido @tahina-pro 