### PR TITLE
getopt: remove use of FStar.BaseTypes

### DIFF
--- a/src/3d/FStar.Getopt.fsti
+++ b/src/3d/FStar.Getopt.fsti
@@ -16,7 +16,7 @@
 module FStar.Getopt
 open FStar.ST
 open FStar.All
-open FStar.BaseTypes
+open FStar.Char
 
 val noshort : char
 val nolong : string


### PR DESCRIPTION
This module will be removed from F*'s library.

See https://github.com/FStarLang/FStar/pull/2883