### PR TITLE
F*+dune: new F* library layout, improved handling of FSTAR_HOME

### DIFF
--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -4,7 +4,7 @@
     "BaseContainerIsEverestImage" : true,
     "BaseContainerImageName" : "fstar",
     "BaseContainerImageTagOrCommitId": "latest",
-    "BranchName" : "_taramana_dune",
+    "BranchName" : "master",
     "GithubCommitUrl" : "https://github.com/FStarLang/FStar/commit",
     "OnDemandBuildDefinition" : "FStar\\FStar-{agentOS}",
 
@@ -30,6 +30,6 @@
     "RepoVersions" : {
         "mitls_version" : "origin/dev",
         "hacl_version" : "origin/main",
-        "karamel_version" : "origin/taramana_fstar_dune"
+        "karamel_version" : "origin/master"
     }
 }

--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -4,7 +4,7 @@
     "BaseContainerIsEverestImage" : true,
     "BaseContainerImageName" : "fstar",
     "BaseContainerImageTagOrCommitId": "latest",
-    "BranchName" : "master",
+    "BranchName" : "_taramana_dune",
     "GithubCommitUrl" : "https://github.com/FStarLang/FStar/commit",
     "OnDemandBuildDefinition" : "FStar\\FStar-{agentOS}",
 
@@ -30,6 +30,6 @@
     "RepoVersions" : {
         "mitls_version" : "origin/dev",
         "hacl_version" : "origin/main",
-        "karamel_version" : "origin/master"
+        "karamel_version" : "origin/taramana_fstar_dune"
     }
 }

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,7 +4,19 @@
 all: html 3d
 
 export EVERPARSE_HOME?=$(realpath ..)
-export FSTAR_HOME?=$(realpath $(EVERPARSE_HOME)/../FStar)
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
+
 export KRML_HOME?=$(realpath $(EVERPARSE_HOME)/../karamel)
 
 3D=$(EVERPARSE_HOME)/bin/3d.exe

--- a/src/3d/Makefile
+++ b/src/3d/Makefile
@@ -1,7 +1,20 @@
 ROOT=Main.fst
-FSTAR_HOME?=$(realpath ../../../FStar)
-KRML_HOME?=$(realpath ../../../karamel)
+
 EVERPARSE_HOME=$(realpath ../..)
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+endif
+export FSTAR_HOME
+
+export KRML_HOME?=$(realpath ../../../karamel)
 
 INCLUDE_PATHS=
 OTHERFLAGS?=

--- a/src/3d/ocaml/Makefile
+++ b/src/3d/ocaml/Makefile
@@ -1,16 +1,26 @@
-FSTAR_HOME ?= $(realpath ../../../../FStar)
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath ../../../../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
 
 ifeq ($(OS),Windows_NT)
-  OCAMLPATH := $(shell cygpath -m $(FSTAR_HOME)/bin);$(OCAMLPATH)
+  OCAMLPATH := $(shell cygpath -m $(FSTAR_HOME)/lib);$(OCAMLPATH)
 else
-  OCAMLPATH := $(FSTAR_HOME)/bin:$(OCAMLPATH)
+  OCAMLPATH := $(FSTAR_HOME)/lib:$(OCAMLPATH)
 endif
 export OCAMLPATH
 
 all: generated/FStar_Getopt.ml $(filter-out %~,$(wildcard *.ml*)) dune
 	dune build
 
-generated/FStar_Getopt.ml: $(FSTAR_HOME)/src/basic/ml/FStar_Getopt.ml
+generated/FStar_Getopt.ml: $(FSTAR_HOME)/ocaml/fstar-lib/FStar_Getopt.ml
 	mkdir -p $(dir $@)
 	cp $^ $@
 

--- a/src/3d/ocaml/Makefile
+++ b/src/3d/ocaml/Makefile
@@ -17,12 +17,8 @@ else
 endif
 export OCAMLPATH
 
