### PR TITLE
Some adjustments to run on Windows

### DIFF
--- a/src/3d/GenMakefile.fst
+++ b/src/3d/GenMakefile.fst
@@ -613,7 +613,7 @@ let write_makefile
       end `List.Tot.append`
       List.map (fun f -> mk_filename (Options.get_module_name f) ext) all_files
     in
-    FStar.IO.write_string file (Printf.sprintf "EVERPARSE_ALL_%s_FILES=%s\n" ext_cap (String.concat " " ln))
+    FStar.IO.write_string file (Printf.sprintf "EVERPARSE_ALL_%s_FILES=%s\n" ext_cap (String.concat " " (List.Tot.map (mk_rule_operand mtype) ln)))
   in
   write_all_ext_files "H" "h";
   write_all_ext_files "C" "c";

--- a/src/3d/GenMakefile.fst
+++ b/src/3d/GenMakefile.fst
@@ -20,6 +20,11 @@ let oext = function
 | HashingOptions.MakefileGMake -> "o"
 | HashingOptions.MakefileNMake -> "obj"
 
+let mk_rule_operand (mtype: HashingOptions.makefile_type) (op: string) : Tot string =
+  match mtype with
+  | HashingOptions.MakefileGMake -> OS.replace_backslashes op // GNU Make uses `/` even on Windows
+  | _ -> op
+
 let print_make_rule
   mtype
   everparse_h
@@ -27,7 +32,7 @@ let print_make_rule
   (r: rule_t)
 : Tot string
 = 
-  let rule = Printf.sprintf "%s : %s\n" r.to (String.concat " " r.from) in
+  let rule = Printf.sprintf "%s : %s\n" (mk_rule_operand mtype r.to) (String.concat " " (List.Tot.map (mk_rule_operand mtype) r.from)) in
   match r.ty with
   | Nop -> Printf.sprintf "%s\n" rule
   | _ ->

--- a/src/3d/OS.fsti
+++ b/src/3d/OS.fsti
@@ -16,6 +16,10 @@ val remove_extension: string -> Tot string
 
 val extension: string -> Tot string
 
