### PR TITLE
Total Length is the length of the datagram, measured in octets, *including* internet header and data.

### DIFF
--- a/src/3d/tests/tcpip/IPV4.3d
+++ b/src/3d/tests/tcpip/IPV4.3d
@@ -36,7 +36,11 @@ typedef struct _IP_DATAGRAM_HEADER_PARAMETRIZED (
 
     //Total length of the IP datagram
 
-    UINT16BE                                             TotalLength;
+    UINT16BE                                             TotalLength
+    {
+        // Total Length is the length of the datagram, measured in octets, *including* internet header and data.
+        TotalLength >= IHL * 4
+    };
 
     UINT16BE                                             Identification;
 


### PR DESCRIPTION
>   Total Length:  16 bits

    Total Length is the length of the datagram, measured in octets,
    including internet header and data.  This field allows the length of
    a datagram to be up to 65,535 octets.  Such long datagrams are
    impractical for most hosts and networks.  All hosts must be prepared
    to accept datagrams of up to 576 octets (whether they arrive whole
    or in fragments).  It is recommended that hosts only send datagrams
    larger than 576 octets if they have assurance that the destination
    is prepared to accept the larger datagrams.

    The number 576 is selected to allow a reasonable sized data block to
    be transmitted in addition to the required header information.  For
    example, this size allows a data block of 512 octets plus 64 header
    octets to fit in a datagram.  The maximal internet header is 60
    octets, and a typical internet header is 20 octets, allowing a
    margin for headers of higher level protocols.

Page 13 of https://datatracker.ietf.org/doc/html/rfc791

Generating a witness without this constraint causes e.g. this wireshark message:

```
Layer IP
:       0100 .... = Version: 4
        .... 0110 = Header Length: 24 bytes (6)
        Differentiated Services Field: 0x00 (DSCP: CS0, ECN: Not-ECT)
        0000 00.. = Differentiated Services Codepoint: Default (0)
        .... ..00 = Explicit Congestion Notification: Not ECN-Capable Transport (0)
        Total Length: 12 bytes (reported as 0, presumed to be because of "TCP segmentation offload" (TSO))
        Identification: 0x0000 (0)
        000. .... = Flags: 0x0
        0... .... = Reserved bit: Not set
        .0.. .... = Don't fragment: Not set
        ..0. .... = More fragments: Not set
        ...0 0000 0000 0000 = Fragment Offset: 0
        Time to Live: 0
        Protocol: IPv6 Hop-by-Hop Option (0)
        Header Checksum: 0x0000 [validation disabled]
        Header checksum status: Unverified
```

An even stronger constraint would be `TotalLength >= sizeof(this)` if `sizeof(this)` would equal the size of the `_IP_DATAGRAM_HEADER_PARAMETRIZED` struct.