### PR TITLE
Clarify bitfields in LowParse and 3d; BE bitfields now MSB-first

### DIFF
--- a/doc/3d-lang.rst
+++ b/doc/3d-lang.rst
@@ -171,7 +171,10 @@ and are implicitly promoted to the underlying integer type, ``UINT32``
 in this case, although the 3d verifier is aware of suitable bounds on
 the types, e.g., that ``0 <= x < 64``.
 
-3d implements C's rules for packing bit fields. For instance,
+For types ``UINT8``. ``UINT16``, ``UINT32`` and ``UINT64``, 3d
+implements `MSVC's rules for packing bit fields
+<https://learn.microsoft.com/en-us/cpp/c-language/c-bit-fields>`_:
+least-significant bit first. For instance:
 
 .. literalinclude:: BF.3d
     :language: c
@@ -181,18 +184,26 @@ the types, e.g., that ``0 <= x < 64``.
 In ``BF2``, although ``x``, ``y`` and ``z`` cumulatively consume only
 26 bits, the layout of ``BF2`` is actually as shown below, consuming
 40 bits, since a given field must be represented within the bounds of
-a single underlying type---we have 10 unused bits after ``x`` and 4
-unused bits after ``y``.
+a single underlying type---we have 10 unused bits before ``x`` and 4
+unused bits before ``y``.
 
 .. code-block:: c
+
+   counting from most-significant bits to least-significant bits:
 
     0                   1                   2                   3                   4
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
-   |     x     |       Unused      |           y           |Unused |        z      |
-   |           |                   |                       |       |               |
+   |      Unused       |     x     | Unused|           y           |        z      |
+   |                   |           |       |                       |               |
    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
-                
+
+EverParse version 2023.04.17 and beyond encode bitfields with
+big-endian integer types ``UINT16BE``, ``UINT32BE`` and ``UINT64BE``
+with the most-significant bit (MSB) first, which is necessary for many
+IETF network protocols ("network byte order".) Those versions of
+EverParse introduce the integer type ``UINT8BE`` to read a 8-bit
+bitfield as MSB-first.
 
 Constants and Enumerations
 --------------------------

--- a/doc/3d-snapshot/BF.c
+++ b/doc/3d-snapshot/BF.c
@@ -2,6 +2,276 @@
 
 #include "BF.h"
 
