### PR TITLE
Generate test checker executable

### DIFF
--- a/doc/3d-snapshot/BF.c
+++ b/doc/3d-snapshot/BF.c
@@ -57,53 +57,55 @@ ValidateBf2bis(
   uint16_t bitfield0 = (uint16_t)(uint32_t)r0;
   /* Checking that we have enough space for a UINT16, i.e., 2 bytes */
   BOOLEAN hasBytes1 = 2ULL <= (InputLength - positionAfterBitfield0);
-  uint64_t positionAfternone;
+  uint64_t positionAfterBitfield1;
   if (hasBytes1)
   {
-    positionAfternone = positionAfterBitfield0 + 2ULL;
+    positionAfterBitfield1 = positionAfterBitfield0 + 2ULL;
   }
   else
   {
-    positionAfternone =
+    positionAfterBitfield1 =
       EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
         positionAfterBitfield0);
   }
   uint64_t positionAfterBf2bis0;
-  if (EverParseIsError(positionAfternone))
+  if (EverParseIsError(positionAfterBitfield1))
   {
-    positionAfterBf2bis0 = positionAfternone;
+    positionAfterBf2bis0 = positionAfterBitfield1;
   }
   else
   {
     uint16_t r = Load16Le(Input + (uint32_t)positionAfterBitfield0);
-    uint16_t none = (uint16_t)(uint32_t)r;
+    uint16_t bitfield1 = (uint16_t)(uint32_t)r;
     BOOLEAN
-    noneConstraintIsOk =
-      EverParseGetBitfield16(none,
+    bitfield1constraintIsOk =
+      EverParseGetBitfield16(bitfield1,
         0U,
         12U)
       < EverParseGetBitfield16(bitfield0, 0U, 6U);
     uint64_t
-    positionAfternone1 = EverParseCheckConstraintOk(noneConstraintIsOk, positionAfternone);
-    if (EverParseIsError(positionAfternone1))
+    positionAfterBitfield11 =
+      EverParseCheckConstraintOk(bitfield1constraintIsOk,
+        positionAfterBitfield1);
+    if (EverParseIsError(positionAfterBitfield11))
     {
-      positionAfterBf2bis0 = positionAfternone1;
+      positionAfterBf2bis0 = positionAfterBitfield11;
     }
     else
     {
       /* Validating field z */
       /* Checking that we have enough space for a UINT8, i.e., 1 byte */
-      BOOLEAN hasBytes = 1ULL <= (InputLength - positionAfternone1);
+      BOOLEAN hasBytes = 1ULL <= (InputLength - positionAfterBitfield11);
       uint64_t positionAfterBf2bis;
       if (hasBytes)
       {
-        positionAfterBf2bis = positionAfternone1 + 1ULL;
+        positionAfterBf2bis = positionAfterBitfield11 + 1ULL;
       }
       else
       {
         positionAfterBf2bis =
           EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
-            positionAfternone1);
+            positionAfterBitfield11);
       }
       uint64_t res;
       if (EverParseIsSuccess(positionAfterBf2bis))
@@ -118,7 +120,7 @@ ValidateBf2bis(
           EverParseGetValidatorErrorKind(positionAfterBf2bis),
           Ctxt,
           Input,
-          positionAfternone1);
+          positionAfterBitfield11);
         res = positionAfterBf2bis;
       }
       positionAfterBf2bis0 = res;
