### PR TITLE
Produce and upload a Windows binary package

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -16,3 +16,8 @@ jobs:
         shell: cmd
         run: |
           .\everparse\everparse.cmd src\3d\tests\Arithmetic.3d src\3d\tests\FieldDependence0.3d && .\everparse\everparse.cmd src\3d\tests\Comments.3d && .\everparse\everparse.cmd --check_hashes inplace src\3d\tests\Comments.3d
+      - name: Archive EverParse package
+        uses: actions/upload-artifact@v3
+        with:
+          name: everparse
+          path: everparse

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Build EverParse and its dependencies
         shell: powershell
         run: |
-          .\src\package\windows\build-everparse.ps1
+          .\src\package\windows\build-everparse.ps1 -WithClean
       - name: Test EverParse
         shell: cmd
         run: |

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: Check out repo        
         uses: actions/checkout@v2
       - name: Build EverParse and its dependencies
-        shell: pwsh
+        shell: powershell
         run: |
           .\src\package\windows\build-everparse.ps1
       - name: Test EverParse

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Build EverParse and its dependencies
         shell: powershell
         run: |
-          .\src\package\windows\build-everparse.ps1 -WithClean
+          .\src\package\windows\build-everparse.ps1 -WithClean -DownloadZ3
       - name: Test EverParse
         shell: cmd
         run: |