+(* The filename where all `\` have been replaced with `/` (because GNU Make uses `/` even on Windows) *)
+
+val replace_backslashes: string -> Tot string
+
 (* Run a command *)
 val run_cmd: string -> list string -> FStar.All.ML unit
 

--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -48,7 +48,7 @@ let krml out_dir =
         let target = Filename.temp_file ~temp_dir:out_dir "krml" ".exe" in
         begin
           (* Here, Windows cannot even read symlinks *)
-          let dir' = filename_concat (filename_concat (filename_concat dir "src") "_build") "default" in
+          let dir' = filename_concat (filename_concat (filename_concat dir "_build") "default") "src" in
           let candidate = aux true [(dir', "Karamel.exe")] in
           copy candidate target
         end;

--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -40,6 +40,7 @@ let krml out_dir =
       aux false [
           (dir_bin, "krml.exe"); (* binary package *)
           (dir, "krml.exe");
+          (dir, "krml");
         ]
     in
     if candidate <> ""

--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -40,7 +40,6 @@ let krml out_dir =
       aux false [
           (dir_bin, "krml.exe"); (* binary package *)
           (dir, "krml.exe");
-          (dir, "krml");
         ]
     in
     if candidate <> ""

--- a/src/3d/ocaml/OS.ml
+++ b/src/3d/ocaml/OS.ml
@@ -14,6 +14,12 @@ let remove_extension = Filename.remove_extension
 
 let extension = Filename.extension
 
+(* The filename where all `\` have been replaced with `/` (because GNU Make uses `/` even on Windows) *)
+
+let regexp_backslash = Re.Posix.compile_pat "\\\\" (* because both OCaml and POSIX regular expressions need to quote backslashes *)
+
+let replace_backslashes (s: string) = Re.replace_string regexp_backslash ~by:"/" s
+
 (* Concatenating a dir path and a filename *)
 
 let filename_concat = Filename.concat

--- a/src/3d/prelude/Makefile
+++ b/src/3d/prelude/Makefile
@@ -1,20 +1,33 @@
 all: verify buffer extern
 
-EVERPARSE_HOME=$(realpath ../../..)
+EVERPARSE_HOME := $(realpath ../../..)
+ifeq ($(OS),Windows_NT)
+  EVERPARSE_HOME := $(shell cygpath -m $(EVERPARSE_HOME))
+endif
 
 ifndef FSTAR_HOME
   FSTAR_EXE=$(shell which fstar.exe)
   ifeq ($(FSTAR_EXE),)
     # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+    FSTAR_HOME:=$(realpath $(EVERPARSE_HOME)/../FStar)
   else
     # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+    FSTAR_HOME:=$(realpath $(dir $(FSTAR_EXE))/..)
   endif
-  export FSTAR_HOME
 endif
+ifeq ($(OS),Windows_NT)
+  FSTAR_HOME:=$(shell cygpath -m $(FSTAR_HOME))
+endif
+export FSTAR_HOME
 
-KRML_HOME?=$(realpath ../../../../karamel)
+ifeq (,$(KRML_HOME))
+  KRML_HOME := $(realpath ../../../../karamel)
+endif
+ifeq ($(OS),Windows_NT)
+  KRML_HOME := $(shell cygpath -m $(KRML_HOME))
+endif
+export KRML_HOME
+
 OTHERFLAGS?=
 
 FSTAR_OPTIONS=--ext context_pruning $(addprefix --include , $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib $(KRML_HOME)/krmllib/obj) --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=10'

--- a/src/3d/prelude/buffer/Makefile
+++ b/src/3d/prelude/buffer/Makefile
@@ -1,20 +1,33 @@
 all: extract
 
-EVERPARSE_HOME=$(realpath ../../../..)
+EVERPARSE_HOME := $(realpath ../../../..)
+ifeq ($(OS),Windows_NT)
+  EVERPARSE_HOME := $(shell cygpath -m $(EVERPARSE_HOME))
+endif
 
 ifndef FSTAR_HOME
   FSTAR_EXE=$(shell which fstar.exe)
   ifeq ($(FSTAR_EXE),)
     # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+    FSTAR_HOME:=$(realpath $(EVERPARSE_HOME)/../FStar)
   else
     # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+    FSTAR_HOME:=$(realpath $(dir $(FSTAR_EXE))/..)
   endif
-  export FSTAR_HOME
 endif
+ifeq ($(OS),Windows_NT)
+  FSTAR_HOME:=$(shell cygpath -m $(FSTAR_HOME))
+endif
+export FSTAR_HOME
 
-KRML_HOME?=$(realpath ../../../../../karamel)
+ifeq (,$(KRML_HOME))
+  KRML_HOME := $(realpath ../../../../karamel)
+endif
+ifeq ($(OS),Windows_NT)
+  KRML_HOME := $(shell cygpath -m $(KRML_HOME))
+endif
+export KRML_HOME
+
 OTHERFLAGS?=
 
 FSTAR_OPTIONS=$(addprefix --include , .. $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib $(KRML_HOME)/krmllib/obj) --z3rlimit_factor 8 --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=100'

--- a/src/3d/prelude/extern/Makefile
+++ b/src/3d/prelude/extern/Makefile
@@ -1,20 +1,33 @@
 all: extract
 
-EVERPARSE_HOME=$(realpath ../../../..)
+EVERPARSE_HOME := $(realpath ../../../..)
+ifeq ($(OS),Windows_NT)
+  EVERPARSE_HOME := $(shell cygpath -m $(EVERPARSE_HOME))
+endif
 
 ifndef FSTAR_HOME
   FSTAR_EXE=$(shell which fstar.exe)
   ifeq ($(FSTAR_EXE),)
     # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+    FSTAR_HOME:=$(realpath $(EVERPARSE_HOME)/../FStar)
   else
     # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+    FSTAR_HOME:=$(realpath $(dir $(FSTAR_EXE))/..)
   endif
-  export FSTAR_HOME
 endif
+ifeq ($(OS),Windows_NT)
+  FSTAR_HOME:=$(shell cygpath -m $(FSTAR_HOME))
+endif
+export FSTAR_HOME
 
-KRML_HOME?=$(realpath ../../../../../karamel)
+ifeq (,$(KRML_HOME))
+  KRML_HOME := $(realpath ../../../../karamel)
+endif
+ifeq ($(OS),Windows_NT)
+  KRML_HOME := $(shell cygpath -m $(KRML_HOME))
+endif
+export KRML_HOME
+
 OTHERFLAGS?=
 
 FSTAR_OPTIONS=$(addprefix --include , .. $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib $(KRML_HOME)/krmllib/obj) --z3rlimit_factor 8 --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=100'

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -107,7 +107,7 @@ batch-interpret-test:
 elf-test: ELF.3d
 	mkdir -p out.batch
 	$(3D) --odir out.batch --batch ELF.3d
-	g++ -o out.batch/elf-test -I out.batch $(addprefix out.batch/, ELF.c ELFWrapper.c) TestELF.cpp
+	$(CXX) -o out.batch/elf-test -I out.batch $(addprefix out.batch/, ELF.c ELFWrapper.c) TestELF.cpp
 
 %-test: %.3d
 	mkdir -p out.batch

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -1,22 +1,35 @@
-EVERPARSE_HOME ?= $(realpath ../../..)
+ifeq (,$(EVERPARSE_HOME))
+  EVERPARSE_HOME := $(realpath ../../..)
+endif
+ifeq ($(OS),Windows_NT)
+  EVERPARSE_HOME := $(shell cygpath -m "$(EVERPARSE_HOME)")
+endif
 export EVERPARSE_HOME
 
 3D=$(EVERPARSE_HOME)/bin/3d.exe
 
-KRML_HOME ?= $(realpath ../../../../karamel)
+ifeq (,$(KRML_HOME))
+  KRML_HOME := $(realpath ../../../../karamel)
+endif
+ifeq ($(OS),Windows_NT)
+  KRML_HOME := $(shell cygpath -m "$(KRML_HOME)")
+endif
 export KRML_HOME
 
 ifndef FSTAR_HOME
   FSTAR_EXE=$(shell which fstar.exe)
   ifeq ($(FSTAR_EXE),)
     # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
+    FSTAR_HOME := $(realpath $(EVERPARSE_HOME)/../FStar)
   else
     # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
+    FSTAR_HOME := $(realpath $(dir $(FSTAR_EXE))/..)
   endif
-  export FSTAR_HOME
 endif
+ifeq ($(OS),Windows_NT)
+  FSTAR_HOME := $(shell cygpath -m "$(FSTAR_HOME)")
+endif
+export FSTAR_HOME
 
 INCLUDES=$(EVERPARSE_HOME)/src/3d/prelude $(EVERPARSE_HOME)/src/3d/prelude/buffer $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib/obj $(KRML_HOME)/krmllib
 

--- a/src/3d/tests/iter/coarse/src/Test.3d
+++ b/src/3d/tests/iter/coarse/src/Test.3d
@@ -1,10 +1,10 @@
 
-extern typedef struct out_iterator OUT
-extern void setCurrentf1(mutable OUT* p, UINT32 f1)
-extern void setCurrentf2(mutable OUT* p, UINT32 f1)
-extern void advance(mutable OUT* p)
+extern typedef struct out_iterator out_t
+extern void setCurrentf1(mutable out_t* p, UINT32 f1)
+extern void setCurrentf2(mutable out_t* p, UINT32 f1)
+extern void advance(mutable out_t* p)
  
-typedef struct pair (mutable OUT* p) {
+typedef struct pair (mutable out_t* p) {
     UINT32 f1{:on-success setCurrentf1(p, f1); return true; };
     UINT32 f2{:on-success setCurrentf2(p, f2);
                     advance(p);
@@ -13,7 +13,7 @@ typedef struct pair (mutable OUT* p) {
 } PAIR;
 
 entrypoint
-typedef struct container (mutable OUT* p) {
+typedef struct container (mutable out_t* p) {
     UINT32 len;
     PAIR(p) pairs[:byte-size len];
 } CONTAINER;

--- a/src/3d/tests/iter/coarse/src/Test.3d
+++ b/src/3d/tests/iter/coarse/src/Test.3d
@@ -1,10 +1,10 @@
 
-extern typedef struct out_iterator out_t
-extern void setCurrentf1(mutable out_t* p, UINT32 f1)
-extern void setCurrentf2(mutable out_t* p, UINT32 f1)
-extern void advance(mutable out_t* p)
+extern typedef struct out_iterator OUT_T
+extern void setCurrentf1(mutable OUT_T* p, UINT32 f1)
+extern void setCurrentf2(mutable OUT_T* p, UINT32 f1)
+extern void advance(mutable OUT_T* p)
  
-typedef struct pair (mutable out_t* p) {
+typedef struct pair (mutable OUT_T* p) {
     UINT32 f1{:on-success setCurrentf1(p, f1); return true; };
     UINT32 f2{:on-success setCurrentf2(p, f2);
                     advance(p);
@@ -13,7 +13,7 @@ typedef struct pair (mutable out_t* p) {
 } PAIR;
 
 entrypoint
-typedef struct container (mutable out_t* p) {
+typedef struct container (mutable OUT_T* p) {
     UINT32 len;
     PAIR(p) pairs[:byte-size len];
 } CONTAINER;

--- a/src/3d/tests/iter/coarse/src/Test_ExternalTypedefs.c
+++ b/src/3d/tests/iter/coarse/src/Test_ExternalTypedefs.c
@@ -3,7 +3,7 @@
 
 // defining iterator operations declared in Test.3d
 
-static bool isOutFailure (out_t* p) {
+static bool isOutFailure (OUT_T* p) {
   if (p == NULL)
     return true;
   if (p->remainingCount == 0)
@@ -13,17 +13,17 @@ static bool isOutFailure (out_t* p) {
 
 #define CHECK_OUT(p) if (isOutFailure(p)) return;
 
-void SetCurrentf1 (out_t* p, uint32_t f1) {
+void SetCurrentf1 (OUT_T* p, uint32_t f1) {
   CHECK_OUT(p);
   p->current->f1 = f1;
 }
 
-void SetCurrentf2 (out_t* p, uint32_t f2) {
+void SetCurrentf2 (OUT_T* p, uint32_t f2) {
   CHECK_OUT(p);
   p->current->f2 = f2;
 }
 
-void Advance (out_t* p) {
+void Advance (OUT_T* p) {
   CHECK_OUT(p);
   p->current++;
   p->remainingCount--;

--- a/src/3d/tests/iter/coarse/src/Test_ExternalTypedefs.c
+++ b/src/3d/tests/iter/coarse/src/Test_ExternalTypedefs.c
@@ -3,7 +3,7 @@
 
 // defining iterator operations declared in Test.3d
 
-static bool isOutFailure (OUT* p) {
+static bool isOutFailure (out_t* p) {
   if (p == NULL)
     return true;
   if (p->remainingCount == 0)
@@ -13,17 +13,17 @@ static bool isOutFailure (OUT* p) {
 
 #define CHECK_OUT(p) if (isOutFailure(p)) return;
 
-void SetCurrentf1 (OUT* p, uint32_t f1) {
+void SetCurrentf1 (out_t* p, uint32_t f1) {
   CHECK_OUT(p);
   p->current->f1 = f1;
 }
 
-void SetCurrentf2 (OUT* p, uint32_t f2) {
+void SetCurrentf2 (out_t* p, uint32_t f2) {
   CHECK_OUT(p);
   p->current->f2 = f2;
 }
 
-void Advance (OUT* p) {
+void Advance (out_t* p) {
   CHECK_OUT(p);
   p->current++;
   p->remainingCount--;

--- a/src/3d/tests/iter/coarse/src/Test_ExternalTypedefs.h
+++ b/src/3d/tests/iter/coarse/src/Test_ExternalTypedefs.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-// defining the OUT iterator type declared in Test.3d
+// defining the out_t iterator type declared in Test.3d
 
 typedef struct out_pair {
   uint32_t f1;
@@ -14,6 +14,6 @@ typedef struct out_pair {
 typedef struct out_iterator {
   OUT_PAIR* current;
   size_t remainingCount;
-} OUT;
+} out_t;
 
 #endif // __TEST_EXTERNALTYPEDEFS

--- a/src/3d/tests/iter/coarse/src/Test_ExternalTypedefs.h
+++ b/src/3d/tests/iter/coarse/src/Test_ExternalTypedefs.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-// defining the out_t iterator type declared in Test.3d
+// defining the OUT_T iterator type declared in Test.3d
 
 typedef struct out_pair {
   uint32_t f1;
@@ -14,6 +14,6 @@ typedef struct out_pair {
 typedef struct out_iterator {
   OUT_PAIR* current;
   size_t remainingCount;
-} out_t;
+} OUT_T;
 
 #endif // __TEST_EXTERNALTYPEDEFS

--- a/src/3d/tests/iter/coarse/src/main.c
+++ b/src/3d/tests/iter/coarse/src/main.c
@@ -18,7 +18,7 @@ void TestEverParseError(char *StructName, char *FieldName, char *Reason) {
 int main(void) {
   uint8_t test[testSize];
   OUT_PAIR array[outCount]; // output only, no need to initialize
-  OUT out = {
+  OUT_T out = {
     .current = array,
     .remainingCount = outCount
   };

--- a/src/3d/tests/iter/fine/src/Test.3d
+++ b/src/3d/tests/iter/fine/src/Test.3d
@@ -1,10 +1,10 @@
 
-extern typedef struct out_iterator out_t
-extern UINT8 setCurrentf1(mutable out_t* p, UINT32 f1)
-extern UINT8 setCurrentf2(mutable out_t* p, UINT32 f1)
-extern UINT8 advance(mutable out_t* p)
+extern typedef struct out_iterator OUT_T
+extern UINT8 setCurrentf1(mutable OUT_T* p, UINT32 f1)
+extern UINT8 setCurrentf2(mutable OUT_T* p, UINT32 f1)
+extern UINT8 advance(mutable OUT_T* p)
  
-typedef struct pair (mutable out_t* p) {
+typedef struct pair (mutable OUT_T* p) {
     UINT32 f1{:on-success var err = setCurrentf1(p, f1); return (err == 0); };
     UINT32 f2{:on-success var err1 = setCurrentf2(p, f2);
            if (err1 == 0) {
@@ -17,7 +17,7 @@ typedef struct pair (mutable out_t* p) {
 } PAIR;
 
 entrypoint
-typedef struct container (mutable out_t* p) {
+typedef struct container (mutable OUT_T* p) {
     UINT32 len;
     PAIR(p) pairs[:byte-size len];
 } CONTAINER;

--- a/src/3d/tests/iter/fine/src/Test.3d
+++ b/src/3d/tests/iter/fine/src/Test.3d
@@ -1,10 +1,10 @@
 
-extern typedef struct out_iterator OUT
-extern UINT8 setCurrentf1(mutable OUT* p, UINT32 f1)
-extern UINT8 setCurrentf2(mutable OUT* p, UINT32 f1)
-extern UINT8 advance(mutable OUT* p)
+extern typedef struct out_iterator out_t
+extern UINT8 setCurrentf1(mutable out_t* p, UINT32 f1)
+extern UINT8 setCurrentf2(mutable out_t* p, UINT32 f1)
+extern UINT8 advance(mutable out_t* p)
  
-typedef struct pair (mutable OUT* p) {
+typedef struct pair (mutable out_t* p) {
     UINT32 f1{:on-success var err = setCurrentf1(p, f1); return (err == 0); };
     UINT32 f2{:on-success var err1 = setCurrentf2(p, f2);
            if (err1 == 0) {
@@ -17,7 +17,7 @@ typedef struct pair (mutable OUT* p) {
 } PAIR;
 
 entrypoint
-typedef struct container (mutable OUT* p) {
+typedef struct container (mutable out_t* p) {
     UINT32 len;
     PAIR(p) pairs[:byte-size len];
 } CONTAINER;

--- a/src/3d/tests/iter/fine/src/Test_ExternalTypedefs.c
+++ b/src/3d/tests/iter/fine/src/Test_ExternalTypedefs.c
@@ -3,7 +3,7 @@
 
 // defining iterator operations declared in Test.3d
 
-static uint8_t isOutFailure (out_t* p) {
+static uint8_t isOutFailure (OUT_T* p) {
   if (p == NULL)
     return 1;
   if (p->remainingCount == 0)
@@ -13,19 +13,19 @@ static uint8_t isOutFailure (out_t* p) {
 
 #define CHECK_OUT(p) { uint8_t err = isOutFailure(p); if (err) return err; }
 
-uint8_t SetCurrentf1 (out_t* p, uint32_t f1) {
+uint8_t SetCurrentf1 (OUT_T* p, uint32_t f1) {
   CHECK_OUT(p);
   p->current->f1 = f1;
   return 0;
 }
 
-uint8_t SetCurrentf2 (out_t* p, uint32_t f2) {
+uint8_t SetCurrentf2 (OUT_T* p, uint32_t f2) {
   CHECK_OUT(p);
   p->current->f2 = f2;
   return 0;
 }
 
-uint8_t Advance (out_t* p) {
+uint8_t Advance (OUT_T* p) {
   CHECK_OUT(p);
   p->current++;
   p->remainingCount--;

--- a/src/3d/tests/iter/fine/src/Test_ExternalTypedefs.c
+++ b/src/3d/tests/iter/fine/src/Test_ExternalTypedefs.c
@@ -3,7 +3,7 @@
 
 // defining iterator operations declared in Test.3d
 
-static uint8_t isOutFailure (OUT* p) {
+static uint8_t isOutFailure (out_t* p) {
   if (p == NULL)
     return 1;
   if (p->remainingCount == 0)
@@ -13,19 +13,19 @@ static uint8_t isOutFailure (OUT* p) {
 
 #define CHECK_OUT(p) { uint8_t err = isOutFailure(p); if (err) return err; }
 
-uint8_t SetCurrentf1 (OUT* p, uint32_t f1) {
+uint8_t SetCurrentf1 (out_t* p, uint32_t f1) {
   CHECK_OUT(p);
   p->current->f1 = f1;
   return 0;
 }
 
-uint8_t SetCurrentf2 (OUT* p, uint32_t f2) {
+uint8_t SetCurrentf2 (out_t* p, uint32_t f2) {
   CHECK_OUT(p);
   p->current->f2 = f2;
   return 0;
 }
 
-uint8_t Advance (OUT* p) {
+uint8_t Advance (out_t* p) {
   CHECK_OUT(p);
   p->current++;
   p->remainingCount--;

--- a/src/3d/tests/iter/fine/src/Test_ExternalTypedefs.h
+++ b/src/3d/tests/iter/fine/src/Test_ExternalTypedefs.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-// defining the OUT iterator type declared in Test.3d
+// defining the out_t iterator type declared in Test.3d
 
 typedef struct out_pair {
   uint32_t f1;
@@ -14,6 +14,6 @@ typedef struct out_pair {
 typedef struct out_iterator {
   OUT_PAIR* current;
   size_t remainingCount;
-} OUT;
+} out_t;
 
 #endif // __TEST_EXTERNALTYPEDEFS

--- a/src/3d/tests/iter/fine/src/Test_ExternalTypedefs.h
+++ b/src/3d/tests/iter/fine/src/Test_ExternalTypedefs.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-// defining the out_t iterator type declared in Test.3d
+// defining the OUT_T iterator type declared in Test.3d
 
 typedef struct out_pair {
   uint32_t f1;
@@ -14,6 +14,6 @@ typedef struct out_pair {
 typedef struct out_iterator {
   OUT_PAIR* current;
   size_t remainingCount;
-} out_t;
+} OUT_T;
 
 #endif // __TEST_EXTERNALTYPEDEFS

--- a/src/3d/tests/iter/fine/src/main.c
+++ b/src/3d/tests/iter/fine/src/main.c
@@ -18,7 +18,7 @@ void TestEverParseError(char *StructName, char *FieldName, char *Reason) {
 int main(void) {
   uint8_t test[testSize];
   OUT_PAIR array[outCount]; // output only, no need to initialize
-  OUT out = {
+  OUT_T out = {
     .current = array,
     .remainingCount = outCount
   };

--- a/src/3d/tests/output_types/ExternVectorDriver.c
+++ b/src/3d/tests/output_types/ExternVectorDriver.c
@@ -25,7 +25,7 @@ VEC *Alloc ()
   VEC *vec = (VEC *) malloc(sizeof(VEC));
   vec->max = 2;
   vec->cur = 0;
-  vec->arr = (POINT *) malloc(sizeof(POINT) * 2);
+  vec->arr = (POINT_T *) malloc(sizeof(POINT_T) * 2);
   return vec;
 }
 

--- a/src/3d/tests/output_types/ExternVector_ExternalTypedefs.h
+++ b/src/3d/tests/output_types/ExternVector_ExternalTypedefs.h
@@ -7,16 +7,16 @@
 extern "C" {
 #endif
 
-typedef struct _POINT {
+typedef struct _POINT_S {
   uint32_t x;
   uint32_t y;
-} POINT;
+} POINT_T;
 
 
 typedef struct _VEC {
   uint8_t max;
   uint8_t cur;
-  POINT   *arr;
+  POINT_T   *arr;
 } VEC;
 
 #ifdef __cplusplus

--- a/src/3d/tests/output_types/Makefile
+++ b/src/3d/tests/output_types/Makefile
@@ -17,11 +17,11 @@ interpret: $(SOURCE_FILES) interpret.out
 	$(EVERPARSE_CMD) --batch AnonStruct.3d --odir interpret.out
 	$(EVERPARSE_CMD) --batch ExternVector.3d --odir interpret.out
 	$(EVERPARSE_CMD) --batch OutputBitFields.3d --odir interpret.out
-	g++ -o interpret.out/test1 -I interpret.out $(addprefix interpret.out/, AnonStruct_OutputTypes.c AnonStruct.c AnonStructWrapper.c) TestAnonStruct.cpp
+	$(CXX) -o interpret.out/test1 -I interpret.out $(addprefix interpret.out/, AnonStruct_OutputTypes.c AnonStruct.c AnonStructWrapper.c) TestAnonStruct.cpp
 	./interpret.out/test1
-	g++ -o interpret.out/test2 -I interpret.out $(addprefix interpret.out/, TPoint_OutputTypes.c TPoint.c TPointWrapper.c) TestTPoint.cpp
+	$(CXX) -o interpret.out/test2 -I interpret.out $(addprefix interpret.out/, TPoint_OutputTypes.c TPoint.c TPointWrapper.c) TestTPoint.cpp
 	./interpret.out/test2
-	gcc -o interpret.out/test3 -I interpret.out -I . $(addprefix interpret.out/, ExternVector.c ExternVectorWrapper.c) ExternVectorDriver.c
+	$(CC) -o interpret.out/test3 -I interpret.out -I . $(addprefix interpret.out/, ExternVector.c ExternVectorWrapper.c) ExternVectorDriver.c
 	./interpret.out/test3
 
 ifndef FSTAR_HOME

--- a/src/3d/tests/output_types/modules_batch/Makefile
+++ b/src/3d/tests/output_types/modules_batch/Makefile
@@ -7,7 +7,7 @@ all: basic
 
 basic: $(SOURCE_FILES) basic.out
 	$(EVERPARSE_CMD) --batch AA.3d BB.3d CC.3d --odir basic.out --no_emit_output_types_defs --add_include \"AA_ExternalTypedefs.h\"
-	g++ -o basic.out/test -I . -I basic.out $(addprefix basic.out/, BB_OutputTypes.c CC_OutputTypes.c BB.c CC.c BBWrapper.c CCWrapper.c) Test.cpp
+	$(CXX) -o basic.out/test -I . -I basic.out $(addprefix basic.out/, BB_OutputTypes.c CC_OutputTypes.c BB.c CC.c BBWrapper.c CCWrapper.c) Test.cpp
 	./basic.out/test
 
 ifndef FSTAR_HOME


### PR DESCRIPTION
This PR integrates some changes to build and test EverParse with the official opam 2.3 for Windows.

Among others:
* GenMakefile GMake now always uses `/` in rule prerequisites and targets, even on Windows.
* fixing 3d tests to avoid some type names used in Cygwin headers (`OUT`, `POINT`)