+static inline uint64_t
+ValidateBf2bis(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+)
+{
+  /* Checking that we have enough space for a UINT16, i.e., 2 bytes */
+  BOOLEAN hasBytes0 = (uint64_t)2U <= (InputLength - StartPosition);
+  uint64_t positionAfterBf2bis;
+  if (hasBytes0)
+  {
+    positionAfterBf2bis = StartPosition + (uint64_t)2U;
+  }
+  else
+  {
+    positionAfterBf2bis =
+      EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
+        StartPosition);
+  }
+  uint64_t positionAfterBitfield0;
+  if (EverParseIsSuccess(positionAfterBf2bis))
+  {
+    positionAfterBitfield0 = positionAfterBf2bis;
+  }
+  else
+  {
+    ErrorHandlerFn("_BF2bis",
+      "__bitfield_0",
+      EverParseErrorReasonOfResult(positionAfterBf2bis),
+      EverParseGetValidatorErrorKind(positionAfterBf2bis),
+      Ctxt,
+      Input,
+      StartPosition);
+    positionAfterBitfield0 = positionAfterBf2bis;
+  }
+  if (EverParseIsError(positionAfterBitfield0))
+  {
+    return positionAfterBitfield0;
+  }
+  uint16_t r0 = Load16Le(Input + (uint32_t)StartPosition);
+  uint16_t bitfield0 = (uint16_t)(uint32_t)r0;
+  /* Checking that we have enough space for a UINT16, i.e., 2 bytes */
+  BOOLEAN hasBytes1 = (uint64_t)2U <= (InputLength - positionAfterBitfield0);
+  uint64_t positionAfternone;
+  if (hasBytes1)
+  {
+    positionAfternone = positionAfterBitfield0 + (uint64_t)2U;
+  }
+  else
+  {
+    positionAfternone =
+      EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
+        positionAfterBitfield0);
+  }
+  uint64_t positionAfterBf2bis0;
+  if (EverParseIsError(positionAfternone))
+  {
+    positionAfterBf2bis0 = positionAfternone;
+  }
+  else
+  {
+    uint16_t r = Load16Le(Input + (uint32_t)positionAfterBitfield0);
+    uint16_t none = (uint16_t)(uint32_t)r;
+    BOOLEAN
+    noneConstraintIsOk =
+      EverParseGetBitfield16(none,
+        (uint32_t)0U,
+        (uint32_t)12U)
+      < EverParseGetBitfield16(bitfield0, (uint32_t)0U, (uint32_t)6U);
+    uint64_t
+    positionAfternone1 = EverParseCheckConstraintOk(noneConstraintIsOk, positionAfternone);
+    if (EverParseIsError(positionAfternone1))
+    {
+      positionAfterBf2bis0 = positionAfternone1;
+    }
+    else
+    {
+      /* Validating field z */
+      /* Checking that we have enough space for a UINT8, i.e., 1 byte */
+      BOOLEAN hasBytes = (uint64_t)1U <= (InputLength - positionAfternone1);
+      uint64_t positionAfterBf2bis;
+      if (hasBytes)
+      {
+        positionAfterBf2bis = positionAfternone1 + (uint64_t)1U;
+      }
+      else
+      {
+        positionAfterBf2bis =
+          EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
+            positionAfternone1);
+      }
+      uint64_t res;
+      if (EverParseIsSuccess(positionAfterBf2bis))
+      {
+        res = positionAfterBf2bis;
+      }
+      else
+      {
+        ErrorHandlerFn("_BF2bis",
+          "z",
+          EverParseErrorReasonOfResult(positionAfterBf2bis),
+          EverParseGetValidatorErrorKind(positionAfterBf2bis),
+          Ctxt,
+          Input,
+          positionAfternone1);
+        res = positionAfterBf2bis;
+      }
+      positionAfterBf2bis0 = res;
+    }
+  }
+  if (EverParseIsSuccess(positionAfterBf2bis0))
+  {
+    return positionAfterBf2bis0;
+  }
+  ErrorHandlerFn("_BF2bis",
+    "none",
+    EverParseErrorReasonOfResult(positionAfterBf2bis0),
+    EverParseGetValidatorErrorKind(positionAfterBf2bis0),
+    Ctxt,
+    Input,
+    positionAfterBitfield0);
+  return positionAfterBf2bis0;
+}
+
+static inline uint64_t
+ValidateBf3(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+)
+{
+  /* Checking that we have enough space for a UINT16BE, i.e., 2 bytes */
+  BOOLEAN hasBytes0 = (uint64_t)2U <= (InputLength - StartPosition);
+  uint64_t positionAfterBf3;
+  if (hasBytes0)
+  {
+    positionAfterBf3 = StartPosition + (uint64_t)2U;
+  }
+  else
+  {
+    positionAfterBf3 =
+      EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
+        StartPosition);
+  }
+  uint64_t positionAfterBitfield0;
+  if (EverParseIsSuccess(positionAfterBf3))
+  {
+    positionAfterBitfield0 = positionAfterBf3;
+  }
+  else
+  {
+    ErrorHandlerFn("_BF3",
+      "__bitfield_0",
+      EverParseErrorReasonOfResult(positionAfterBf3),
+      EverParseGetValidatorErrorKind(positionAfterBf3),
+      Ctxt,
+      Input,
+      StartPosition);
+    positionAfterBitfield0 = positionAfterBf3;
+  }
+  if (EverParseIsError(positionAfterBitfield0))
+  {
+    return positionAfterBitfield0;
+  }
+  uint16_t bitfield0 = Load16Be(Input + (uint32_t)StartPosition);
+  /* Checking that we have enough space for a UINT16BE, i.e., 2 bytes */
+  BOOLEAN hasBytes1 = (uint64_t)2U <= (InputLength - positionAfterBitfield0);
+  uint64_t positionAfternone;
+  if (hasBytes1)
+  {
+    positionAfternone = positionAfterBitfield0 + (uint64_t)2U;
+  }
+  else
+  {
+    positionAfternone =
+      EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
+        positionAfterBitfield0);
+  }
+  uint64_t positionAfterBf30;
+  if (EverParseIsError(positionAfternone))
+  {
+    positionAfterBf30 = positionAfternone;
+  }
+  else
+  {
+    uint16_t none = Load16Be(Input + (uint32_t)positionAfterBitfield0);
+    BOOLEAN
+    noneConstraintIsOk =
+      EverParseGetBitfield16MsbFirst(none,
+        (uint32_t)0U,
+        (uint32_t)12U)
+      < EverParseGetBitfield16MsbFirst(bitfield0, (uint32_t)0U, (uint32_t)6U);
+    uint64_t
+    positionAfternone1 = EverParseCheckConstraintOk(noneConstraintIsOk, positionAfternone);
+    if (EverParseIsError(positionAfternone1))
+    {
+      positionAfterBf30 = positionAfternone1;
+    }
+    else
+    {
+      /* Validating field z */
+      /* Checking that we have enough space for a UINT8BE, i.e., 1 byte */
+      BOOLEAN hasBytes = (uint64_t)1U <= (InputLength - positionAfternone1);
+      uint64_t positionAfterBf3;
+      if (hasBytes)
+      {
+        positionAfterBf3 = positionAfternone1 + (uint64_t)1U;
+      }
+      else
+      {
+        positionAfterBf3 =
+          EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
+            positionAfternone1);
+      }
+      uint64_t res;
+      if (EverParseIsSuccess(positionAfterBf3))
+      {
+        res = positionAfterBf3;
+      }
+      else
+      {
+        ErrorHandlerFn("_BF3",
+          "z",
+          EverParseErrorReasonOfResult(positionAfterBf3),
+          EverParseGetValidatorErrorKind(positionAfterBf3),
+          Ctxt,
+          Input,
+          positionAfternone1);
+        res = positionAfterBf3;
+      }
+      positionAfterBf30 = res;
+    }
+  }
+  if (EverParseIsSuccess(positionAfterBf30))
+  {
+    return positionAfterBf30;
+  }
+  ErrorHandlerFn("_BF3",
+    "none",
+    EverParseErrorReasonOfResult(positionAfterBf30),
+    EverParseGetValidatorErrorKind(positionAfterBf30),
+    Ctxt,
+    Input,
+    positionAfterBitfield0);
+  return positionAfterBf30;
+}
+
 uint64_t
 BfValidateDummy(
   uint8_t *Ctxt,
@@ -20,42 +290,43 @@ BfValidateDummy(
   uint64_t StartPosition
 )
 {
-  /* Validating field emp1 */
-  uint64_t positionAfterDummy = StartPosition;
-  uint64_t res;
+  /* Validating field emp2 */
+  uint64_t
+  positionAfterDummy = ValidateBf2bis(Ctxt, ErrorHandlerFn, Input, InputLength, StartPosition);
+  uint64_t positionAfteremp2;
   if (EverParseIsSuccess(positionAfterDummy))
   {
-    res = positionAfterDummy;
+    positionAfteremp2 = positionAfterDummy;
   }
   else
   {
     ErrorHandlerFn("_dummy",
-      "emp1",
+      "emp2",
       EverParseErrorReasonOfResult(positionAfterDummy),
       EverParseGetValidatorErrorKind(positionAfterDummy),
       Ctxt,
       Input,
       StartPosition);
-    res = positionAfterDummy;
+    positionAfteremp2 = positionAfterDummy;
   }
-  uint64_t positionAfteremp1 = res;
-  if (EverParseIsError(positionAfteremp1))
+  if (EverParseIsError(positionAfteremp2))
   {
-    return positionAfteremp1;
+    return positionAfteremp2;
   }
-  /* Validating field emp2 */
-  uint64_t positionAfterDummy0 = positionAfteremp1;
+  /* Validating field emp3 */
+  uint64_t
+  positionAfterDummy0 = ValidateBf3(Ctxt, ErrorHandlerFn, Input, InputLength, positionAfteremp2);
   if (EverParseIsSuccess(positionAfterDummy0))
   {
     return positionAfterDummy0;
   }
   ErrorHandlerFn("_dummy",
-    "emp2",
+    "emp3",
     EverParseErrorReasonOfResult(positionAfterDummy0),
     EverParseGetValidatorErrorKind(positionAfterDummy0),
     Ctxt,
     Input,
-    positionAfteremp1);
+    positionAfteremp2);
   return positionAfterDummy0;
 }
 

