### PR TITLE
Add constraint for UDP's length field

### DIFF
--- a/src/3d/tests/tcpip/UDP.3d
+++ b/src/3d/tests/tcpip/UDP.3d
@@ -22,6 +22,12 @@ typedef struct _UDP_Header
 {
   UINT16BE SourcePort;
   UINT16BE DestinationPort;
-  UINT16BE Length;
+  UINT16BE Length
+  {
+    // Length is the length in octets of this user datagram including this header and the data (this
+    // means the minimum value of the length is eight, unless the length of the UDP header + data is
+    // greater than 65,535 (see Jumboframes in RFC 2675), in which case it is zero.
+    Length >= 8 || Length == 0
+  };
   UINT16BE CheckSum;
 } UDP_HEADER;


### PR DESCRIPTION
https://www.ietf.org/rfc/rfc768.txt

> Length  is the length  in octets  of this user datagram  including  this header  and the data.   (This  means  the minimum value of the length is eight.)

https://en.wikipedia.org/wiki/User_Datagram_Protocol#UDP_datagram_structure

> This field specifies the length in bytes of the UDP header and UDP data. The minimum length is 8 bytes, the length of the header. The field size sets a theoretical limit of 65,535 bytes (8-byte header + 65,527 bytes of data) for a UDP datagram. However, the actual limit for the data length, which is imposed by the underlying [IPv4](https://en.wikipedia.org/wiki/IPv4) protocol, is 65,507 bytes (65,535 bytes − 8-byte UDP header − 20-byte [IP header](https://en.wikipedia.org/wiki/IPv4_header)).[[5]](https://en.wikipedia.org/wiki/User_Datagram_Protocol#cite_note-5)
Using IPv6 [jumbograms](https://en.wikipedia.org/wiki/Jumbogram) it is possible to have UDP datagrams of size greater than 65,535 bytes. The length field is set to zero if the length of the UDP header plus UDP data is greater than 65,535.[[6]](https://en.wikipedia.org/wiki/User_Datagram_Protocol#cite_note-rfc2675-6)