@@ -129,7 +131,7 @@ ValidateBf2bis(
     return positionAfterBf2bis0;
   }
   ErrorHandlerFn("_BF2bis",
-    "none",
+    "__bitfield_1",
     EverParseErrorReasonOfResult(positionAfterBf2bis0),
     EverParseGetValidatorErrorKind(positionAfterBf2bis0),
     Ctxt,
@@ -192,52 +194,54 @@ ValidateBf3(
   uint16_t bitfield0 = Load16Be(Input + (uint32_t)StartPosition);
   /* Checking that we have enough space for a UINT16BE, i.e., 2 bytes */
   BOOLEAN hasBytes1 = 2ULL <= (InputLength - positionAfterBitfield0);
-  uint64_t positionAfternone;
+  uint64_t positionAfterBitfield1;
   if (hasBytes1)
   {
-    positionAfternone = positionAfterBitfield0 + 2ULL;
+    positionAfterBitfield1 = positionAfterBitfield0 + 2ULL;
   }
   else
   {
-    positionAfternone =
+    positionAfterBitfield1 =
       EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
         positionAfterBitfield0);
   }
   uint64_t positionAfterBf30;
-  if (EverParseIsError(positionAfternone))
+  if (EverParseIsError(positionAfterBitfield1))
   {
-    positionAfterBf30 = positionAfternone;
+    positionAfterBf30 = positionAfterBitfield1;
   }
   else
   {
-    uint16_t none = Load16Be(Input + (uint32_t)positionAfterBitfield0);
+    uint16_t bitfield1 = Load16Be(Input + (uint32_t)positionAfterBitfield0);
     BOOLEAN
-    noneConstraintIsOk =
-      EverParseGetBitfield16MsbFirst(none,
+    bitfield1constraintIsOk =
+      EverParseGetBitfield16MsbFirst(bitfield1,
         0U,
         12U)
       < EverParseGetBitfield16MsbFirst(bitfield0, 0U, 6U);
     uint64_t
-    positionAfternone1 = EverParseCheckConstraintOk(noneConstraintIsOk, positionAfternone);
-    if (EverParseIsError(positionAfternone1))
+    positionAfterBitfield11 =
+      EverParseCheckConstraintOk(bitfield1constraintIsOk,
+        positionAfterBitfield1);
+    if (EverParseIsError(positionAfterBitfield11))
     {
-      positionAfterBf30 = positionAfternone1;
+      positionAfterBf30 = positionAfterBitfield11;
     }
     else
     {
       /* Validating field z */
       /* Checking that we have enough space for a UINT8BE, i.e., 1 byte */
-      BOOLEAN hasBytes = 1ULL <= (InputLength - positionAfternone1);
+      BOOLEAN hasBytes = 1ULL <= (InputLength - positionAfterBitfield11);
       uint64_t positionAfterBf3;
       if (hasBytes)
       {
-        positionAfterBf3 = positionAfternone1 + 1ULL;
+        positionAfterBf3 = positionAfterBitfield11 + 1ULL;
       }
       else
       {
         positionAfterBf3 =
           EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
-            positionAfternone1);
+            positionAfterBitfield11);
       }
       uint64_t res;
       if (EverParseIsSuccess(positionAfterBf3))
@@ -252,7 +256,7 @@ ValidateBf3(
           EverParseGetValidatorErrorKind(positionAfterBf3),
           Ctxt,
           Input,
-          positionAfternone1);
+          positionAfterBitfield11);
         res = positionAfterBf3;
       }
       positionAfterBf30 = res;
@@ -263,7 +267,7 @@ ValidateBf3(
     return positionAfterBf30;
   }
   ErrorHandlerFn("_BF3",
-    "none",
+    "__bitfield_1",
     EverParseErrorReasonOfResult(positionAfterBf30),
     EverParseGetValidatorErrorKind(positionAfterBf30),
     Ctxt,

--- a/doc/3d-snapshot/BoundedSumWhere.c
+++ b/doc/3d-snapshot/BoundedSumWhere.c
@@ -21,35 +21,37 @@ BoundedSumWhereValidateBoundedSum(
   uint64_t StartPosition
 )
 {
-  uint64_t positionAfternone = StartPosition;
+  uint64_t positionAfterPrecondition = StartPosition;
   uint64_t positionAfterBoundedSum;
-  if (EverParseIsError(positionAfternone))
+  if (EverParseIsError(positionAfterPrecondition))
   {
-    positionAfterBoundedSum = positionAfternone;
+    positionAfterBoundedSum = positionAfterPrecondition;
   }
   else
   {
-    BOOLEAN noneConstraintIsOk = Bound <= (uint32_t)1729U;
+    BOOLEAN preconditionConstraintIsOk = Bound <= (uint32_t)1729U;
     uint64_t
-    positionAfternone1 = EverParseCheckConstraintOk(noneConstraintIsOk, positionAfternone);
-    if (EverParseIsError(positionAfternone1))
+    positionAfterPrecondition1 =
+      EverParseCheckConstraintOk(preconditionConstraintIsOk,
+        positionAfterPrecondition);
+    if (EverParseIsError(positionAfterPrecondition1))
     {
-      positionAfterBoundedSum = positionAfternone1;
+      positionAfterBoundedSum = positionAfterPrecondition1;
     }
     else
     {
       /* Checking that we have enough space for a UINT32, i.e., 4 bytes */
-      BOOLEAN hasBytes0 = 4ULL <= (InputLength - positionAfternone1);
+      BOOLEAN hasBytes0 = 4ULL <= (InputLength - positionAfterPrecondition1);
       uint64_t positionAfterBoundedSum0;
       if (hasBytes0)
       {
-        positionAfterBoundedSum0 = positionAfternone1 + 4ULL;
+        positionAfterBoundedSum0 = positionAfterPrecondition1 + 4ULL;
       }
       else
       {
         positionAfterBoundedSum0 =
           EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
-            positionAfternone1);
+            positionAfterPrecondition1);
       }
       uint64_t positionAfterleft;
       if (EverParseIsSuccess(positionAfterBoundedSum0))
@@ -64,7 +66,7 @@ BoundedSumWhereValidateBoundedSum(
           EverParseGetValidatorErrorKind(positionAfterBoundedSum0),
           Ctxt,
           Input,
-          positionAfternone1);
+          positionAfterPrecondition1);
         positionAfterleft = positionAfterBoundedSum0;
       }
       if (EverParseIsError(positionAfterleft))