--- a/doc/BF.3d
+++ b/doc/BF.3d
@@ -14,8 +14,20 @@ typedef struct _BF2 {
 } BF2;
 // SNIPPET_END: BF2
 
+typedef struct _BF2bis {
+  UINT16 x : 6;
+  UINT16 y : 12 { y < x };
+  UINT8 z;
+} BF2bis;
+
+typedef struct _BF3 {
+  UINT16BE x : 6;
+  UINT16BE y : 12 { y < x };
+  UINT8BE z;
+} BF3;
+
 entrypoint
 typedef struct _dummy {
- unit emp1;
- unit emp2;
+ BF2bis emp2;
+ BF3 emp3;
 } dummy;

--- a/src/3d/Binding.fsti
+++ b/src/3d/Binding.fsti
@@ -31,6 +31,7 @@ val parser_weak_kind  (env:global_env) (id:ident) : ML (option weak_kind)
 val unfold_typ_abbrev_only (_:env) (t:typ) : ML typ
 val update_typ_abbrev (_:env) (id:ident) (t:typ) : ML unit
 val size_of_integral_typ (_:env) (_:typ) (_:range) : ML int
+val bit_order_of_integral_typ (_:env) (_:typ) (_:range) : ML bitfield_bit_order
 val bind_decls (g:global_env) (p:list decl) : ML (list decl & global_env)
 //val add_field_error_code_decls (ge: env) : ML (list decl)
 

--- a/src/3d/BitFields.fst
+++ b/src/3d/BitFields.fst
@@ -68,6 +68,7 @@ let coalesce_grouped_bit_field env (f:bitfield_group)
   = let id, typ, fields = f in
     let size = B.size_of_integral_typ env typ typ.range in
     let bitsize = 8 * size in
