### PR TITLE
Avoid local variable shadowing in generated C code

### DIFF
--- a/doc/3d-snapshot/BF.c
+++ b/doc/3d-snapshot/BF.c
@@ -96,32 +96,32 @@ ValidateBf2bis(
       /* Validating field z */
       /* Checking that we have enough space for a UINT8, i.e., 1 byte */
       BOOLEAN hasBytes = 1ULL <= (InputLength - positionAfterBitfield11);
-      uint64_t positionAfterBf2bis;
+      uint64_t positionAfterBf2bis1;
       if (hasBytes)
       {
-        positionAfterBf2bis = positionAfterBitfield11 + 1ULL;
+        positionAfterBf2bis1 = positionAfterBitfield11 + 1ULL;
       }
       else
       {
-        positionAfterBf2bis =
+        positionAfterBf2bis1 =
           EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
             positionAfterBitfield11);
       }
       uint64_t res;
-      if (EverParseIsSuccess(positionAfterBf2bis))
+      if (EverParseIsSuccess(positionAfterBf2bis1))
       {
-        res = positionAfterBf2bis;
+        res = positionAfterBf2bis1;
       }
       else
       {
         ErrorHandlerFn("_BF2bis",
           "z",
-          EverParseErrorReasonOfResult(positionAfterBf2bis),
-          EverParseGetValidatorErrorKind(positionAfterBf2bis),
+          EverParseErrorReasonOfResult(positionAfterBf2bis1),
+          EverParseGetValidatorErrorKind(positionAfterBf2bis1),
           Ctxt,
           Input,
           positionAfterBitfield11);
-        res = positionAfterBf2bis;
+        res = positionAfterBf2bis1;
       }
       positionAfterBf2bis0 = res;
     }
@@ -232,32 +232,32 @@ ValidateBf3(
       /* Validating field z */
       /* Checking that we have enough space for a UINT8BE, i.e., 1 byte */
       BOOLEAN hasBytes = 1ULL <= (InputLength - positionAfterBitfield11);
-      uint64_t positionAfterBf3;
+      uint64_t positionAfterBf31;
       if (hasBytes)
       {
-        positionAfterBf3 = positionAfterBitfield11 + 1ULL;
+        positionAfterBf31 = positionAfterBitfield11 + 1ULL;
       }
       else
       {
-        positionAfterBf3 =
+        positionAfterBf31 =
           EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
             positionAfterBitfield11);
       }
       uint64_t res;
-      if (EverParseIsSuccess(positionAfterBf3))
+      if (EverParseIsSuccess(positionAfterBf31))
       {
-        res = positionAfterBf3;
+        res = positionAfterBf31;
       }
       else
       {
         ErrorHandlerFn("_BF3",
           "z",
-          EverParseErrorReasonOfResult(positionAfterBf3),
-          EverParseGetValidatorErrorKind(positionAfterBf3),
+          EverParseErrorReasonOfResult(positionAfterBf31),
+          EverParseGetValidatorErrorKind(positionAfterBf31),
           Ctxt,
           Input,
           positionAfterBitfield11);
-        res = positionAfterBf3;
+        res = positionAfterBf31;
       }
       positionAfterBf30 = res;
     }

--- a/doc/3d-snapshot/BoundedSumWhere.c
+++ b/doc/3d-snapshot/BoundedSumWhere.c
@@ -90,10 +90,10 @@ BoundedSumWhereValidateBoundedSum(
             EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
               positionAfterleft);
         }
-        uint64_t positionAfterBoundedSum0;
+        uint64_t positionAfterBoundedSum1;
         if (EverParseIsError(positionAfterright_refinement))
         {
-          positionAfterBoundedSum0 = positionAfterright_refinement;
+          positionAfterBoundedSum1 = positionAfterright_refinement;
         }
         else
         {
@@ -103,24 +103,24 @@ BoundedSumWhereValidateBoundedSum(
           BOOLEAN
           right_refinementConstraintIsOk = left <= Bound && right_refinement <= (Bound - left);
           /* end: checking constraint */
-          positionAfterBoundedSum0 =
+          positionAfterBoundedSum1 =
             EverParseCheckConstraintOk(right_refinementConstraintIsOk,
               positionAfterright_refinement);
         }
-        if (EverParseIsSuccess(positionAfterBoundedSum0))
+        if (EverParseIsSuccess(positionAfterBoundedSum1))
         {
-          positionAfterBoundedSum = positionAfterBoundedSum0;
+          positionAfterBoundedSum = positionAfterBoundedSum1;
         }
         else
         {
           ErrorHandlerFn("_boundedSum",
             "right.refinement",
-            EverParseErrorReasonOfResult(positionAfterBoundedSum0),
-            EverParseGetValidatorErrorKind(positionAfterBoundedSum0),
+            EverParseErrorReasonOfResult(positionAfterBoundedSum1),
+            EverParseGetValidatorErrorKind(positionAfterBoundedSum1),
             Ctxt,
             Input,
             positionAfterleft);
-          positionAfterBoundedSum = positionAfterBoundedSum0;
+          positionAfterBoundedSum = positionAfterBoundedSum1;
         }
       }
     }