--- a/src/package/windows/build-everparse.ps1
+++ b/src/package/windows/build-everparse.ps1
@@ -3,6 +3,7 @@
 
 param(
   [switch] $WithClean,
+  [switch] $DownloadZ3,
   [switch] $Release,
   [string] $GHToken,
   [string] $ReleaseOrg,
@@ -61,12 +62,14 @@ $ProgressPreference = 'SilentlyContinue'
 # Switch to this script's directory
 Push-Location -ErrorAction Stop -LiteralPath $PSScriptRoot
 
-# Build z3 with Visual Studio
-$Error.Clear()
-cmd.exe /c .\build-z3.cmd
-if (-not $?) {
-    $Error
-    exit 1
+if (-not $DownloadZ3) {
+  # Build z3 with Visual Studio
+  $Error.Clear()
+  cmd.exe /c .\build-z3.cmd
+  if (-not $?) {
+      $Error
+      exit 1
+  }
 }
 
 $Error.Clear()
@@ -81,11 +84,15 @@ Remove-Item "cygwinsetup.exe"
 
 $Error.Clear()
 Write-Host "Install and build everparse dependencies"
+$everestCmd = "./everest.sh --yes -j 6"
 if ($Release) {
-    Invoke-BashCmd "./everest.sh --yes --release -j 6 check"
-} else {
-    Invoke-BashCmd "./everest.sh --yes -j 6 check"
+   $everestCmd += " --release"
 }
+if ($DownloadZ3) {
+   $everestCmd += " --no-z3"
+}
+$everestCmd += " check"
+Invoke-BashCmd $everestCmd
 if (-not $?) {
     $Error
     exit 1

--- a/src/package/windows/build-everparse.ps1
+++ b/src/package/windows/build-everparse.ps1
@@ -21,7 +21,7 @@ if ($Release) {
 $tmpRoot = "C:\"
 [string] $tmpBaseName = "everparse-cygwin64.tmp"
 if ($WithClean) {
-   Remove-Item -Path ($tmpRoot + $tmpBaseName) -Recurse
+   Remove-Item -Path ($tmpRoot + $tmpBaseName) -Recurse -Force
 }
 New-Item -Path $tmpRoot -Name $tmpBaseName -ItemType directory
 if (-not $?) {

--- a/src/package/windows/build-everparse.ps1
+++ b/src/package/windows/build-everparse.ps1
@@ -2,6 +2,7 @@
 # and builds EverParse.
 
 param(
+  [switch] $WithClean,
   [switch] $Release,
   [string] $GHToken,
   [string] $ReleaseOrg,
@@ -18,6 +19,9 @@ if ($Release) {
 # Choose a temporary directory name for Cygwin
 $tmpRoot = "C:\"
 [string] $tmpBaseName = "everparse-cygwin64.tmp"
+if ($WithClean) {
+   Remove-Item -Path ($tmpRoot + $tmpBaseName) -Recurse
+}
 New-Item -Path $tmpRoot -Name $tmpBaseName -ItemType directory
 if (-not $?) {
    $Error

--- a/src/package/windows/build-everparse.ps1
+++ b/src/package/windows/build-everparse.ps1
@@ -21,7 +21,9 @@ if ($Release) {
 $tmpRoot = "C:\"
 [string] $tmpBaseName = "everparse-cygwin64.tmp"
 if ($WithClean) {
-   Remove-Item -Path ($tmpRoot + $tmpBaseName) -Recurse -Force
+   if (Test-Path ($tmpRoot + $tmpBaseName)) {
+      Remove-Item -Path ($tmpRoot + $tmpBaseName) -Recurse -Force
+   }
 }
 New-Item -Path $tmpRoot -Name $tmpBaseName -ItemType directory
 if (-not $?) {

--- a/src/package/windows/build-everparse.sh
+++ b/src/package/windows/build-everparse.sh
@@ -12,8 +12,8 @@ git config --global --add safe.directory $(pwd)
 # Revert the submodules back to a clean working copy
 submodules="FStar karamel"
 rm -rf $submodules
-git checkout $submodules
-git submodule update --init
+git checkout -- $submodules || true
+git submodule update --init || true
 rm -rf everparse* EverParse* nuget_package
 export EVERPARSE_MAKE_OPTS='-j 12'
 if [[ "$1" = "--release" ]] ; then

--- a/src/package/windows/everest.sh
+++ b/src/package/windows/everest.sh
@@ -235,14 +235,20 @@ use_our_z3 () {
     prompt_yes "write_z3_env_dest_file z3" true
 }
 
+no_z3=false
+
 do_update_z3 () {
-  local current_z3=$(parse_z3_version)
-  echo "... version of z3 found in PATH: $current_z3"
-  local new_z3=4.8.5
-  if [[ $new_z3 != $current_z3 ]]; then
-    red "This is not z3 $current_z3"
-    magenta "Use our existing z3? [Yn]"
-    prompt_yes use_our_z3 false
+  if $no_z3 ; then
+    echo "... skipping z3"
+  else
+    local current_z3=$(parse_z3_version)
+    echo "... version of z3 found in PATH: $current_z3"
+    local new_z3=4.8.5
+    if [[ $new_z3 != $current_z3 ]]; then
+        red "This is not z3 $current_z3"
+        magenta "Use our existing z3? [Yn]"
+        prompt_yes use_our_z3 false
+    fi
   fi
 }
 
@@ -558,7 +564,7 @@ set_opt () {
 # ------------------------------------------------------------------------------
 
 OPTIONS=j:k
-LONGOPTS=yes,release,windows,openssl,opt,admit,no-vale-archive
+LONGOPTS=yes,release,windows,openssl,opt,admit,no-vale-archive,no-z3
 
 # Temporarily stores output to check for errors
 # --alternative allows long options to start with a single '-'
@@ -591,6 +597,11 @@ while true; do
 
         (-release|--release)
             everparse_do_release=1
+            shift
+            ;;
+
+        --no-z3)
+            no_z3=true
             shift
             ;;
 

--- a/src/package/windows/opam-packages
+++ b/src/package/windows/opam-packages
@@ -24,3 +24,5 @@ ppxlib ppxlib
 re re
 odoc odoc
 sha sha
+sexplib sexplib
+memtrace memtrace


### PR DESCRIPTION
This PR enables an action workflow to produce a EverParse binary package for Windows and upload it as a build artifact.

Right now the corresponding workflow is enabled only for pull requests or on-demand, as opposed to Linux binary packages which are produced and uploaded at every push.
