### PR TITLE
Fully specify integer parsers

### DIFF
--- a/src/lowparse/LowParse.Spec.BoundedInt.fsti
+++ b/src/lowparse/LowParse.Spec.BoundedInt.fsti
@@ -77,7 +77,29 @@ val parse_bounded_integer_le
 
 val parse_u16_le : parser parse_u16_kind U16.t
 
+val parse_u16_le_spec
+  (b: bytes)
+: Lemma
+  (requires (Seq.length b >= 2))
+  (ensures (
+    let pp = parse parse_u16_le b in
+    Some? pp /\ (
+    let (Some (v, consumed)) = pp in
+    U16.v v == E.le_to_n (Seq.slice b 0 2) /\ consumed == 2
+  )))
+
 val parse_u32_le : parser parse_u32_kind U32.t
+
+val parse_u32_le_spec
+  (b: bytes)
+: Lemma
+  (requires (Seq.length b >= 4))
+  (ensures (
+    let pp = parse parse_u32_le b in
+    Some? pp /\ (
+    let (Some (v, consumed)) = pp in
+    U32.v v == E.le_to_n (Seq.slice b 0 4) /\ consumed == 4
+  )))
 
 val serialize_bounded_integer_le
   (sz: integer_size)

--- a/src/lowparse/LowParse.Spec.Int.fsti
+++ b/src/lowparse/LowParse.Spec.Int.fsti
@@ -23,7 +23,7 @@ val parse_u8_spec
     let pp = parse parse_u8 b in
     Some? pp /\ (
     let (Some (v, consumed)) = pp in
-    U8.v v == E.be_to_n (Seq.slice b 0 1)
+    U8.v v == E.be_to_n (Seq.slice b 0 1) /\ consumed == 1
   )))
 
 val parse_u8_spec'
@@ -34,7 +34,7 @@ val parse_u8_spec'
     let pp = parse parse_u8 b in
     Some? pp /\ (
     let (Some (v, consumed)) = pp in
-    v == Seq.index b 0
+    v == Seq.index b 0 /\ consumed == 1
   )))
 
 val serialize_u8 : serializer parse_u8
@@ -66,7 +66,7 @@ val parse_u16_spec
     let pp = parse parse_u16 b in
     Some? pp /\ (
     let (Some (v, consumed)) = pp in
-    U16.v v == E.be_to_n (Seq.slice b 0 2)
+    U16.v v == E.be_to_n (Seq.slice b 0 2) /\ consumed == 2
   )))
 
 val serialize_u16 : serializer parse_u16
@@ -85,7 +85,7 @@ val parse_u32_spec
     let pp = parse parse_u32 b in
     Some? pp /\ (
     let (Some (v, consumed)) = pp in
-    U32.v v == E.be_to_n (Seq.slice b 0 4)
+    U32.v v == E.be_to_n (Seq.slice b 0 4) /\ consumed == 4
   )))
 
 val serialize_u32 : serializer parse_u32
@@ -104,7 +104,7 @@ val parse_u64_spec
     let pp = parse parse_u64 b in
     Some? pp /\ (
     let (Some (v, consumed)) = pp in
-    U64.v v == E.be_to_n (Seq.slice b 0 8)
+    U64.v v == E.be_to_n (Seq.slice b 0 8) /\ consumed == 8
   )))
 
 val serialize_u64 : serializer parse_u64
@@ -119,7 +119,7 @@ val parse_u64_le_spec
     let pp = parse parse_u64_le b in
     Some? pp /\ (
     let (Some (v, consumed)) = pp in
-    U64.v v == E.le_to_n (Seq.slice b 0 8)
+    U64.v v == E.le_to_n (Seq.slice b 0 8) /\ consumed == 8
   )))
 
 val serialize_u64_le : serializer parse_u64_le


### PR DESCRIPTION
The parsers for little-endian 16- and 32-bit numbers did not have any specification lemmas at all.  The others did not have any constraints on the number of consumed bytes.  (Although that follows from parser injectivity with a bit of effort.)

I also got rid of one rlimit by locally adding some SMT patterns.  The rlimit didn't work at all for me in VS Code.