--- a/doc/3d-snapshot/GetFieldPtr.c
+++ b/doc/3d-snapshot/GetFieldPtr.c
@@ -47,32 +47,32 @@ GetFieldPtrValidateT(
       {
         /* Checking that we have enough space for a UINT8, i.e., 1 byte */
         BOOLEAN hasBytes = 1ULL <= (truncatedInputLength - position);
-        uint64_t positionAfterT;
+        uint64_t positionAfterT0;
         if (hasBytes)
         {
-          positionAfterT = position + 1ULL;
+          positionAfterT0 = position + 1ULL;
         }
         else
         {
-          positionAfterT =
+          positionAfterT0 =
             EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
               position);
         }
         uint64_t res;
-        if (EverParseIsSuccess(positionAfterT))
+        if (EverParseIsSuccess(positionAfterT0))
         {
-          res = positionAfterT;
+          res = positionAfterT0;
         }
         else
         {
           ErrorHandlerFn("_T",
             "f1.element",
-            EverParseErrorReasonOfResult(positionAfterT),
-            EverParseGetValidatorErrorKind(positionAfterT),
+            EverParseErrorReasonOfResult(positionAfterT0),
+            EverParseGetValidatorErrorKind(positionAfterT0),
             Ctxt,
             truncatedInput,
             position);
-          res = positionAfterT;
+          res = positionAfterT0;
         }
         uint64_t result1 = res;
         result = result1;
@@ -132,32 +132,32 @@ GetFieldPtrValidateT(
       {
         /* Checking that we have enough space for a UINT8, i.e., 1 byte */
         BOOLEAN hasBytes = 1ULL <= (truncatedInputLength - position);
-        uint64_t positionAfterT;
+        uint64_t positionAfterT1;
         if (hasBytes)
         {
-          positionAfterT = position + 1ULL;
+          positionAfterT1 = position + 1ULL;
         }
         else
         {
-          positionAfterT =
+          positionAfterT1 =
             EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA,
               position);
         }
         uint64_t res;
-        if (EverParseIsSuccess(positionAfterT))
+        if (EverParseIsSuccess(positionAfterT1))
         {
-          res = positionAfterT;
+          res = positionAfterT1;
         }
         else
         {
           ErrorHandlerFn("_T",
             "f2.base.element",
-            EverParseErrorReasonOfResult(positionAfterT),
-            EverParseGetValidatorErrorKind(positionAfterT),
+            EverParseErrorReasonOfResult(positionAfterT1),
+            EverParseGetValidatorErrorKind(positionAfterT1),
             Ctxt,
             truncatedInput,
             position);
-          res = positionAfterT;
+          res = positionAfterT1;
         }
         uint64_t result1 = res;
         result = result1;

--- a/doc/3d-snapshot/Triangle2.c
+++ b/doc/3d-snapshot/Triangle2.c
@@ -126,27 +126,27 @@ Triangle2ValidateTriangle(
       else
       {
         uint64_t
-        positionAfterTriangle =
+        positionAfterTriangle0 =
           ValidatePoint(Ctxt,
             ErrorHandlerFn,
             truncatedInput,
             truncatedInputLength,
             position);
         uint64_t result1;
-        if (EverParseIsSuccess(positionAfterTriangle))
+        if (EverParseIsSuccess(positionAfterTriangle0))
         {
-          result1 = positionAfterTriangle;
+          result1 = positionAfterTriangle0;
         }
         else
         {
           ErrorHandlerFn("_triangle",
             "corners.element",
-            EverParseErrorReasonOfResult(positionAfterTriangle),
-            EverParseGetValidatorErrorKind(positionAfterTriangle),
+            EverParseErrorReasonOfResult(positionAfterTriangle0),
+            EverParseGetValidatorErrorKind(positionAfterTriangle0),
             Ctxt,
             truncatedInput,
             position);
-          result1 = positionAfterTriangle;
+          result1 = positionAfterTriangle0;
         }
         result = result1;
         ite = EverParseIsError(result1);

--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -361,6 +361,7 @@ let krml_args input_stream_binding emit_output_types_defs add_include skip_c_mak
                       "-fparentheses" ::
                         "-fcurly-braces" ::
                           "-fmicrosoft" ::
+                          "-fno-shadow" ::
                             "-header" :: filename_concat ddd_home "noheader.txt" ::
                               "-minimal" ::
                                 "-add-include" :: "\"EverParse.h\"" ::


### PR DESCRIPTION
This PR makes 3d call KaRaMeL with the `-fno-shadow` option to avoid local variable shadowing in the generated C code. Thanks @msprotz for your advice!
