### PR TITLE
Two bug fixes

### DIFF
--- a/src/3d/Binding.fst
+++ b/src/3d/Binding.fst
@@ -552,7 +552,8 @@ let rec check_out_expr (env:env) (oe0:out_expr)
     (match bopt with
      | None ->
        {oe0 with
-        out_expr_node={oe0.out_expr_node with v=OE_addrof oe};
+        out_expr_node={oe0.out_expr_node with v=OE_addrof oe};
+
         out_expr_meta=Some ({
           out_expr_base_t = oe_bt;
           out_expr_t = with_range (Pointer oe_t) oe.out_expr_node.range;
@@ -1452,15 +1453,15 @@ let elaborate_bit_fields env (fields:list field)
                    (print_typ sf.field_type)
                    (print_typ bit_field_typ));
 
+             let type_matches_current_open_field = eq_typ env sf.field_type bit_field_typ in
              if remaining_size < bw.v //not enough space in this bit field, start a new one
+             || not type_matches_current_open_field
              then let _ = next_bf_index () in
                   let af, open_bit_field = new_bit_field sf bw hd.range in
                   let tl = aux open_bit_field tl in
                   { hd with v = AtomicField af } :: tl
              else //extend this bit field
                   begin
-                   if not (eq_typ env sf.field_type bit_field_typ)
-                   then raise (error "Packing fields of different types into the same bit field is not yet supported" hd.range);
                    let remaining_size = remaining_size - bw.v in
                    let from = pos in
                    let to = pos + bw.v in

--- a/src/3d/tests/Bitfields0.3d
+++ b/src/3d/tests/Bitfields0.3d
@@ -42,3 +42,11 @@ typedef struct _BFA (mutable UINT8 *outx, mutable UINT8 *outy, mutable UINT8 *ou
      {:act *outz = z; };     
    UINT32 blah;
 } BFA;
+
+//bitfield boundaries coincide with the the types of their underlying fields
+typedef struct _BFBoundary {
+   UINT16 x : 12; //4 bits of padding here are implicit
+   UINT8 y : 4;
+   UINT8 z : 3; //y and z are packed, but with 1 bit of padding left
+   UINT16 w : 12; //4 bits of padding here are implicit
+} BFBoundary;

--- a/src/3d/tests/FAILArrayBitWidth.3d
+++ b/src/3d/tests/FAILArrayBitWidth.3d
@@ -1,0 +1,5 @@
+entrypoint
+typedef struct _dummy {
+   UINT8 a:4[2];
+   UINT32 b;
+} dummy;

--- a/src/3d/tests/FAILArrayRefinement.3d
+++ b/src/3d/tests/FAILArrayRefinement.3d
@@ -1,0 +1,5 @@
+entrypoint
+typedef struct _dummy {
+   UINT8 a[2]{ a == 0};
+   UINT32 b;
+} dummy;

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -33,7 +33,7 @@ all: batch-test batch-test-negative batch-cleanup-test inplace-hash-test modules
 
 #AR: TODO: remove ELF.3d from here
 
-INTERPRETABLE_FILES=$(filter-out FAILNoEntrypoint.3d ELF.3d, $(wildcard *.3d))
+INTERPRETABLE_FILES=$(filter-out FAIL%.3d ELF.3d, $(wildcard *.3d))
 INTERPRETABLE_MODULES=$(basename $(INTERPRETABLE_FILES))
 interpret_all: $(addsuffix .interpret, $(INTERPRETABLE_MODULES))
 


### PR DESCRIPTION
* Forbid refinements and bitwidths on non-scalar fields

* A bit field ends with the type of the underlying field changes. Previously 3D would reject this:

```
//bitfield boundaries coincide with the the types of their underlying fields
typedef struct _BFBoundary {
   UINT16 x : 12; //4 bits of padding here are implicit
   UINT8 y : 4;
   UINT8 z : 3; //y and z are packed, but with 1 bit of padding left
   UINT16 w : 12; //4 bits of padding here are implicit
} BFBoundary;
```

since the field `y` could be packed into the 16 bit field that contains `x`, but `y` has a different type than `x`. Now, it is accepted.

Thanks to @Smfakhoury for finding these issues.

