### PR TITLE
lowparse: rlimit tweaks for new F*

### DIFF
--- a/src/lowparse/LowParse.Low.BoundedInt.fst
+++ b/src/lowparse/LowParse.Low.BoundedInt.fst
@@ -365,6 +365,7 @@ let serialize32_bounded_integer_le_1
 let write_bounded_integer_le_1
 = leaf_writer_strong_of_serializer32 serialize32_bounded_integer_le_1 ()
 
+#push-options "--z3rlimit 20"
 let serialize32_bounded_integer_le_2
 = fun x #rrel #rel b pos ->
   bounded_integer_prop_equiv 2 x;
@@ -375,6 +376,7 @@ let serialize32_bounded_integer_le_2
   let h' = HST.get () in
   LE.store_post_modifies b (U32.v pos) 2 (fun s -> E.le_to_n s == U16.v x') h h';
   2ul
+#pop-options
 
 let write_bounded_integer_le_2 = leaf_writer_strong_of_serializer32 serialize32_bounded_integer_le_2 ()
 

--- a/src/lowparse/LowParse.SLow.BoundedInt.fst
+++ b/src/lowparse/LowParse.SLow.BoundedInt.fst
@@ -1,6 +1,8 @@
 module LowParse.SLow.BoundedInt
 
 open LowParse.SLow.Combinators
+#set-options "--split_queries no"
+#set-options "--z3rlimit 20"
 
 module Seq = FStar.Seq
 module U8  = FStar.UInt8
@@ -374,6 +376,9 @@ let serialize32_bounded_int32_le'
     (fun x -> x)
     ()
 
+#push-options "--z3rlimit 40"
+#restart-solver // somehow needed
+
 let serialize32_bounded_int32_le_1
   min max
 = serialize32_bounded_int32_le' min max 1ul
@@ -397,3 +402,5 @@ let parse32_bounded_int32_le_fixed_size
 let serialize32_bounded_int32_le_fixed_size
   min32 max32
 = serialize32_filter serialize32_u32_le (in_bounds (U32.v min32) (U32.v max32))
+
+#pop-options


### PR DESCRIPTION
Hi Tahina, I needed to bump some rlimits to get an everest green for a change that's coming to F* (https://github.com/FStarLang/FStar/commit/fc1b447469df181057d6cf2c7d16926cc61cbfd4, https://github.com/FStarLang/FStar/issues/2894).

Would be good if, given that it comes back green, we merge this before to avoid breakage and syncing up.