### PR TITLE
Allow probe length expressions to mention sizeof(this)

### DIFF
--- a/doc/3d-snapshot/ProbeWrapper.c
+++ b/doc/3d-snapshot/ProbeWrapper.c
@@ -109,13 +109,3 @@ BOOLEAN ProbeCheckI(EVERPARSE_COPY_BUFFER_T dest, uint8_t *base, uint32_t len) {
 	}
 	return TRUE;
 }
-
-BOOLEAN ProbeProbeAndCopyCheckI(EVERPARSE_COPY_BUFFER_T dest, EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr) {
-	if (ProbeAndCopy(probeAddr, 9U, probeDest)) {
-         uint8_t * base = EverParseStreamOf(probeDest);
-         return ProbeCheckI(dest,  base, 9U);
-       } else {
-         // FIXME: we currently assume that the probe function handles its own error
-         return FALSE;
-       }
-}

--- a/doc/3d-snapshot/ProbeWrapper.h
+++ b/doc/3d-snapshot/ProbeWrapper.h
@@ -24,8 +24,6 @@ BOOLEAN ProbeCheckIndirect(uint8_t *base, uint32_t len);
 BOOLEAN ProbeProbeAndCopyCheckIndirect(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr);
 
 BOOLEAN ProbeCheckI(EVERPARSE_COPY_BUFFER_T dest, uint8_t *base, uint32_t len);
-
-BOOLEAN ProbeProbeAndCopyCheckI(EVERPARSE_COPY_BUFFER_T dest, EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr);
 #ifdef __cplusplus
 }
 #endif

--- a/doc/Probe.3d
+++ b/doc/Probe.3d
@@ -36,7 +36,7 @@ typedef struct _V(EVERPARSE_COPY_BUFFER_T destS, EVERPARSE_COPY_BUFFER_T destT) 
 //SNIPPET_END: reuse copy buffer$
 
 //SNIPPET_START: indirect$
-entrypoint probe ProbeAndCopy(length=9)
+entrypoint probe ProbeAndCopy(length=sizeof(this))
 typedef struct _Indirect {
   UINT32 fst;
   UINT32 snd;
@@ -53,8 +53,8 @@ typedef struct _TT {
   UINT8 tag;
 } TT;
 
-entrypoint probe ProbeAndCopy(length=9)
+entrypoint
 typedef struct _I(EVERPARSE_COPY_BUFFER_T dest) {
-  TT *ttptr probe ProbeAndCopy(length=9, destination=dest);
+  TT *ttptr probe ProbeAndCopy(length=sizeof(TT), destination=dest);
 } I;
 //SNIPPET_END: indirect alt$


### PR DESCRIPTION
* Probe length expressions can mention sizeof(this), where this resolves to the name of the enclosing type, or in the case of probe attributes, to the type on which the attribute appears

* I also fixed the documentation of probe to use sizeof(this), and corrected the last example which had a misplaced extra probe