### PR TITLE
3d: weaken allow_reading for entrypoints

### DIFF
--- a/src/3d/InterpreterTarget.fsti
+++ b/src/3d/InterpreterTarget.fsti
@@ -144,6 +144,10 @@ type typ : Type =
       act:lam action ->
       typ
 
+  | T_drop:
+      t:typ ->
+      typ
+
   | T_with_comment:
       fn:non_empty_string ->
       t:typ ->
@@ -190,7 +194,7 @@ type type_decl = {
   kind : T.parser_kind;
   typ_indexes : typ_indexes;
   allow_reading: bool;
-  attrs : T.decl_attributes;
+  attrs : (attrs: T.decl_attributes { attrs.is_entrypoint ==> ~ allow_reading });
   enum_typ: option (t:T.typ {T.T_refine? t })
 }
 let not_type_decl = (d: T.decl { ~ (T.Type_decl? (fst d)) })

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -104,6 +104,7 @@ let has_external_api (ds:list decl) : bool =
 
 let default_attrs = {
     is_hoisted = false;
+    is_entrypoint = false;
     is_if_def = false;
     is_exported = false;
     should_inline = false;

--- a/src/3d/Target.fsti
+++ b/src/3d/Target.fsti
@@ -223,6 +223,7 @@ let assumption = A.ident * typ
 
 type decl_attributes = {
   is_hoisted: bool;
+  is_entrypoint: bool;
   is_exported: bool;
   is_if_def: bool;
   should_inline: bool;

--- a/src/3d/Z3TestGen.fst
+++ b/src/3d/Z3TestGen.fst
@@ -919,6 +919,7 @@ let rec typ_depth (t: I.typ) : GTot nat
   | I.T_dep_pair_with_refinement _ _ _ (_, t')
   | I.T_dep_pair_with_refinement_and_action _ _ _ (_, t') _
   | I.T_with_action _ t' _
+  | I.T_drop t'
   | I.T_with_comment _ t' _
   | I.T_at_most _ _ t'
   | I.T_exact _ _ t'
@@ -949,6 +950,7 @@ let rec parse_typ (t : I.typ) : Tot (parser not_reading)
   | I.T_dep_pair_with_refinement _ base (lam_cond, cond) (lam_k, k) -> parse_dep_pair_with_refinement (parse_readable_dtyp base) lam_cond (fun _ -> mk_expr cond) lam_k (parse_typ k)
   | I.T_if_else cond t1 t2 -> parse_ifthenelse cond t1 t2 0
   | I.T_with_action _ base _
+  | I.T_drop base
   | I.T_with_comment _ base _ -> parse_typ base
   | I.T_at_most _ size body -> parse_at_most (fun _ -> mk_expr size) (parse_typ body)
   | I.T_exact _ size body -> parse_exact (fun _ -> mk_expr size) (parse_typ body)

--- a/src/3d/prelude/EverParse3d.Actions.Base.fst
+++ b/src/3d/prelude/EverParse3d.Actions.Base.fst
@@ -385,6 +385,8 @@ let validate_drop
   then validate_drop_true v
   else v
 
+let validate_without_reading v = validate_drop v
+
 let validate_with_success_action
   name v1 a
 = validate_with_success_action' name (validate_drop v1) a

--- a/src/3d/prelude/EverParse3d.Actions.Base.fsti
+++ b/src/3d/prelude/EverParse3d.Actions.Base.fsti
@@ -191,6 +191,20 @@ val leaf_reader
  : Type u#0
 
 inline_for_extraction noextract
+val validate_without_reading
+      (#nz:bool)
+      (#wk: _)
+      (#k:parser_kind nz wk)
+      (#[@@@erasable] t:Type)
+      (#[@@@erasable] p:parser k t)
+      (#[@@@erasable] inv:slice_inv)
+      (#[@@@erasable] disj:disjointness_pre)
+      (#[@@@erasable] l:eloc)
+      (#allow_reading:bool)
+      (v: validate_with_action_t p inv disj l allow_reading)
+: Tot (validate_with_action_t p inv disj l false)
+
+inline_for_extraction noextract
 val validate_with_success_action
       (name: string)
       (#nz:bool)
@@ -209,7 +223,6 @@ val validate_with_success_action
       (#b:bool)
       (a:action inv2 disj2 l2 b bool)
   : validate_with_action_t p1 (conj_inv inv1 inv2) (conj_disjointness disj1 disj2) (l1 `eloc_union` l2) false
-
 
 inline_for_extraction noextract
 val validate_with_error_handler

--- a/src/3d/prelude/EverParse3d.Interpreter.fst
+++ b/src/3d/prelude/EverParse3d.Interpreter.fst
@@ -882,6 +882,12 @@ type typ
       act:(dtyp_as_type head -> action i2 d2 l2 b2 bool) ->
       typ pk1 (join_inv i1 i2) (join_disj d1 d2) (join_loc l1 l2) false
 
+  | T_drop:
+      #nz:_ -> #wk:_ -> #pk:P.parser_kind nz wk ->
+      #l:_ -> #i:_ -> #d:_ -> #b:_ ->
+      t:typ pk i d l b ->
+      typ pk i d l false
+
   | T_with_comment:
       fieldname:string ->       
       #nz:_ -> #wk:_ -> #pk:P.parser_kind nz wk ->
@@ -991,6 +997,7 @@ let rec as_type
     | T_cases b t0 t1 ->
       P.t_ite b (fun _ -> as_type t0) (fun _ -> as_type t1)
 
+    | T_drop t
     | T_with_action _ t _
     | T_with_comment _ t _ ->
       as_type t
@@ -1078,6 +1085,10 @@ let rec as_parser
     | T_with_dep_action _ i a ->
       //assert_norm (as_type g (T_with_dep_action i a) == itype_as_type i);
       dtyp_as_parser i
+
+    | T_drop t ->
+      //assert_norm (as_type g (T_with_comment t c) == as_type g t);
+      as_parser t
 
     | T_with_comment _ t c ->
       //assert_norm (as_type g (T_with_comment t c) == as_type g t);
@@ -1279,6 +1290,10 @@ let rec as_validator
             (dtyp_as_leaf_reader i)
             (fun x -> action_as_action (a x))))
 
+    | T_drop t ->
+      assert_norm (as_type (T_drop t) == as_type t);
+      assert_norm (as_parser (T_drop t) == as_parser t);
+      A.validate_without_reading (as_validator typename t)
 
     | T_with_comment fn t c ->
       assert_norm (as_type (T_with_comment fn t c) == as_type t);


### PR DESCRIPTION
Consider the following 3D data format description:

```
entrypoint typedef struct _test {
  UINT16 x;
} test;
```

From this definition, currently, 3D generates F* code that does not typecheck, because entrypoints are not supposed to have a reader, and the way we currently enforce this requirement is to forbid such definitions.

This PR relaxes this requirement to allow those definitions, by casting entrypoint validators with `validate_drop` to weaken their types.
