### PR TITLE
Define KRML_HOST_IGNORE to mark unused arguments

### DIFF
--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -29,6 +29,6 @@
 
     "RepoVersions" : {
         "mitls_version" : "origin/dev",
-        "karamel_version" : "origin/master"
+        "karamel_version" : "origin/protz_all_warnings_on"
     }
 }

--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -29,6 +29,6 @@
 
     "RepoVersions" : {
         "mitls_version" : "origin/dev",
-        "karamel_version" : "origin/protz_all_warnings_on"
+        "karamel_version" : "origin/master"
     }
 }

--- a/src/3d/EverParseEndianness.h
+++ b/src/3d/EverParseEndianness.h
@@ -36,6 +36,10 @@ extern "C" {
 typedef const char * EVERPARSE_STRING;
 typedef EVERPARSE_STRING PRIMS_STRING;
 
+#ifndef KRML_HOST_IGNORE
+#  define KRML_HOST_IGNORE(x) (void)(x);
+#endif
+
 #ifndef KRML_HOST_PRINTF
 #  include <stdio.h>
 #  define KRML_HOST_PRINTF printf

--- a/src/3d/EverParseEndianness_Windows_NT.h
+++ b/src/3d/EverParseEndianness_Windows_NT.h
@@ -37,6 +37,10 @@ nswamy, protz, taramana 5-Feb-2020
 typedef const char * EVERPARSE_STRING;
 typedef EVERPARSE_STRING PRIMS_STRING;
 
+#ifndef KRML_HOST_IGNORE
+#  define KRML_HOST_IGNORE(x) (void)(x);
+#endif
+
 #ifndef KRML_HOST_PRINTF
 #  include <stdio.h>
 #  define KRML_HOST_PRINTF printf


### PR DESCRIPTION
FStarLang/karamel#381 now generates `KRML_HOST_IGNORE(x)` in the body of a validator `v(x)` if `x` is an argument not used in that body.

Since EverParse uses `krml -minimal` and defines all Karamel constants and symbols in `EverParseEndianness.h`  and `EverParseEndianness_Windows_NT.h`, we need to define `KRML_HOST_IGNORE` there.

This issue should fix #80 .