+    let order = B.bit_order_of_integral_typ env typ typ.range in
     let field_id = with_range (to_ident' (Printf.sprintf "__bitfield_%d" id)) dummy_range in
     let id = with_range (Identifier field_id) field_id.range in
     let mk_e (e:expr') :expr = with_range e field_id.range in
@@ -104,7 +105,7 @@ let coalesce_grouped_bit_field env (f:bitfield_group)
           in
           let bf_exp =
             App
-              (BitFieldOf bitsize)
+              (BitFieldOf bitsize order)
               [id;
               mk_e (Constant (Int UInt32 (bitfield_attrs f).bitfield_from));
               mk_e (Constant (Int UInt32 (bitfield_attrs f).bitfield_to))]

--- a/src/3d/Desugar.fst
+++ b/src/3d/Desugar.fst
@@ -165,7 +165,7 @@ let push_name (env:qenv) (name:string) : qenv =
 
 let prim_consts = [
   "unit"; "Bool"; "UINT8"; "UINT16"; "UINT32"; "UINT64";
-  "UINT16BE"; "UINT32BE"; "UINT64BE";
+  "UINT8BE"; "UINT16BE"; "UINT32BE"; "UINT64BE";
   "field_id"; "PUINT8";
   "all_bytes"; "all_zeros";
   "is_range_okay";

--- a/src/3d/GlobalEnv.fst
+++ b/src/3d/GlobalEnv.fst
@@ -36,6 +36,7 @@ module H = Hashtable
 type decl_attributes = {
   may_fail:bool;
   integral:option integer_type;
+  bit_order: (bit_order: option bitfield_bit_order { Some? bit_order ==> Some? integral });
   has_reader:bool;
   parser_weak_kind:weak_kind;
   parser_kind_nz:option bool

--- a/src/3d/InterpreterTarget.fst
+++ b/src/3d/InterpreterTarget.fst
@@ -29,6 +29,7 @@ type itype =
   | UInt16
   | UInt32
   | UInt64
+  | UInt8BE
   | UInt16BE
   | UInt32BE
   | UInt64BE
@@ -250,6 +251,7 @@ let itype_of_ident (hd:A.ident)
     | "UINT16" -> Some UInt16
     | "UINT32" -> Some UInt32
     | "UINT64" -> Some UInt64
+    | "UINT8BE" -> Some UInt8BE
     | "UINT16BE" -> Some UInt16BE
     | "UINT32BE" -> Some UInt32BE
     | "UINT64BE" -> Some UInt64BE
@@ -534,6 +536,7 @@ let print_ityp (i:itype) =
   | UInt16 -> "UInt16"
   | UInt32 -> "UInt32"
   | UInt64 -> "UInt64"
+  | UInt8BE -> "UInt8BE"
   | UInt16BE -> "UInt16BE"
   | UInt32BE -> "UInt32BE"
   | UInt64BE -> "UInt64BE"

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -216,6 +216,13 @@ let is_infix =
   | Or -> true
   | _ -> false
 
+// Bitfield operators from EverParse3d.Prelude.StaticHeader are least
+// significant bit first by default, following MSVC
+// (https://learn.microsoft.com/en-us/cpp/c-language/c-bit-fields)
+let print_bitfield_bit_order = function
+  | A.LSBFirst -> ""
+  | A.MSBFirst -> "_msb_first"
+
 let print_op_with_range ropt o =
   match o with
   | Eq -> "="
@@ -239,7 +246,7 @@ let print_op_with_range ropt o =
   | LE t -> Printf.sprintf "FStar.%s.lte" (namespace_of_integer_type t)
   | GE t -> Printf.sprintf "FStar.%s.gte" (namespace_of_integer_type t)
   | IfThenElse -> "ite"
-  | BitFieldOf i -> Printf.sprintf "get_bitfield%d" i
+  | BitFieldOf i order -> Printf.sprintf "get_bitfield%d%s" i (print_bitfield_bit_order order)
   | Cast from to ->
     let tfrom = print_integer_type from in
     let tto = print_integer_type to in
@@ -276,10 +283,10 @@ let rec print_expr (mname:string) (e:expr) : ML string =
     Printf.sprintf
       "(if %s then %s else %s)"
       (print_expr mname e1) (print_expr mname e2) (print_expr mname e3)
-  | App (BitFieldOf i) [e1;e2;e3] ->
+  | App (BitFieldOf i order) [e1;e2;e3] ->
     Printf.sprintf
       "(%s %s %s %s)"
-      (print_op (BitFieldOf i))
+      (print_op (BitFieldOf i order))
       (print_expr mname e1) (print_expr mname e2) (print_expr mname e3)
   | App op [] ->
     print_op op

--- a/src/3d/Target.fsti
+++ b/src/3d/Target.fsti
@@ -43,7 +43,7 @@ type op =
   | LE of A.integer_type
   | GE of A.integer_type
   | IfThenElse
-  | BitFieldOf of int //BitFieldOf(i, from, to)
+  | BitFieldOf: size: int -> order: A.bitfield_bit_order -> op //BitFieldOf(i, from, to)
   | Cast : from:A.integer_type -> to:A.integer_type -> op
   | Ext of string
 

--- a/src/3d/TranslateForInterpreter.fst
+++ b/src/3d/TranslateForInterpreter.fst
@@ -283,7 +283,7 @@ let translate_op : A.op -> ML T.op =
   | LE topt -> T.LE (force_topt topt)
   | GE topt -> T.GE (force_topt topt)
   | IfThenElse -> T.IfThenElse
-  | BitFieldOf i -> T.BitFieldOf i
+  | BitFieldOf i order -> T.BitFieldOf i order
   | Cast (Some from) to -> T.Cast from to
   | Ext s -> T.Ext s
   | Cast None _

--- a/src/3d/TypeSizes.fst
+++ b/src/3d/TypeSizes.fst
@@ -45,6 +45,7 @@ let initial_senv () =
        ("UINT16",   (Fixed 2,  Some 2));
        ("UINT32",   (Fixed 4,  Some 4));
        ("UINT64",   (Fixed 8,  Some 8));
+       ("UINT8BE",   (Fixed 1,  Some 1));
        ("UINT16BE",   (Fixed 2,  Some 2));
        ("UINT32BE",   (Fixed 4,  Some 4));
        ("UINT64BE",   (Fixed 8,  Some 8));

--- a/src/3d/prelude/EverParse3d.Actions.Base.fst
+++ b/src/3d/prelude/EverParse3d.Actions.Base.fst
@@ -1347,6 +1347,18 @@ let read____UINT8
 = lift_reader _ LowParse.Low.Int.read_u8 1ul 1uL
 
 inline_for_extraction noextract
+let validate____UINT8BE
+  : validator parse____UINT8BE
+  = validate_with_comment
+      "Checking that we have enough space for a UINT8BE, i.e., 1 byte"
+      (validate_total_constant_size_no_read parse____UINT8BE 1uL () _ _)
+
+inline_for_extraction noextract
+let read____UINT8BE
+  : leaf_reader parse____UINT8BE
+= lift_reader _ LowParse.Low.Int.read_u8 1ul 1uL
+
+inline_for_extraction noextract
 let validate____UINT16BE
   : validator parse____UINT16BE
   = validate_with_comment

--- a/src/3d/prelude/EverParse3d.Actions.Base.fsti
+++ b/src/3d/prelude/EverParse3d.Actions.Base.fsti
@@ -510,6 +510,14 @@ val read____UINT8
   : leaf_reader parse____UINT8
 
 inline_for_extraction noextract
+val validate____UINT8BE
+  : validator parse____UINT8BE
+
+inline_for_extraction noextract
+val read____UINT8BE
+  : leaf_reader parse____UINT8BE
+
+inline_for_extraction noextract
 val validate____UINT16BE
   : validator parse____UINT16BE
 

--- a/src/3d/prelude/EverParse3d.Interpreter.fst
+++ b/src/3d/prelude/EverParse3d.Interpreter.fst
@@ -64,6 +64,7 @@ type itype =
   | UInt16
   | UInt32
   | UInt64
+  | UInt8BE
   | UInt16BE
   | UInt32BE
   | UInt64BE
@@ -80,6 +81,7 @@ let itype_as_type (i:itype)
     | UInt16 -> P.___UINT16
     | UInt32 -> P.___UINT32
     | UInt64 -> P.___UINT64
+    | UInt8BE -> P.___UINT8BE
     | UInt16BE -> P.___UINT16BE
     | UInt32BE -> P.___UINT32BE
     | UInt64BE -> P.___UINT64BE
@@ -114,6 +116,7 @@ let parser_kind_of_itype (i:itype)
     | UInt16 -> P.kind____UINT16
     | UInt32 -> P.kind____UINT32
     | UInt64 -> P.kind____UINT64
+    | UInt8BE -> P.kind____UINT8BE
     | UInt16BE -> P.kind____UINT16BE
     | UInt32BE -> P.kind____UINT32BE
     | UInt64BE -> P.kind____UINT64BE
@@ -129,6 +132,7 @@ let itype_as_parser (i:itype)
     | UInt16 -> P.parse____UINT16
     | UInt32 -> P.parse____UINT32
     | UInt64 -> P.parse____UINT64
+    | UInt8BE -> P.parse____UINT8BE
     | UInt16BE -> P.parse____UINT16BE
     | UInt32BE -> P.parse____UINT32BE
     | UInt64BE -> P.parse____UINT64BE
@@ -153,6 +157,7 @@ let itype_as_leaf_reader (i:itype { allow_reader_of_itype i })
     | UInt16 -> A.read____UINT16
     | UInt32 -> A.read____UINT32
     | UInt64 -> A.read____UINT64
+    | UInt8BE -> A.read____UINT8BE
     | UInt16BE -> A.read____UINT16BE
     | UInt32BE -> A.read____UINT32BE
     | UInt64BE -> A.read____UINT64BE
@@ -168,6 +173,7 @@ let itype_as_validator (i:itype)
     | UInt16 -> A.validate____UINT16
     | UInt32 -> A.validate____UINT32
     | UInt64 -> A.validate____UINT64
+    | UInt8BE -> A.validate____UINT8BE
     | UInt16BE -> A.validate____UINT16BE
     | UInt32BE -> A.validate____UINT32BE
     | UInt64BE -> A.validate____UINT64BE

--- a/src/3d/prelude/EverParse3d.Kinds.fst
+++ b/src/3d/prelude/EverParse3d.Kinds.fst
@@ -116,6 +116,11 @@ let kind____UINT8
   = LowParse.Spec.Int.parse_u8_kind
 
 inline_for_extraction noextract
+let kind____UINT8BE
+  : parser_kind true WeakKindStrongPrefix
+  = LowParse.Spec.BoundedInt.parse_u8_kind
+
+inline_for_extraction noextract
 let kind____UINT16BE
   : parser_kind true WeakKindStrongPrefix
   = LowParse.Spec.BoundedInt.parse_u16_kind

--- a/src/3d/prelude/EverParse3d.Kinds.fsti
+++ b/src/3d/prelude/EverParse3d.Kinds.fsti
@@ -91,6 +91,10 @@ val kind____UINT8
   : parser_kind true WeakKindStrongPrefix
 
 inline_for_extraction noextract
+val kind____UINT8BE
+  : parser_kind true WeakKindStrongPrefix
+
+inline_for_extraction noextract
 val kind____UINT16BE
   : parser_kind true WeakKindStrongPrefix
 

--- a/src/3d/prelude/EverParse3d.Prelude.StaticHeader.fst
+++ b/src/3d/prelude/EverParse3d.Prelude.StaticHeader.fst
@@ -9,6 +9,9 @@ module LBF = LowParse.BitFields
 ////////////////////////////////////////////////////////////////////////////////
 // Bit fields
 ////////////////////////////////////////////////////////////////////////////////
+
+// The get_bitfield operators are least significant bit first by default
+// following MSVC (https://learn.microsoft.com/en-us/cpp/c-language/c-bit-fields)
 let get_bitfield8
   (value:U8.t)
   (bitsFrom:U32.t{U32.v bitsFrom < 8})
@@ -37,3 +40,30 @@ let get_bitfield64 (value:U64.t)
                    (bitsTo:U32.t{U32.v bitsFrom < U32.v bitsTo /\ U32.v bitsTo <= 64})
    : i:U64.t{FStar.UInt.size (U64.v i) (U32.v bitsTo - U32.v bitsFrom)}
    = LBF.uint64.LBF.get_bitfield_gen value bitsFrom bitsTo
+
+// Most significant bit first variants:
+
+let get_bitfield8_msb_first
+  (value:U8.t)
+  (bitsFrom:U32.t{U32.v bitsFrom < 8})
+  (bitsTo:U32.t{U32.v bitsFrom < U32.v bitsTo /\ U32.v bitsTo <= 8})
+: Tot (i:U8.t{FStar.UInt.size (U8.v i) (U32.v bitsTo - U32.v bitsFrom)})
+= get_bitfield8 value (8ul `U32.sub` bitsTo) (8ul `U32.sub` bitsFrom)
+
+let get_bitfield16_msb_first (value:U16.t)
+                   (bitsFrom:U32.t{U32.v bitsFrom < 16})
+                   (bitsTo:U32.t{U32.v bitsFrom < U32.v bitsTo /\ U32.v bitsTo <= 16})
+   : i:U16.t{FStar.UInt.size (U16.v i) (U32.v bitsTo - U32.v bitsFrom)}
+   = get_bitfield16 value (16ul `U32.sub` bitsTo) (16ul `U32.sub` bitsFrom)
+
+let get_bitfield32_msb_first (value:U32.t)
+                   (bitsFrom:U32.t{U32.v bitsFrom < 32})
+                   (bitsTo:U32.t{U32.v bitsFrom < U32.v bitsTo /\ U32.v bitsTo <= 32})
+   : i:U32.t{FStar.UInt.size (U32.v i) (U32.v bitsTo - U32.v bitsFrom)}
+   = get_bitfield32 value (32ul `U32.sub` bitsTo) (32ul `U32.sub` bitsFrom)
+
+let get_bitfield64_msb_first (value:U64.t)
+                   (bitsFrom:U32.t{U32.v bitsFrom < 64})
+                   (bitsTo:U32.t{U32.v bitsFrom < U32.v bitsTo /\ U32.v bitsTo <= 64})
+   : i:U64.t{FStar.UInt.size (U64.v i) (U32.v bitsTo - U32.v bitsFrom)}
+   = get_bitfield64 value (64ul `U32.sub` bitsTo) (64ul `U32.sub` bitsFrom)

--- a/src/3d/prelude/EverParse3d.Prelude.fst
+++ b/src/3d/prelude/EverParse3d.Prelude.fst
@@ -280,6 +280,10 @@ let parse_all_zeros = LowParse.Spec.List.parse_list (LowParse.Spec.Combinators.p
 let parse____UINT8 = LowParse.Spec.Int.parse_u8
 let read____UINT8 = LowParse.Low.Int.read_u8
 
+/// UINT8BE
+let parse____UINT8BE = LowParse.Spec.Int.parse_u8
+let read____UINT8BE = LowParse.Low.Int.read_u8
+
 /// UInt16BE
 let parse____UINT16BE = LowParse.Spec.Int.parse_u16
 let read____UINT16BE = LowParse.Low.Int.read_u16

--- a/src/3d/prelude/EverParse3d.Prelude.fsti
+++ b/src/3d/prelude/EverParse3d.Prelude.fsti
@@ -194,6 +194,11 @@ val read____UINT8 : reader parse____UINT8
 
 // Big-endian (or "network order")
 
+/// UINT8BE
+let ___UINT8BE : eqtype = FStar.UInt8.t
+val parse____UINT8BE : parser kind____UINT8BE ___UINT8BE
+val read____UINT8BE : reader parse____UINT8BE
+
 /// UInt16BE
 let ___UINT16BE : eqtype = U16.t
 val parse____UINT16BE : parser kind____UINT16BE ___UINT16BE

--- a/src/3d/tests/tcpip/Ethernet.3d
+++ b/src/3d/tests/tcpip/Ethernet.3d
@@ -53,12 +53,12 @@ typedef struct _MAC_ADDRESS
 typedef struct _VLAN_ETHTYPE(mutable UINT16* VlanTagOut,
                              mutable UINT16* EthTypeOut)
 {
-  UINT16 VlanTag
+  UINT16BE VlanTag
   {:on-success
       *VlanTagOut = VlanTag;
        return true; 
   };
-  UINT16 EthType
+  UINT16BE EthType
   {:on-success
       *EthTypeOut = EthType;
        return true;
@@ -129,7 +129,7 @@ typedef struct _ETHERNET_FRAME(mutable Bool* Dot1QOut,
 {
   MAC_ADDRESS Destination;
   MAC_ADDRESS Source;
-  UINT16 EthTypeOrDot1Q;
+  UINT16BE EthTypeOrDot1Q;
   VLAN_ETHTYPE_OR_EMPTY(EthTypeOrDot1Q,
                         Dot1QOut,
                         VlanTagOut,

--- a/src/3d/tests/tcpip/ICMP.3d
+++ b/src/3d/tests/tcpip/ICMP.3d
@@ -27,7 +27,7 @@ UINT8 enum DESTINATION_UNREACHABLE_CODE
 typedef struct _IP_HEADER_AND_DATAGRAM
 {
     IPV4::IPV4_HEADER    IpHeader;
-    UINT64               IpData;
+    UINT64BE             IpData;
 } IP_HEADER_AND_DATAGRAM;
 
 
@@ -46,7 +46,7 @@ typedef struct _UNUSED_BYTES (UINT32 len)
 typedef struct _DESTINATION_UNREACHABLE_MESSAGE
 {
      DESTINATION_UNREACHABLE_CODE        Code;
-     UINT16                              Checksum;
+     UINT16BE                            Checksum;
      UNUSED_BYTES(32)                    Unused;
      IP_HEADER_AND_DATAGRAM              OriginalMsg;
 } DESTINATION_UNREACHABLE_MESSAGE;
@@ -62,7 +62,7 @@ UINT8 enum TIME_EXCEEDED_CODE
 typedef struct _TIME_EXCEEDED_MESSAGE
 {
     TIME_EXCEEDED_CODE        Code;
-    UINT16                    Checksum;
+    UINT16BE                  Checksum;
     UNUSED_BYTES(32)          Unused;
     IP_HEADER_AND_DATAGRAM    OriginalMsg;
 } TIME_EXCEEDED_MESSAGE;
@@ -74,7 +74,7 @@ typedef struct _PARAMETER_PROBLEM_MESSAGE
     {
         Code == 0
     };
-    UINT16                    Checksum;
+    UINT16BE                  Checksum;
     UINT8                     Pointer;  //Valid only if code is 0, is there something to check?
     UNUSED_BYTES(24)          Unused;
     IP_HEADER_AND_DATAGRAM    OriginalMsg;
@@ -87,7 +87,7 @@ typedef struct _SOURCE_QUENCH_MESSAGE
     {
         Code == 0
     };
-    UINT16                    Checksum;
+    UINT16BE                  Checksum;
     UNUSED_BYTES(32)          Unused;
     IP_HEADER_AND_DATAGRAM    OriginalMsg;
 } SOURCE_QUENCH_MESSAGE;
@@ -104,8 +104,8 @@ UINT8 enum REDIRECT_CODE
 typedef struct _REDIRECT_MESSAGE
 {
     REDIRECT_CODE             Code;
-    UINT16                    Checksum;
-    UINT32                    GatewayInternetAddress;
+    UINT16BE                  Checksum;
+    UINT32BE                  GatewayInternetAddress;
     IP_HEADER_AND_DATAGRAM    OriginalMsg;
 } REDIRECT_MESSAGE;
 
@@ -117,9 +117,9 @@ where (len >= sizeof (this))
     {
         Code == 0
     };
-    UINT16                    Checksum;
-    UINT16                    Identifier;
-    UINT16                    SequenceNumber;
+    UINT16BE                  Checksum;
+    UINT16BE                  Identifier;
+    UINT16BE                  SequenceNumber;
     UINT8                     Data[:byte-size len - sizeof (this)];  //TODO: get an opinion on this
 } ECHO_OR_ECHO_REPLY_MESSAGE;
 
@@ -130,12 +130,12 @@ typedef struct _TIMESTAMP_OR_TIMESTAMP_REPLY_MESSAGE
     {
         Code == 0
     };
-    UINT16                    Checksum;
-    UINT16                    Identifier;
-    UINT16                    SequenceNumber;
-    UINT32                    OriginalTimeStamp;
-    UINT32                    ReceiveTimeStamp;
-    UINT32                    TransmitTimeStamp;
+    UINT16BE                  Checksum;
+    UINT16BE                  Identifier;
+    UINT16BE                  SequenceNumber;
+    UINT32BE                  OriginalTimeStamp;
+    UINT32BE                  ReceiveTimeStamp;
+    UINT32BE                  TransmitTimeStamp;
 } TIMESTAMP_OR_TIMESTAMP_REPLY_MESSAGE;
 
 
@@ -145,9 +145,9 @@ typedef struct _INFORMATION_REQUEST_OR_INFORMATION_REPLY_MESSAGE
     {
         Code == 0
     };
-    UINT16                    Checksum;
-    UINT16                    Identifier;
-    UINT16                    SequenceNumber;
+    UINT16BE                  Checksum;
+    UINT16BE                  Identifier;
+    UINT16BE                  SequenceNumber;
 } INFORMATION_REQUEST_OR_INFORMATION_REPLY_MESSAGE;
     
 

--- a/src/3d/tests/tcpip/IPV4.3d
+++ b/src/3d/tests/tcpip/IPV4.3d
@@ -15,40 +15,40 @@ typedef struct _IP_DATAGRAM_HEADER_PARAMETRIZED (
 {
     //RFC 791 describes Version 4
 
-    UINT16                                               Version:4
+    UINT16BE                                             Version:4
     {
         Version == 4
     };
 
     //Length of the header in 32 bit words, minimum value 5
 
-    UINT16                                               IHL:4
+    UINT16BE                                             IHL:4
     {
         (5 <= IHL) && (IHL < (_MAX_UINT32_ / 4))
     };
 
     //Type of Service may be a specific value, in the case of ICMP (RFC 792) for example
 
-    UINT16                                               ToS:8
+    UINT16BE                                             ToS:8
     {
         (!SpecificToS) || (ToS == ToSVal)
     };
 
     //Total length of the IP datagram
 
-    UINT16                                               TotalLength;
+    UINT16BE                                             TotalLength;
 
-    UINT16                                               Identification;
+    UINT16BE                                             Identification;
 
     //Flags is 3 bits, the first bit is 0
 
-    UINT16                                               Flags_0:1
+    UINT16BE                                             Flags_0:1
     {
         Flags_0 == 0
     };
-    UINT16                                               Flags_1_2:2;
+    UINT16BE                                             Flags_1_2:2;
 
-    UINT16                                               FragmentOffset:13;
+    UINT16BE                                             FragmentOffset:13;
 
     UINT8                                                TimeToLive;
 
@@ -58,16 +58,16 @@ typedef struct _IP_DATAGRAM_HEADER_PARAMETRIZED (
         (!SpecificProtocol) || (Protocol == ProtocolVal)
     };
 
-    UINT16                                               HeaderCheckSum;
+    UINT16BE                                             HeaderCheckSum;
 
-    UINT32                                               SourceAddress;
+    UINT32BE                                             SourceAddress;
 
-    UINT32                                               DestinationAddress;
+    UINT32BE                                             DestinationAddress;
 
     //TODO: RFC 791 defines Options precisely, underspecifying for now
     //Note, base type is UINT32, so that it ends on a 32bit boundary
     
-    UINT32                                               OptionsAndPadding [:byte-size ((UINT32) IHL) * 4 - sizeof (this)];
+    UINT32BE                                             OptionsAndPadding [:byte-size ((UINT32) IHL) * 4 - sizeof (this)];
 
 } IP_DATAGRAM_HEADER_PARAMETRIZED;
 

--- a/src/3d/tests/tcpip/IPV6.3d
+++ b/src/3d/tests/tcpip/IPV6.3d
@@ -64,13 +64,13 @@
 entrypoint
 typedef struct _IPV6_HEADER
 {
-  UINT32 Version : 4
+  UINT32BE Version : 4
   {
     Version == IPV6_VERSION
   };
-  UINT32 TrafficClass:8;
-  UINT32 FlowLabel:20;
-  UINT16 PayloadLength;
+  UINT32BE TrafficClass:8;
+  UINT32BE FlowLabel:20;
+  UINT16BE PayloadLength;
   UINT8 NextHeader;
   UINT8 HopLimit;
   UINT8 SourceAddress[16];

--- a/src/3d/tests/tcpip/TCP.3d
+++ b/src/3d/tests/tcpip/TCP.3d
@@ -41,12 +41,12 @@
 
 */
 
-typedef UINT16 PORT;
-typedef UINT32 SEQ_NUMBER;
-typedef UINT32 ACK_NUMBER;
-typedef UINT16 WINDOW;
-typedef UINT16 CHECK_SUM;
-typedef UINT16 URGENT_PTR;
+typedef UINT16BE PORT;
+typedef UINT32BE SEQ_NUMBER;
+typedef UINT32BE ACK_NUMBER;
+typedef UINT16BE WINDOW;
+typedef UINT16BE CHECK_SUM;
+typedef UINT16BE URGENT_PTR;
 
 #define OPTION_KIND_END_OF_OPTION_LIST 0x00
 #define OPTION_KIND_NO_OPERATION 0x01
@@ -113,7 +113,7 @@ where MaxSegSizeAllowed
   {
     Length == 4
   };
-  UINT16 MaxSegSize
+  UINT16BE MaxSegSize
   {:act
     OptRx->MSS_CLAMP = MaxSegSize;
   };
@@ -127,8 +127,8 @@ where TimeStampAllowed
   {
     Length == 10
   };
-  UINT32       Tsval;
-  UINT32       Tsecr
+  UINT32BE     Tsval;
+  UINT32BE     Tsecr
   {:act
     OptRx->SAW_TSTAMP = 1;
     OptRx->RCV_TSVAL = Tsval;
@@ -239,29 +239,29 @@ typedef struct _TCP_HEADER(UINT32 SegmentLength,
   PORT            DestinationPort;
   SEQ_NUMBER      SeqNumber;
   ACK_NUMBER      AckNumber;
-  UINT16          DataOffset:4
+  UINT16BE        DataOffset:4
   { //DataOffset is in units of 32 bit words
     sizeof(this) == 20 && //Sanity check: static size in bytes of this type, excluding the variable length elements, is 20
     sizeof(this) <= DataOffset * 4 && //DataOffset points after the static fields
     DataOffset * 4 <= SegmentLength
   };
-  UINT16          Reserved:3
+  UINT16BE        Reserved:3
   {
     Reserved == 0 //Reserved bytes are unused
   };
-  UINT16          NS:1;
-  UINT16          CWR:1;
-  UINT16          ECE:1;
-  UINT16          URG:1;
-  UINT16          ACK:1
+  UINT16BE        NS:1;
+  UINT16BE        CWR:1;
+  UINT16BE        ECE:1;
+  UINT16BE        URG:1;
+  UINT16BE        ACK:1
   {
       AckNumber == 0 ||
       ACK == 1 //AckNumber can only be set if the ACK flag is set
   } ;
-  UINT16          PSH:1;
-  UINT16          RST:1;
-  UINT16          SYN:1;
-  UINT16          FIN:1;
+  UINT16BE        PSH:1;
+  UINT16BE        RST:1;
+  UINT16BE        SYN:1;
+  UINT16BE        FIN:1;
   WINDOW          Window;
   CHECK_SUM       CheckSum;
   URGENT_PTR      UrgentPointer

--- a/src/3d/tests/tcpip/UDP.3d
+++ b/src/3d/tests/tcpip/UDP.3d
@@ -20,8 +20,8 @@
 entrypoint
 typedef struct _UDP_Header
 {
-  UINT16 SourcePort;
-  UINT16 DestinationPort;
-  UINT16 Length;
-  UINT16 CheckSum;
+  UINT16BE SourcePort;
+  UINT16BE DestinationPort;
+  UINT16BE Length;
+  UINT16BE CheckSum;
 } UDP_HEADER;

--- a/src/3d/tests/tcpip/VXLAN.3d
+++ b/src/3d/tests/tcpip/VXLAN.3d
@@ -15,9 +15,9 @@
 entrypoint
 typedef struct _VXLAN_HEADER
 {
-  UINT8 R4:4;
-  UINT8 I:1 { I == 1 };
-  UINT8 R3:3;
+  UINT8BE R4:4;
+  UINT8BE I:1 { I == 1 };
+  UINT8BE R3:3;
   UINT8 Reserved24[3];
   UINT8 VXLanId;
   UINT8 Reserved8;

--- a/src/lowparse/LowParse.BitFields.fsti
+++ b/src/lowparse/LowParse.BitFields.fsti
@@ -3,6 +3,9 @@ module U = FStar.UInt
 
 type ubitfield (tot: nat) (sz: nat) = (x: U.uint_t tot { x < pow2 sz })
 
+// IMPORTANT: these bitfield operators are defined in a least
+// significant bit (LSB) first fashion.
+
 val get_bitfield 
   (#tot: pos) (x: U.uint_t tot) (lo: nat) (hi: nat {lo <= hi /\ hi <= tot})
 : Tot (ubitfield tot (hi - lo))

--- a/src/lowparse/LowParse.Spec.BitFields.fst
+++ b/src/lowparse/LowParse.Spec.BitFields.fst
@@ -5,6 +5,9 @@ include LowParse.BitFields
 
 module BF = LowParse.BitFields
 
+// IMPORTANT: these bitfield operators are defined in a least
+// significant bit (LSB) first fashion.
+
 let rec valid_bitfield_bounds (lo: nat) (hi: nat { lo <= hi }) (l: list nat) : Tot bool (decreases l) =
   match l with
   | [] -> true

--- a/src/lowparse/LowParse.Spec.BitSum.fst
+++ b/src/lowparse/LowParse.Spec.BitSum.fst
@@ -4,6 +4,9 @@ include LowParse.BitFields
 
 module L = FStar.List.Tot
 
+// IMPORTANT: these bitfield operators are defined in a MOST
+// significant bit (MSB) first fashion.
+
 noeq
 type bitsum'
   (#tot: pos)


### PR DESCRIPTION
This PR clarifies bit fields in LowParse and 3d regarding least-significant bit first (LSB-first) vs. most significant bit first (MSB-first.)

# 3d behavior changes

This PR changes some behavior in 3d:
* Bitfields of 3d types `UINT16BE`, `UINT32BE`, `UINT64BE`, parsed in big-endian fashion, now operate as MSB-first instead of LSB-first, to follow the "network byte order" used by many IETF protocols, as defined in, say, [RFC 1700](https://datatracker.ietf.org/doc/html/rfc1700)
* New 3d type `UINT8BE` for MSB-first 8-bit bitfields.
* Updated TCPIP example to use big-endian integer types

# Clarifications
This PR clarifies, but does not change, the following current behavior, by adding comments and updating the 3d documentation:
* `LowParse.BitFields` and `LowParse.Spec.BitFields` define LSB-first operations.
* `LowParse.Spec.BitSum` defines MSB-first operations (as correctly used by https://github.com/project-everest/everquic-crypto)
* Bitfields of 3d types `UINT8`, `UINT16`, `UINT32`, parsed in little-endian fashion, operate as LSB-first, as in MSVC (https://learn.microsoft.com/en-us/cpp/c-language/c-bit-fields)
