### PR TITLE
Adapt Windows CI to new opam 2.3

### DIFF
--- a/.docker/produce-binary.Dockerfile
+++ b/.docker/produce-binary.Dockerfile
@@ -23,7 +23,7 @@ RUN eval $(opam env) && .docker/build/install-deps.sh
 ARG CI_THREADS=24
 ARG CI_BRANCH=master
 
-RUN eval $(opam env) && OTHERFLAGS="--admit_smt_queries true" make -j $EVEREST_THREADS package-noversion
+RUN eval $(opam env) && OTHERFLAGS="--admit_smt_queries true" make -j $CI_THREADS package-noversion
 
 WORKDIR $HOME
 ENV EVERPARSE_HOME=$HOME/everparse

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -4,21 +4,29 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: [self-hosted, windows, X64]
+    runs-on: [self-hosted, windows, X64, opam-2-3]
     steps:
       - name: Check out repo        
-        uses: actions/checkout@v2
-      - name: Build EverParse and its dependencies
-        shell: powershell
+        uses: actions/checkout@v4
+      - name: Build EverParse
+        shell: C:\cygwin64\bin\bash.exe --login '{0}'
         run: |
-          .\src\package\windows\build-everparse.ps1 -WithClean -DownloadZ3
-      - name: Test EverParse
-        shell: cmd
-        run: |
-          .\everparse\everparse.cmd src\3d\tests\Arithmetic.3d src\3d\tests\FieldDependence0.3d && .\everparse\everparse.cmd src\3d\tests\Comments.3d && .\everparse\everparse.cmd --check_hashes inplace src\3d\tests\Comments.3d
+          eval $(opam env) && CC=x86_64-w64-mingw32-gcc.exe make -C $GITHUB_WORKSPACE -j 8 everparse && echo "There is a CR at the end of this line"
       - name: Archive EverParse package
         uses: actions/upload-artifact@v4
         with:
           name: everparse
           path: everparse
           include-hidden-files: true
+  test:
+    needs: build
+    runs-on: windows-latest
+    steps:
+      - name: Download and extract artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: everparse
+      - name: Test EverParse
+        shell: cmd
+        run: |
+          .\everparse\everparse.cmd src\3d\tests\Arithmetic.3d src\3d\tests\FieldDependence0.3d && .\everparse\everparse.cmd src\3d\tests\Comments.3d && .\everparse\everparse.cmd --check_hashes inplace src\3d\tests\Comments.3d

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -26,7 +26,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: everparse
+          path: ${{ github.workspace }}\test
+      - name: Check out repo        
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: src\3d\tests
+          path: ${{ github.workspace }}\everparse
       - name: Test EverParse
         shell: cmd
         run: |
-          .\everparse\everparse.cmd src\3d\tests\Arithmetic.3d src\3d\tests\FieldDependence0.3d && .\everparse\everparse.cmd src\3d\tests\Comments.3d && .\everparse\everparse.cmd --check_hashes inplace src\3d\tests\Comments.3d
+          ${{ github.workspace }}\test\everparse.cmd ${{ github.workspace }}\everparse\src\3d\tests\Arithmetic.3d ${{ github.workspace }}\everparse\src\3d\tests\FieldDependence0.3d && ${{ github.workspace }}\test\everparse.cmd ${{ github.workspace }}\everparse\src\3d\tests\Comments.3d && ${{ github.workspace }}\test\everparse.cmd --check_hashes inplace ${{ github.workspace }}\everparse\src\3d\tests\Comments.3d

--- a/src/package/package.sh
+++ b/src/package/package.sh
@@ -114,12 +114,7 @@ make_everparse() {
         elif find_fstar="$(which fstar.exe)" ; then
             export FSTAR_HOME=$(fixpath "$(dirname $find_fstar)"/..)
         else
-            if $is_windows ; then
-                fstar_branch_opt="--branch taramana_dune_3.5"
-            else
-                fstar_branch_opt=
-            fi
-            git clone $fstar_branch_opt https://github.com/FStarLang/FStar
+            git clone https://github.com/FStarLang/FStar
             export FSTAR_HOME=$(fixpath $PWD/FStar)
         fi
     else


### PR DESCRIPTION
This PR adapts Windows CI to the new [official Windows support for OCaml with opam 2.3](https://ocaml.org/docs/ocaml-on-windows).

For now this PR assumes a CI machine already configured with `windows-init.ps1` introduced by project-everest/everest#118. In other words, this PR **does not** adapt `src/package/windows/` to the new official opam 2.3; there is no unattended machine configuration yet.

However, this PR now tests the EverParse binary package on a GitHub-hosted runner, to make sure the package can work on a bare Windows machine without Cygwin, OCaml, etc.
