### PR TITLE
EverParse3d.InputStream.Extern.fst: proof maintenance

### DIFF
--- a/src/3d/prelude/extern/EverParse3d.InputStream.Extern.fst
+++ b/src/3d/prelude/extern/EverParse3d.InputStream.Extern.fst
@@ -219,8 +219,7 @@ let read
 
 #pop-options
 
-#restart-solver
-#push-options "--z3rlimit 64 --fuel 0 --ifuel 1 --z3cliopt smt.arith.nl=false --using_facts_from '* -FStar.Tactics -FStar.Reflection -FStar.Seq.Properties.slice_slice'"
+#push-options "--z3rlimit 64 --fuel 0 --ifuel 1 --z3cliopt smt.arith.nl=false --split_queries"
 inline_for_extraction
 noextract
 let peep


### PR DESCRIPTION
Needed to merge https://github.com/FStarLang/FStar/pull/2835, which somehow breaks this proof. Thankfully it just seems like normal flakiness, so this can be merge before the F* PR. Note the use of `--split_queries`, it makes the proof more stable (otherwise it fails, retries the query to localize errors, and ends up succeeding with a warning).