### PR TITLE
VxLAN packets are two octets short.

### DIFF
--- a/src/3d/tests/tcpip/VXLAN.3d
+++ b/src/3d/tests/tcpip/VXLAN.3d
@@ -19,6 +19,6 @@ typedef struct _VXLAN_HEADER
   UINT8BE I:1 { I == 1 };
   UINT8BE R3:3;
   UINT8 Reserved24[3];
-  UINT8 VXLanId;
+  UINT8BE VXLanId[3];
   UINT8 Reserved8;
 } VXLAN_HEADER;


### PR DESCRIPTION
A VxLAN network identifier (VIN) is 24 bits/3 octets.

Found by assembling packets as part of 3DGen:

```bash
@lemmy ➜ /workspaces/RFC-3D (mku-tshark) $ ./validate_with_tshark.py 
Temporary directory created at: /tmp/tmptarwfqr8
Traceback (most recent call last):
  File "/workspaces/RFC-3D/./validate_with_tshark.py", line 47, in <module>
    vxlan = VXLAN(pkt_layer)
  File "/home/codespace/.python/current/lib/python3.10/site-packages/scapy/base_classes.py", line 399, in __call__
    i.__init__(*args, **kargs)
  File "/home/codespace/.python/current/lib/python3.10/site-packages/scapy/packet.py", line 165, in __init__
    self.dissect(_pkt)
  File "/home/codespace/.python/current/lib/python3.10/site-packages/scapy/packet.py", line 1029, in dissect
    s = self.do_dissect(s)
  File "/home/codespace/.python/current/lib/python3.10/site-packages/scapy/packet.py", line 986, in do_dissect
    s, fval = f.getfield(self, s)
  File "/home/codespace/.python/current/lib/python3.10/site-packages/scapy/fields.py", line 1046, in getfield
    return s[3:], self.m2i(pkt, struct.unpack(self.fmt, b"\x00" + s[:3])[0])  # noqa: E501
struct.error: unpack requires a buffer of 4 bytes
```