-all: generated/FStar_Getopt.ml $(filter-out %~,$(wildcard *.ml*)) dune
+all: $(filter-out %~,$(wildcard *.ml*)) dune
 	dune build
-
-generated/FStar_Getopt.ml: $(FSTAR_HOME)/ocaml/fstar-lib/FStar_Getopt.ml
-	mkdir -p $(dir $@)
-	cp $^ $@
 
 clean-local:
 	rm -rf _build *~ dune dune.tmp

--- a/src/3d/ocaml/dune.tmpl
+++ b/src/3d/ocaml/dune.tmpl
@@ -11,7 +11,7 @@
   (libraries
     batteries
     menhirLib
-    fstarlib
+    fstar.lib
     process
 #ifdef NO_EVERCRYPT
     sha

--- a/src/3d/prelude/Makefile
+++ b/src/3d/prelude/Makefile
@@ -1,9 +1,21 @@
 all: verify buffer extern
 
-FSTAR_HOME?=$(realpath ../../../../FStar)
+EVERPARSE_HOME=$(realpath ../../..)
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
+
 KRML_HOME?=$(realpath ../../../../karamel)
 OTHERFLAGS?=
-EVERPARSE_HOME=$(realpath ../../..)
 
 FSTAR_OPTIONS=$(addprefix --include , $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib $(KRML_HOME)/krmllib/obj) --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=10'
 #--z3cliopt 'smt.arith.nl=false' --smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr wrapped

--- a/src/3d/prelude/buffer/Makefile
+++ b/src/3d/prelude/buffer/Makefile
@@ -1,9 +1,21 @@
 all: extract
 
-FSTAR_HOME?=$(realpath ../../../../../FStar)
+EVERPARSE_HOME=$(realpath ../../../..)
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
+
 KRML_HOME?=$(realpath ../../../../../karamel)
 OTHERFLAGS?=
-EVERPARSE_HOME=$(realpath ../../../..)
 
 FSTAR_OPTIONS=$(addprefix --include , .. $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib $(KRML_HOME)/krmllib/obj) --z3rlimit_factor 8 --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=100'
 FSTAR=$(FSTAR_HOME)/bin/fstar.exe $(FSTAR_OPTIONS) $(OTHERFLAGS) --cmi

--- a/src/3d/prelude/extern/Makefile
+++ b/src/3d/prelude/extern/Makefile
@@ -1,9 +1,21 @@
 all: extract
 
-FSTAR_HOME?=$(realpath ../../../../../FStar)
+EVERPARSE_HOME=$(realpath ../../../..)
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
+
 KRML_HOME?=$(realpath ../../../../../karamel)
 OTHERFLAGS?=
-EVERPARSE_HOME=$(realpath ../../../..)
 
 FSTAR_OPTIONS=$(addprefix --include , .. $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib $(KRML_HOME)/krmllib/obj) --z3rlimit_factor 8 --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=100'
 FSTAR=$(FSTAR_HOME)/bin/fstar.exe $(FSTAR_OPTIONS) $(OTHERFLAGS) --cmi

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -6,8 +6,17 @@ export EVERPARSE_HOME
 KRML_HOME ?= $(realpath ../../../../karamel)
 export KRML_HOME
 
-FSTAR_HOME ?= $(realpath ../../../../FStar)
-export FSTAR_HOME
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
 
 INCLUDES=$(EVERPARSE_HOME)/src/3d/prelude $(EVERPARSE_HOME)/src/3d/prelude/buffer $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib/obj $(KRML_HOME)/krmllib
 

--- a/src/3d/tests/output_types/Makefile
+++ b/src/3d/tests/output_types/Makefile
@@ -37,8 +37,17 @@ interpret: $(SOURCE_FILES) interpret.out
 	gcc -o interpret.out/test3 -I interpret.out -I . $(addprefix interpret.out/, ExternVector.c ExternVectorWrapper.c) ExternVectorDriver.c
 	./interpret.out/test3
 
-FSTAR_HOME ?= $(realpath ../../../../../FStar)
-export FSTAR_HOME
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
 
 INCLUDES=$(EVERPARSE_HOME)/src/3d/prelude $(EVERPARSE_HOME)/src/3d/prelude/buffer $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib/obj $(KRML_HOME)/krmllib
 

--- a/src/3d/tests/output_types/modules_batch/Makefile
+++ b/src/3d/tests/output_types/modules_batch/Makefile
@@ -9,8 +9,18 @@ basic: $(SOURCE_FILES) basic.out
 	$(EVERPARSE_CMD) --batch AA.3d BB.3d CC.3d --odir basic.out --no_emit_output_types_defs --add_include \"AA_ExternalTypedefs.h\"
 	g++ -o basic.out/test -I . -I basic.out $(addprefix basic.out/, BB_OutputTypes.c CC_OutputTypes.c BB.c CC.c BBWrapper.c CCWrapper.c) Test.cpp
 	./basic.out/test
-FSTAR_HOME ?= $(realpath ../../../../../FStar)
-export FSTAR_HOME
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
 
 INCLUDES=$(EVERPARSE_HOME)/src/3d/prelude $(EVERPARSE_HOME)/src/3d/prelude/buffer $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib/obj $(KRML_HOME)/krmllib
 

--- a/src/lowparse/Makefile
+++ b/src/lowparse/Makefile
@@ -7,23 +7,23 @@
 all: verify-all
 
 ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
+  FSTAR_EXE:=$(shell which fstar.exe)
   ifneq ($(.SHELLSTATUS),0)
     FSTAR_HOME=$(realpath ../../../FStar)
   endif
 endif
 ifdef FSTAR_HOME
-  FSTAR_EXE=$(FSTAR_HOME)/bin/fstar.exe
+  FSTAR_EXE:=$(FSTAR_HOME)/bin/fstar.exe
 endif
 
 ifndef KRML_HOME
-  KRMLLIB=$(shell ocamlfind query karamel)
+  KRMLLIB:=$(shell ocamlfind query karamel)
   ifneq ($(.SHELLSTATUS),0)
     KRML_HOME=$(realpath ../../../karamel)
   endif
 endif
 ifdef KRML_HOME
-  KRMLLIB=$(KRML_HOME)/krmllib
+  KRMLLIB:=$(KRML_HOME)/krmllib
 endif
 INCLUDE_KRML=--include $(KRMLLIB) --include $(KRMLLIB)/obj
 

--- a/tests/bitfields/Makefile.common
+++ b/tests/bitfields/Makefile.common
@@ -1,9 +1,20 @@
-FSTAR_HOME ?= ../../../FStar
-KRML_HOME ?= ../../../karamel
 EVERPARSE_HOME ?= $(realpath ../..)
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
+
+KRML_HOME ?= ../../../karamel
 LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
 
-export FSTAR_HOME
 export LOWPARSE_HOME
 export KRML_HOME
 export EVERPARSE_HOME

--- a/tests/lowparse/Makefile
+++ b/tests/lowparse/Makefile
@@ -5,23 +5,23 @@ LOWPARSE_HOME ?= ../../src/lowparse
 FSTAR_OUT_DIR?=.fstar-out
 
 ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
+  FSTAR_EXE:=$(shell which fstar.exe)
   ifneq ($(.SHELLSTATUS),0)
     FSTAR_HOME=../../../FStar
   endif
 endif
 ifdef FSTAR_HOME
-  FSTAR_EXE=$(FSTAR_HOME)/bin/fstar.exe
+  FSTAR_EXE:=$(FSTAR_HOME)/bin/fstar.exe
 endif
 
 ifndef KRML_HOME
-  KRMLLIB=$(shell ocamlfind query karamel)
+  KRMLLIB:=$(shell ocamlfind query karamel)
   ifneq ($(.SHELLSTATUS),0)
     KRML_HOME=../../../karamel
   endif
 endif
 ifdef KRML_HOME
-  KRMLLIB=$(KRML_HOME)/krmllib
+  KRMLLIB:=$(KRML_HOME)/krmllib
   KRML_EXE=$(KRML_HOME)/krml
 else
   KRML_EXE=krml

--- a/tests/sample/Makefile.common
+++ b/tests/sample/Makefile.common
@@ -1,9 +1,20 @@
-FSTAR_HOME ?= ../../../FStar
-KRML_HOME ?= ../../../karamel
 EVERPARSE_HOME ?= ../..
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
+
+KRML_HOME ?= ../../../karamel
 LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
 
-export FSTAR_HOME
 export LOWPARSE_HOME
 export KRML_HOME
 export EVERPARSE_HOME

--- a/tests/sample0/Makefile.common
+++ b/tests/sample0/Makefile.common
@@ -1,9 +1,20 @@
-FSTAR_HOME ?= ../../../FStar
-KRML_HOME ?= ../../../karamel
 EVERPARSE_HOME ?= ../..
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
+
+KRML_HOME ?= ../../../karamel
 LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
 
-export FSTAR_HOME
 export LOWPARSE_HOME
 export KRML_HOME
 export EVERPARSE_HOME

--- a/tests/sample_client/Makefile
+++ b/tests/sample_client/Makefile
@@ -1,6 +1,18 @@
 PREFIX=Sample.AutoGen_
 EVERPARSE_HOME=../..
-FSTAR_HOME?=../../../FStar
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
+
 LOWPARSE_HOME?=$(EVERPARSE_HOME)/src/lowparse
 INCLUDES=$(KRML_HOME)/krmllib \
 	$(KRML_HOME)/krmllib/obj \

--- a/tests/sample_low/Makefile.common
+++ b/tests/sample_low/Makefile.common
@@ -1,9 +1,20 @@
-FSTAR_HOME ?= ../../../FStar
-KRML_HOME ?= ../../../karamel
 EVERPARSE_HOME ?= ../..
+
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
+
+KRML_HOME ?= ../../../karamel
 LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
 
-export FSTAR_HOME
 export LOWPARSE_HOME
 export KRML_HOME
 export EVERPARSE_HOME

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -1,4 +1,15 @@
-FSTAR_HOME ?= ../../../FStar
+ifndef FSTAR_HOME
+  FSTAR_EXE=$(shell which fstar.exe)
+  ifeq ($(FSTAR_EXE),)
+    # fstar.exe not found in PATH, assuming Everest source tree
+    FSTAR_HOME=$(realpath ../../../FStar)
+  else
+    # fstar.exe found in PATH, assuming directory ending with /bin
+    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+  endif
+  export FSTAR_HOME
+endif
+
 LOWPARSE_HOME ?= ../../src/lowparse
 KRML_HOME ?= ../../../karamel
 


### PR DESCRIPTION
This PR is a companion to FStarLang/FStar#2815
With F* being built with `dune`, its library is now organized differently: `fstar-lib`, `fstar-compiler-lib` and `fstar-tactics-lib` are now merged into `fstar.lib` located in `$FSTAR_HOME/lib/fstar/lib/fstar_lib.cmx*` instead of `$FSTAR_HOME/bin/*.cmx*` So this PR fixes the dune builds for qd.exe and 3d.exe accordingly. In this process, FStar_Getopt.ml need no longer be copied from the F* sources, since it is already implemented in fstar.lib

This PR also improves the handling of the `FSTAR_HOME` environment variable in Makefiles, so that EverParse can now be compiled and tested even if F* is installed from opam (or with `make install`), with `fstar.exe` in the `PATH`, so that the user need no longer set `FSTAR_HOME` in such cases.

I have an Everest branch reporting green CI (cf. project-everest/everest@925043549b2573160e93a23fab3abd10f969e70a) with this PR and the corresponding F* and Karamel PRs (FStarLang/Karamel#333)