@@ -73,7 +75,7 @@ BoundedSumWhereValidateBoundedSum(
       }
       else
       {
-        uint32_t left = Load32Le(Input + (uint32_t)positionAfternone1);
+        uint32_t left = Load32Le(Input + (uint32_t)positionAfterPrecondition1);
         /* Validating field right */
         /* Checking that we have enough space for a UINT32, i.e., 4 bytes */
         BOOLEAN hasBytes = 4ULL <= (InputLength - positionAfterleft);
@@ -128,7 +130,7 @@ BoundedSumWhereValidateBoundedSum(
     return positionAfterBoundedSum;
   }
   ErrorHandlerFn("_boundedSum",
-    "none",
+    "__precondition",
     EverParseErrorReasonOfResult(positionAfterBoundedSum),
     EverParseGetValidatorErrorKind(positionAfterBoundedSum),
     Ctxt,

--- a/doc/3d-snapshot/EnumConstraint.c
+++ b/doc/3d-snapshot/EnumConstraint.c
@@ -22,52 +22,51 @@ EnumConstraintValidateEnumConstraint(
 {
   /* Checking that we have enough space for a UINT32, i.e., 4 bytes */
   BOOLEAN hasBytes0 = 4ULL <= (InputLength - StartPosition);
-  uint64_t positionAfternone;
+  uint64_t positionAftercol;
   if (hasBytes0)
   {
-    positionAfternone = StartPosition + 4ULL;
+    positionAftercol = StartPosition + 4ULL;
   }
   else
   {
-    positionAfternone =
+    positionAftercol =
       EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
         StartPosition);
   }
   uint64_t positionAfterEnumConstraint;
-  if (EverParseIsError(positionAfternone))
+  if (EverParseIsError(positionAftercol))
   {
-    positionAfterEnumConstraint = positionAfternone;
+    positionAfterEnumConstraint = positionAftercol;
   }
   else
   {
-    uint32_t none = Load32Le(Input + (uint32_t)StartPosition);
+    uint32_t col = Load32Le(Input + (uint32_t)StartPosition);
     BOOLEAN
-    noneConstraintIsOk =
-      none
+    colConstraintIsOk =
+      col
       == ENUMCONSTRAINT_RED
-      || none == ENUMCONSTRAINT_GREEN
-      || none == ENUMCONSTRAINT_BLUE;
-    uint64_t
-    positionAfternone1 = EverParseCheckConstraintOk(noneConstraintIsOk, positionAfternone);
-    if (EverParseIsError(positionAfternone1))
+      || col == ENUMCONSTRAINT_GREEN
+      || col == ENUMCONSTRAINT_BLUE;
+    uint64_t positionAftercol1 = EverParseCheckConstraintOk(colConstraintIsOk, positionAftercol);
+    if (EverParseIsError(positionAftercol1))
     {
-      positionAfterEnumConstraint = positionAfternone1;
+      positionAfterEnumConstraint = positionAftercol1;
     }
     else
     {
       /* Validating field x */
       /* Checking that we have enough space for a UINT32, i.e., 4 bytes */
-      BOOLEAN hasBytes = 4ULL <= (InputLength - positionAfternone1);
+      BOOLEAN hasBytes = 4ULL <= (InputLength - positionAftercol1);
       uint64_t positionAfterx_refinement;
       if (hasBytes)
       {
-        positionAfterx_refinement = positionAfternone1 + 4ULL;
+        positionAfterx_refinement = positionAftercol1 + 4ULL;
       }
       else
       {
         positionAfterx_refinement =
           EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
-            positionAfternone1);
+            positionAftercol1);
       }
       uint64_t positionAfterEnumConstraint0;
       if (EverParseIsError(positionAfterx_refinement))
@@ -77,10 +76,10 @@ EnumConstraintValidateEnumConstraint(
       else
       {
         /* reading field_value */
-        uint32_t x_refinement = Load32Le(Input + (uint32_t)positionAfternone1);
+        uint32_t x_refinement = Load32Le(Input + (uint32_t)positionAftercol1);
         /* start: checking constraint */
         BOOLEAN
-        x_refinementConstraintIsOk = x_refinement == (uint32_t)0U || none == ENUMCONSTRAINT_GREEN;
+        x_refinementConstraintIsOk = x_refinement == (uint32_t)0U || col == ENUMCONSTRAINT_GREEN;
         /* end: checking constraint */
         positionAfterEnumConstraint0 =
           EverParseCheckConstraintOk(x_refinementConstraintIsOk,
@@ -98,7 +97,7 @@ EnumConstraintValidateEnumConstraint(
           EverParseGetValidatorErrorKind(positionAfterEnumConstraint0),
           Ctxt,
           Input,
-          positionAfternone1);
+          positionAftercol1);
         positionAfterEnumConstraint = positionAfterEnumConstraint0;
       }
     }
@@ -108,7 +107,7 @@ EnumConstraintValidateEnumConstraint(
     return positionAfterEnumConstraint;
   }
   ErrorHandlerFn("_enum_constraint",
-    "none",
+    "col",
     EverParseErrorReasonOfResult(positionAfterEnumConstraint),
     EverParseGetValidatorErrorKind(positionAfterEnumConstraint),
     Ctxt,

--- a/doc/3d-snapshot/Smoker.c
+++ b/doc/3d-snapshot/Smoker.c
@@ -22,47 +22,46 @@ SmokerValidateSmoker(
 {
   /* Checking that we have enough space for a UINT32, i.e., 4 bytes */
   BOOLEAN hasBytes0 = 4ULL <= (InputLength - StartPosition);
-  uint64_t positionAfternone;
+  uint64_t positionAfterage;
   if (hasBytes0)
   {
-    positionAfternone = StartPosition + 4ULL;
+    positionAfterage = StartPosition + 4ULL;
   }
   else
   {
-    positionAfternone =
+    positionAfterage =
       EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
         StartPosition);
   }
   uint64_t positionAfterSmoker;
-  if (EverParseIsError(positionAfternone))
+  if (EverParseIsError(positionAfterage))
   {
-    positionAfterSmoker = positionAfternone;
+    positionAfterSmoker = positionAfterage;
   }
   else
   {
-    uint32_t none = Load32Le(Input + (uint32_t)StartPosition);
-    BOOLEAN noneConstraintIsOk = none >= (uint32_t)21U;
-    uint64_t
-    positionAfternone1 = EverParseCheckConstraintOk(noneConstraintIsOk, positionAfternone);
-    if (EverParseIsError(positionAfternone1))
+    uint32_t age = Load32Le(Input + (uint32_t)StartPosition);
+    BOOLEAN ageConstraintIsOk = age >= (uint32_t)21U;
+    uint64_t positionAfterage1 = EverParseCheckConstraintOk(ageConstraintIsOk, positionAfterage);
+    if (EverParseIsError(positionAfterage1))
     {
-      positionAfterSmoker = positionAfternone1;
+      positionAfterSmoker = positionAfterage1;
     }
     else
     {
       /* Validating field cigarettesConsumed */
       /* Checking that we have enough space for a UINT8, i.e., 1 byte */
-      BOOLEAN hasBytes = 1ULL <= (InputLength - positionAfternone1);
+      BOOLEAN hasBytes = 1ULL <= (InputLength - positionAfterage1);
       uint64_t positionAfterSmoker0;
       if (hasBytes)
       {
-        positionAfterSmoker0 = positionAfternone1 + 1ULL;
+        positionAfterSmoker0 = positionAfterage1 + 1ULL;
       }
       else
       {
         positionAfterSmoker0 =
           EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
-            positionAfternone1);
+            positionAfterage1);
       }
       uint64_t res;
       if (EverParseIsSuccess(positionAfterSmoker0))
@@ -77,7 +76,7 @@ SmokerValidateSmoker(
           EverParseGetValidatorErrorKind(positionAfterSmoker0),
           Ctxt,
           Input,
-          positionAfternone1);
+          positionAfterage1);
         res = positionAfterSmoker0;
       }
       positionAfterSmoker = res;
@@ -88,7 +87,7 @@ SmokerValidateSmoker(
     return positionAfterSmoker;
   }
   ErrorHandlerFn("_smoker",
-    "none",
+    "age",
     EverParseErrorReasonOfResult(positionAfterSmoker),
     EverParseGetValidatorErrorKind(positionAfterSmoker),
     Ctxt,

--- a/src/3d/Main.fst
+++ b/src/3d/Main.fst
@@ -551,7 +551,7 @@ let produce_z3_and_test
   (name: string)
 : Tot process_files_t
 = produce_z3_and_test_gen batch out_dir (fun out_file nbwitnesses prog z3 ->
-    Z3TestGen.do_test out_file z3 prog name nbwitnesses (Options.get_z3_pos_test ()) (Options.get_z3_neg_test ())
+    Z3TestGen.do_test out_dir out_file z3 prog name nbwitnesses (Options.get_z3_pos_test ()) (Options.get_z3_neg_test ())
   )
 
 let produce_z3_and_diff_test
@@ -562,7 +562,7 @@ let produce_z3_and_diff_test
 =
   let (name1, name2) = names in
   produce_z3_and_test_gen batch out_dir (fun out_file nbwitnesses prog z3 ->
-    Z3TestGen.do_diff_test out_file z3 prog name1 name2 nbwitnesses
+    Z3TestGen.do_diff_test out_dir out_file z3 prog name1 name2 nbwitnesses
   )
 
 let produce_test_checker_exe

--- a/src/3d/Main.fst
+++ b/src/3d/Main.fst
@@ -495,7 +495,7 @@ let build_test_exe
 =
   if not (Options.get_skip_c_makefiles ())
   then begin
-    OS.run_cmd "make" ["-C"; out_dir; "-f"; "Makefile.basic"; "USER_TARGET=test.exe"]
+    OS.run_cmd "make" ["-C"; out_dir; "-f"; "Makefile.basic"; "USER_TARGET=test.exe"; "USER_CFLAGS=-Wno-type-limits"]
   end
 
 let build_and_run_test_exe

--- a/src/3d/OS.fsti
+++ b/src/3d/OS.fsti
@@ -25,6 +25,10 @@ val file_exists: string -> FStar.All.ML bool
 
 val file_contents: string -> FStar.All.ML string
 
+(* Write a witness into a binary file *)
+
+val write_witness_to_file: list int -> string -> FStar.All.ML unit
+
 (* Moved here to break dependency cycle *)
 
 val int_of_string (x:string) : FStar.All.ML int

--- a/src/3d/Options.fst
+++ b/src/3d/Options.fst
@@ -133,6 +133,8 @@ let z3_witnesses : ref (option vstring) = alloc None
 
 let z3_executable : ref (option vstring) = alloc None
 
+let test_checker : ref (option vstring) = alloc None
+
 noeq
 type cmd_option_kind =
   | OptBool:
@@ -364,6 +366,7 @@ let (display_usage_2, compute_options_2, fstar_options) =
     CmdOption "save_z3_transcript" (OptStringOption "some file name" always_valid save_z3_transcript) "Save the Z3 transcript (input and output) to a file" [];
     CmdOption "skip_c_makefiles" (OptBool skip_c_makefiles) "Do not Generate Makefile.basic, Makefile.include" [];
     CmdOption "skip_o_rules" (OptBool skip_o_rules) "With --makefile, do not generate rules for .o files" [];
+    CmdOption "test_checker" (OptStringOption "parser name" always_valid test_checker) "produce a test checker executable" [];
     CmdFStarOption (let open FStar.Getopt in noshort, "version", ZeroArgs (fun _ -> FStar.IO.print_string (Printf.sprintf "EverParse/3d %s\nCopyright 2018, 2019, 2020 Microsoft Corporation\n" Version.everparse_version); exit 0), "Show this version of EverParse");
     CmdOption "equate_types" (OptList "an argument of the form A,B, to generate asserts of the form (A.t == B.t)" valid_equate_types equate_types_list) "Takes an argument of the form A,B and then for each entrypoint definition in B, it generates an assert (A.t == B.t) in the B.Types file, useful when refactoring specs, you can provide multiple equate_types on the command line" [];
     CmdOption "z3_diff_test" (OptStringOption "parser1,parser2" valid_equate_types z3_diff_test) "produce differential tests for two parsers" [];
@@ -574,3 +577,5 @@ let get_z3_executable () =
   | Some z3 -> z3
 
 let get_save_z3_transcript () = !save_z3_transcript
+
+let get_test_checker () = !test_checker

--- a/src/3d/Options.fsti
+++ b/src/3d/Options.fsti
@@ -77,3 +77,5 @@ val get_debug: unit -> ML bool
 val get_z3_diff_test: unit -> ML (option (string & string))
 
 val get_save_z3_transcript: unit -> ML (option string)
+
+val get_test_checker: unit -> ML (option string)

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -1118,6 +1118,15 @@ let wrapper_name
     fn
   |> pascal_case
 
+let validator_name
+  (modul: string)
+  (fn: string)
+: ML string
+= Printf.sprintf "%s_validate_%s"
+    modul
+    fn
+  |> pascal_case
+
 let print_c_entry
                   (produce_everparse_error: opt_produce_everparse_error)
                   (modul: string)
@@ -1236,12 +1245,7 @@ let print_c_entry
              wrapper_name
              (print_params params)
     in
-    let validator_name =
-       Printf.sprintf "%s_validate_%s"
-         modul
-         d.decl_name.td_name.A.v.A.name
-       |> pascal_case
-    in
+    let validator_name = validator_name modul d.decl_name.td_name.A.v.A.name in
     let impl =
       let body = 
         if is_input_stream_buffer

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -1329,7 +1329,7 @@ let print_c_entry
     if HashingOptions.InputStreamBuffer? input_stream_binding
     then Printf.sprintf "void %sEverParseError(const char *StructName, const char *FieldName, const char *Reason)%s"
                          modul
-                         (if produce_everparse_error = Some ProduceEverParseError then "{}" else ";")
+                         (if produce_everparse_error = Some ProduceEverParseError then "{(void) StructName; (void) FieldName; (void) Reason;}" else ";")
     else ""
   in
   let impl =

--- a/src/3d/Target.fsti
+++ b/src/3d/Target.fsti
@@ -421,6 +421,7 @@ val print_decls (modul: string) (ds:list decl) : ML string
 val print_types_decls (modul: string) (ds:list decl) : ML string
 val print_decls_signature (modul: string) (ds:list decl) : ML string
 val wrapper_name (modul: string) (fn: string) : ML string
+val validator_name (modul: string) (fn: string) : ML string
 type produce_everparse_error = | ProduceEverParseError
 type opt_produce_everparse_error = option produce_everparse_error
 val print_c_entry (_: opt_produce_everparse_error) (modul: string) (env: global_env) (ds:list decl)

--- a/src/3d/TranslateForInterpreter.fst
+++ b/src/3d/TranslateForInterpreter.fst
@@ -185,7 +185,7 @@ let pair_parser n1 p1 p2 =
     mk_parser (pk_and_then p1.p_kind p2.p_kind)
               pt
               t_id
-              "none"
+              (ident_to_string n1)
               (Parse_pair n1 p1 p2)
 let dep_pair_typ t1 (t2:(A.ident & T.typ)) : T.typ =
     T.T_dep_pair t1 t2
@@ -202,7 +202,7 @@ let dep_pair_parser n1 p1 (p2:A.ident & T.parser) =
       (pk_and_then p1.p_kind (snd p2).p_kind) 
       t
       t_id
-      "none"
+      (ident_to_string n1)
       (Parse_dep_pair n1 p1 (Some (fst p2), snd p2))
 let dep_pair_with_refinement_parser n1 p1 (e:T.lam T.expr) (p2:A.ident & T.parser) =
   let open T in
@@ -214,7 +214,7 @@ let dep_pair_with_refinement_parser n1 p1 (e:T.lam T.expr) (p2:A.ident & T.parse
       (pk_and_then k1 (snd p2).p_kind)
       t
       t_id
-      "none"
+      (ident_to_string n1)
       (Parse_dep_pair_with_refinement n1 p1 e (Some (fst p2), snd p2))
 let dep_pair_with_refinement_and_action_parser n1 p1 (e:T.lam T.expr) (a:T.lam T.action) (p2:A.ident & T.parser) =
   let open T in
@@ -226,7 +226,7 @@ let dep_pair_with_refinement_and_action_parser n1 p1 (e:T.lam T.expr) (a:T.lam T
       (pk_and_then k1 (snd p2).p_kind)
       t
       t_id
-      "none"
+      (ident_to_string n1)
       (Parse_dep_pair_with_refinement_and_action n1 p1 e a (Some (fst p2), snd p2))
 let dep_pair_with_action_parser p1 (a:T.lam T.action) (p2:A.ident & T.parser) =
   let open T in

--- a/src/3d/Z3TestGen.fst
+++ b/src/3d/Z3TestGen.fst
@@ -13,6 +13,14 @@ let prelude : string =
 (declare-datatypes () ((State (mk-state (input-size Int) (choice-index Int)))))
 (declare-datatypes () ((Result (mk-result (return-value Int) (after-state State)))))
 
+; From EverParse3d.ErrorCode.is_range_okay
+(define-fun is_range_okay ((size Int) (offset Int) (access_size Int)) Bool
+  (and
+    (>= size access_size)
+    (>= (- size access_size) offset)
+  )
+)
+
 (define-fun parse-empty ((x State)) Result
   (mk-result 0 x)
 )

--- a/src/3d/ocaml/OS.ml
+++ b/src/3d/ocaml/OS.ml
@@ -121,4 +121,13 @@ let file_contents f =
   close_in ic;
   s
 
+let write_witness_to_file w filename =
+  BatFile.with_file_out filename (fun out ->
+    List.iter
+      (fun x ->
+        BatIO.write out (char_of_int (Z.to_int x))
+      )
+      w
+  )
+
 let int_of_string x = Z.of_string x

--- a/src/3d/tests/TestSMT.3d
+++ b/src/3d/tests/TestSMT.3d
@@ -9,3 +9,10 @@ typedef struct test2 {
   UINT8 x { x >= 10 };
   UINT8 y { (UINT16)x + (UINT16)y <= 30 };
 } test2_t;
+
+entrypoint
+typedef struct test3 {
+  UINT8 x { x >= 10 };
+  UINT8 y { (UINT16)x + (UINT16)y <= 30 };
+  UINT8 rab;
+} test3_t;


### PR DESCRIPTION
This PR introduces 3D option `--test_checker`, which, when followed by a parser name of the form `Modulename.parsername`, generates a test executable, `test.exe`, so that `./test.exe filename.dat arg1 arg2...` opens the file `filename.dat` and runs the validator for `Modulename.parsername`, with arguments `arg1`, `arg2`..., on the binary data contained in that file, and returns 0 if the data in the file passes validation, 1 if it fails validation, 2 for any other error (wrong number of arguments, file is missing, cannot mmap, etc.)

The file passed to `test.exe` is assumed to contain all of the input data to be passed to the validator, in binary form. If the user wants to start from some `filename.hex` that contains hex data instead (e.g. .pcap), it is the responsibility of the user to first run something like `xxd -r -p filename.hex filename.dat ` to convert that hex file to a binary file before passing the latter to `test.exe`

This should fix #105 