### PR TITLE
EverParse3d.InputStream.Extern.fst: fix proof regression

### DIFF
--- a/src/3d/prelude/extern/EverParse3d.InputStream.Extern.fst
+++ b/src/3d/prelude/extern/EverParse3d.InputStream.Extern.fst
@@ -219,7 +219,7 @@ let read
 
 #pop-options
 
-#push-options "--z3rlimit 64 --fuel 0 --ifuel 1 --z3cliopt smt.arith.nl=false --using_facts_from '* -FStar.Tactics -FStar.Reflection' --split_queries no"
+#push-options "--z3rlimit 32 --fuel 0 --ifuel 1 --z3cliopt smt.arith.nl=false --using_facts_from '* -FStar.Tactics -FStar.Reflection' --split_queries always --z3refresh"
 #restart-solver
 inline_for_extraction
 noextract


### PR DESCRIPTION
This proof regressed again. I tried to stabilize it by splittin queries, but ran into this:
```
(EverParse3d.InputStream.Extern.fst(246,1-271,5))	Query-stats (EverParse3d.InputStream.Extern.peep, 63)	failed {reason-unknown=unknown because Overflow encountered when expanding old_vector} in 42 milliseconds with fuel 0 and ifuel 1 and rlimit 256 
```
which is a z3 bug. To work around it I also added --z3refresh, and now this works reliably, albeit slowly.

I wanted to add hints but noticed there are none in the repo?