### PR TITLE
No FSTAR_HOME (for _taramana_cbor)

### DIFF
--- a/.docker/build/build_helper.sh
+++ b/.docker/build/build_helper.sh
@@ -6,7 +6,7 @@ threads=$3
 branchname=$4
 fstarVersion=$5
 
-export FSTAR_HOME=$(pwd)/FStar
+export FSTAR_EXE=$(pwd)/FStar/bin/fstar.exe
 
 eval $(opam config env)
 

--- a/.docker/build/config.json
+++ b/.docker/build/config.json
@@ -30,6 +30,6 @@
     "RepoVersions" : {
         "mitls_version" : "origin/dev",
         "pulse_version" : "origin/main",
-        "karamel_version" : "origin/master"
+        "karamel_version" : "origin/guido_dev"
     }
 }

--- a/.docker/build/install-deps.sh
+++ b/.docker/build/install-deps.sh
@@ -29,15 +29,15 @@ opam depext conf-gmp z3.4.8.5-1 conf-m4
 FSTAR_BRANCH=$(jq -c -r '.BranchName' "$build_home"/config.json)
 
 # Install F*
-[[ -n "$FSTAR_HOME" ]]
-git clone --branch $FSTAR_BRANCH https://github.com/FStarLang/FStar "$FSTAR_HOME"
-opam install --deps-only "$FSTAR_HOME/fstar.opam"
+[[ -n "$FSTAR_DIR" ]]
+git clone --branch $FSTAR_BRANCH https://github.com/FStarLang/FStar "$FSTAR_DIR"
+opam install --deps-only "$FSTAR_DIR/fstar.opam"
 if ! $skip_z3 ; then
-    "$FSTAR_HOME/bin/get_fstar_z3.sh" "$FSTAR_HOME/z3-versions"
-    export PATH="$FSTAR_HOME/z3-versions:$PATH"
+    "$FSTAR_DIR/bin/get_fstar_z3.sh" "$FSTAR_DIR/z3-versions"
+    export PATH="$FSTAR_DIR/z3-versions:$PATH"
 fi
-$skip_build || OTHERFLAGS='--admit_smt_queries true' make -j 24 -C "$FSTAR_HOME"
-$skip_build || OTHERFLAGS='--admit_smt_queries true' make -j 24 -C "$FSTAR_HOME" bootstrap
+$skip_build || make -j 24 -C "$FSTAR_DIR" ADMIT=1
+export FSTAR_EXE="$FSTAR_DIR/bin/fstar.exe"
 
 # Install other EverParse deps
 "$build_home"/install-other-deps.sh "${args[@]}"

--- a/.docker/hierarchic.Dockerfile
+++ b/.docker/hierarchic.Dockerfile
@@ -3,6 +3,9 @@
 ARG FSTAR_BRANCH=master
 FROM fstar:local-branch-$FSTAR_BRANCH
 
+# A crutch: the image above sets FSTAR_HOME but not FSTAR_EXE
+ENV FSTAR_EXE=$FSTAR_HOME/bin/fstar.exe
+
 ADD --chown=opam:opam ./ $HOME/everparse/
 WORKDIR $HOME/everparse
 

--- a/.docker/produce-binary.Dockerfile
+++ b/.docker/produce-binary.Dockerfile
@@ -16,11 +16,10 @@ RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends \
 
 # Dependencies (F*, Karamel and opam packages)
 # NOTE: $PULSE_HOME is now $PULSE_REPO/out, cf. FStarLang/pulse#246
-ENV FSTAR_HOME=$HOME/FStar
 ENV KRML_HOME=$HOME/karamel
 ENV PULSE_REPO=$HOME/pulse
 ENV PULSE_HOME=$PULSE_REPO/out
-RUN eval $(opam env) && .docker/build/install-deps.sh --skip-build --skip-z3
+RUN eval $(opam env) && FSTAR_DIR/$HOME/FStar .docker/build/install-deps.sh --skip-build --skip-z3
 
 # CI proper
 ARG CI_THREADS=24

--- a/.docker/standalone.Dockerfile
+++ b/.docker/standalone.Dockerfile
@@ -18,11 +18,10 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 # Dependencies (F*, Karamel and opam packages)
 # NOTE: $PULSE_HOME is now $PULSE_REPO/out, cf. FStarLang/pulse#246
-ENV FSTAR_HOME=$HOME/FStar
 ENV KRML_HOME=$HOME/karamel
 ENV PULSE_REPO=$HOME/pulse
 ENV PULSE_HOME=$PULSE_REPO/out
-RUN eval $(opam env) && .docker/build/install-deps.sh
+RUN eval $(opam env) && FSTAR_DIR=$HOME/FStar .docker/build/install-deps.sh
 
 # CI dependencies: sphinx (for the docs)
 # sudo pip3 because of https://bugs.launchpad.net/ubuntu/+source/bash/+bug/1588562

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ ifeq (,$(NO_PULSE))
   SRC_DIRS += src/lowparse/pulse src/cbor/pulse src/cbor/pulse/raw src/cbor/pulse/raw/everparse src/cddl/pulse
 endif
 
+include $(EVERPARSE_SRC_PATH)/fstar.Makefile
 include $(EVERPARSE_SRC_PATH)/karamel.Makefile
 ifeq (,$(NO_PULSE))
   include $(EVERPARSE_SRC_PATH)/pulse.Makefile

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -5,17 +5,7 @@ all: html 3d
 
 export EVERPARSE_HOME?=$(realpath ..)
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-  export FSTAR_HOME
-endif
+FSTAR_EXE ?= fstar.exe
 
 export KRML_HOME?=$(realpath $(EVERPARSE_HOME)/../karamel)
 

--- a/doc/build.rst
+++ b/doc/build.rst
@@ -211,9 +211,9 @@ fetch and build EverParse sources:
       to run ``eval $(opam env)`` (as instructed during ``opam init``
       or ``./everest opam``), or log out and back in.
 
-4. Set the ``FSTAR_HOME`` environment variable to the ``FStar``
-   subdirectory of your Everest clone, which contains a clone of the
-   latest F\*.
+4. Set the ``FSTAR_EXE`` environment variable to the fstar.exe binary
+   in your Everest clone (in ``FStar/bin/fstar.exe``), or add the 
+   ``FStar/bin`` directory to your ``$PATH``.
 
 5. Set the ``KRML_HOME`` environment variable to the ``karamel``
    subdirectory of your Everest clone, which contains a clone of the

--- a/src/3d/Makefile
+++ b/src/3d/Makefile
@@ -2,23 +2,14 @@ ROOT=Main.fst
 
 EVERPARSE_HOME=$(realpath ../..)
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-endif
-export FSTAR_HOME
+FSTAR_EXE ?= fstar.exe
+export FSTAR_EXE
 
 export KRML_HOME?=$(realpath ../../../karamel)
 
 INCLUDE_PATHS=
 OTHERFLAGS?=
-FSTAR=$(FSTAR_HOME)/bin/fstar.exe --ext context_pruning $(OTHERFLAGS) $(addprefix --include , $(INCLUDE_PATHS) $(EVERPARSE_HOME)/src/3d/prelude) --already_cached 'Prims FStar -FStarC'
+FSTAR=$(FSTAR_EXE) --ext context_pruning $(OTHERFLAGS) $(addprefix --include , $(INCLUDE_PATHS) $(EVERPARSE_HOME)/src/3d/prelude) --already_cached 'Prims FStar -FStarC'
 
 all: 3d prelude
 

--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -2,7 +2,6 @@ open OS
 open HashingOptions
 
 (* paths *)
-let fstar_home = OS.getenv "FSTAR_HOME"
 let krml_home = OS.getenv "KRML_HOME"
 let krmllib = filename_concat krml_home "krmllib"
 let everparse_home = OS.getenv "EVERPARSE_HOME"
@@ -22,7 +21,7 @@ let ddd_actions_c_home input_stream_binding =
   filename_concat ddd_prelude_home (string_of_input_stream_binding input_stream_binding)
 
 (* fstar.exe executable *)
-let fstar_exe = (filename_concat (filename_concat fstar_home "bin") "fstar.exe")
+let fstar_exe = try OS.getenv "FSTAR_EXE" with | OS.Undefined_environment_variable _ -> "fstar.exe"
 
 (* krml: on Windows, needs to be copied into .exe *)
 let krml out_dir =

--- a/src/3d/ocaml/Makefile
+++ b/src/3d/ocaml/Makefile
@@ -1,24 +1,7 @@
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath ../../../../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-  export FSTAR_HOME
-endif
-
-ifeq ($(OS),Windows_NT)
-  OCAMLPATH := $(shell cygpath -m $(FSTAR_HOME)/lib);$(OCAMLPATH)
-else
-  OCAMLPATH := $(FSTAR_HOME)/lib:$(OCAMLPATH)
-endif
-export OCAMLPATH
+FSTAR_EXE ?= fstar.exe
 
 all: $(filter-out %~,$(wildcard *.ml*))
-	dune build
+	$(FSTAR_EXE) --ocamlenv dune build
 
 clean-local:
 	rm -rf _build *~

--- a/src/3d/prelude/Makefile
+++ b/src/3d/prelude/Makefile
@@ -5,20 +5,7 @@ ifeq ($(OS),Windows_NT)
   EVERPARSE_HOME := $(shell cygpath -m $(EVERPARSE_HOME))
 endif
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME:=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME:=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-endif
-ifeq ($(OS),Windows_NT)
-  FSTAR_HOME:=$(shell cygpath -m $(FSTAR_HOME))
-endif
-export FSTAR_HOME
+FSTAR_EXE ?= fstar.exe
 
 ifeq (,$(KRML_HOME))
   KRML_HOME := $(realpath ../../../../karamel)
@@ -32,7 +19,7 @@ OTHERFLAGS?=
 
 FSTAR_OPTIONS=--ext context_pruning $(addprefix --include , $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib $(KRML_HOME)/krmllib/obj) --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=10'
 #--z3cliopt 'smt.arith.nl=false' --smtencoding.elim_box true --smtencoding.l_arith_repr native --smtencoding.nl_arith_repr wrapped
-FSTAR=$(FSTAR_HOME)/bin/fstar.exe $(FSTAR_OPTIONS) $(OTHERFLAGS) --cmi
+FSTAR=$(FSTAR_EXE) $(FSTAR_OPTIONS) $(OTHERFLAGS) --cmi
 
 ROOT=$(wildcard *.fst) $(wildcard *.fsti)
 ALREADY_CACHED=--already_cached '+Prims +LowStar +FStar +LowParse +C +Spec.Loops'

--- a/src/3d/prelude/buffer/Makefile
+++ b/src/3d/prelude/buffer/Makefile
@@ -5,20 +5,7 @@ ifeq ($(OS),Windows_NT)
   EVERPARSE_HOME := $(shell cygpath -m $(EVERPARSE_HOME))
 endif
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME:=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME:=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-endif
-ifeq ($(OS),Windows_NT)
-  FSTAR_HOME:=$(shell cygpath -m $(FSTAR_HOME))
-endif
-export FSTAR_HOME
+FSTAR_EXE ?= fstar.exe
 
 ifeq (,$(KRML_HOME))
   KRML_HOME := $(realpath ../../../../karamel)
@@ -31,7 +18,7 @@ export KRML_HOME
 OTHERFLAGS?=
 
 FSTAR_OPTIONS=$(addprefix --include , .. $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib $(KRML_HOME)/krmllib/obj) --z3rlimit_factor 8 --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=100'
-FSTAR=$(FSTAR_HOME)/bin/fstar.exe $(FSTAR_OPTIONS) $(OTHERFLAGS) --cmi
+FSTAR=$(FSTAR_EXE) $(FSTAR_OPTIONS) $(OTHERFLAGS) --cmi
 
 ROOT=$(wildcard *.fst) $(wildcard *.fsti)
 ALREADY_CACHED=--already_cached '*,-EverParse3d.Actions.All,-EverParse3d.InputStream.All,-EverParse3d.InputStream.Buffer,-EverParse3d.Actions.BackendFlag,-EverParse3d.Actions.BackendFlagValue,-EverParse3d.Readable,-EverParse3d.InputBuffer'

--- a/src/3d/prelude/buffer/Makefile
+++ b/src/3d/prelude/buffer/Makefile
@@ -37,7 +37,7 @@ EverParse.rsp: $(ALL_KRML_FILES) ../EverParse.rsp
 	mv $@.tmp $@
 
 EverParse.h: EverParse.rsp
-	$(KRML_HOME)/krml \
+	$(KRML) \
 	  -skip-compilation \
 	  -skip-makefiles \
 	  -bundle 'Prims,C.\*,FStar.\*,LowStar.\*[rename=SHOULDNOTBETHERE]' \

--- a/src/3d/prelude/extern/Makefile
+++ b/src/3d/prelude/extern/Makefile
@@ -5,20 +5,7 @@ ifeq ($(OS),Windows_NT)
   EVERPARSE_HOME := $(shell cygpath -m $(EVERPARSE_HOME))
 endif
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME:=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME:=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-endif
-ifeq ($(OS),Windows_NT)
-  FSTAR_HOME:=$(shell cygpath -m $(FSTAR_HOME))
-endif
-export FSTAR_HOME
+FSTAR_EXE ?= fstar.exe
 
 ifeq (,$(KRML_HOME))
   KRML_HOME := $(realpath ../../../../karamel)
@@ -31,7 +18,7 @@ export KRML_HOME
 OTHERFLAGS?=
 
 FSTAR_OPTIONS=$(addprefix --include , .. $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib $(KRML_HOME)/krmllib/obj) --z3rlimit_factor 8 --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=100'
-FSTAR=$(FSTAR_HOME)/bin/fstar.exe $(FSTAR_OPTIONS) $(OTHERFLAGS) --cmi
+FSTAR=$(FSTAR_EXE) $(FSTAR_OPTIONS) $(OTHERFLAGS) --cmi
 
 ROOT=$(wildcard *.fst) $(wildcard *.fsti)
 ALREADY_CACHED=--already_cached '*,-EverParse3d.Actions.All,-EverParse3d.InputStream.All,-EverParse3d.InputStream.Extern,-EverParse3d.Actions.BackendFlag,-EverParse3d.Actions.BackendFlagValue'

--- a/src/3d/prelude/extern/Makefile
+++ b/src/3d/prelude/extern/Makefile
@@ -43,6 +43,7 @@ EverParse.rsp: $(FILTERED_KRML_FILES) ../EverParse.rsp
 	mv $@.tmp $@
 
 KRML_EXTERN = $(KRML_HOME)/krml \
+	  -fstar $(FSTAR_EXE) \
 	  -skip-compilation \
 	  -skip-makefiles \
 	  -bundle 'Prims,C.\*,FStar.\*,LowStar.\*[rename=SHOULDNOTBETHERE]' \

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -16,20 +16,7 @@ ifeq ($(OS),Windows_NT)
 endif
 export KRML_HOME
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME := $(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME := $(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-endif
-ifeq ($(OS),Windows_NT)
-  FSTAR_HOME := $(shell cygpath -m "$(FSTAR_HOME)")
-endif
-export FSTAR_HOME
+FSTAR_EXE ?= fstar.exe
 
 INCLUDES=$(EVERPARSE_HOME)/src/3d/prelude $(EVERPARSE_HOME)/src/3d/prelude/buffer $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib/obj $(KRML_HOME)/krmllib
 

--- a/src/3d/tests/output_types/Makefile
+++ b/src/3d/tests/output_types/Makefile
@@ -24,17 +24,7 @@ interpret: $(SOURCE_FILES) interpret.out
 	$(CC) -o interpret.out/test3 -I interpret.out -I . $(addprefix interpret.out/, ExternVector.c ExternVectorWrapper.c) ExternVectorDriver.c
 	./interpret.out/test3
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-  export FSTAR_HOME
-endif
+FSTAR_EXE ?= fstar.exe
 
 INCLUDES=$(EVERPARSE_HOME)/src/3d/prelude $(EVERPARSE_HOME)/src/3d/prelude/buffer $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib/obj $(KRML_HOME)/krmllib
 

--- a/src/3d/tests/output_types/modules_batch/Makefile
+++ b/src/3d/tests/output_types/modules_batch/Makefile
@@ -10,17 +10,7 @@ basic: $(SOURCE_FILES) basic.out
 	$(CXX) -o basic.out/test -I . -I basic.out $(addprefix basic.out/, BB_OutputTypes.c CC_OutputTypes.c BB.c CC.c BBWrapper.c CCWrapper.c) Test.cpp
 	./basic.out/test
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-  export FSTAR_HOME
-endif
+FSTAR_EXE ?= fstar.exe
 
 INCLUDES=$(EVERPARSE_HOME)/src/3d/prelude $(EVERPARSE_HOME)/src/3d/prelude/buffer $(EVERPARSE_HOME)/src/lowparse $(KRML_HOME)/krmllib/obj $(KRML_HOME)/krmllib
 

--- a/src/3d/version.sh
+++ b/src/3d/version.sh
@@ -20,8 +20,7 @@ get_everparse_version() {
 
 get_fstar_commit() {
     (
-	cd $FSTAR_HOME
-        git show --no-patch --format=%h
+	$FSTAR_EXE --version | sed -n 's/commit=\(.\{10\}\).*/\1/p'
     )
 }
 

--- a/src/ASN1/Dockerfile
+++ b/src/ASN1/Dockerfile
@@ -11,7 +11,7 @@ SHELL ["/bin/bash", "--login", "-c"]
 ARG CI_THREADS=24
 RUN env OPAMYES=1 CI_THREADS=$CI_THREADS NO_INTERACTIVE=1 ./install-everparse.sh
 
-ENV FSTAR_HOME=$HOME/asn1star/everest/FStar
+ENV FSTAR_EXE=$HOME/asn1star/everest/FStar/bin/fstar.exe
 ENV KRML_HOME=$HOME/asn1star/everest/karamel
 ENV EVERPARSE_HOME=$HOME/asn1star/everest/everparse
 

--- a/src/ASN1/Makefile
+++ b/src/ASN1/Makefile
@@ -54,7 +54,7 @@ krml.rsp: $(ALL_KRML_FILES)
 	mv $@.tmp $@
 
 Test.c: krml.rsp
-	$(KRML_HOME)/krml \
+	$(KRML_HOME)/krml -fstar $(FSTAR_EXE) \
 	  -bundle 'ASN1Test=ASN1Test.\*,Prims,FStar.\*,C.\*,C,LowStar.\*,LowParse.\*' \
 	  -no-prefix ASN1Test \
 	  -skip-makefiles \

--- a/src/ASN1/Makefile
+++ b/src/ASN1/Makefile
@@ -15,11 +15,7 @@ FSTAR_OPTIONS = --cache_checked_modules --ext context_pruning \
 		$(OTHERFLAGS)
 
 
-ifdef FSTAR_HOME
-FSTAR_EXE = $(FSTAR_HOME)/bin/fstar.exe
-else
-FSTAR_EXE = fstar.exe
-endif
+FSTAR_EXE ?= fstar.exe
 FSTAR = $(FSTAR_EXE) $(FSTAR_OPTIONS)
 
 NOT_INCLUDED=ASN1.Tmp.fst ASN1.Test.Interpreter.fst $(wildcard ASN1.Low.*) ASN1Test.fst $(wildcard ASN1.bak*)

--- a/src/ASN1/install-everparse.sh
+++ b/src/ASN1/install-everparse.sh
@@ -22,7 +22,7 @@ export PATH=$PWD/z3/bin:$PATH
 make -C everparse -j "$CI_THREADS" lowparse
 
 echo "Please set the following environment variables:"
-echo "FSTAR_HOME=$(pwd)/FStar"
+echo "FSTAR_EXE=$(pwd)/FStar/bin/fstar.exe"
 echo "KRML_HOME=$(pwd)/karamel"
 echo "EVERPARSE_HOME=$(pwd)/everparse"
 popd

--- a/src/ASN1/ocaml/Makefile
+++ b/src/ASN1/ocaml/Makefile
@@ -1,7 +1,5 @@
-export OCAMLPATH += $(FSTAR_HOME)/lib
-
 all:
-	dune build
+	$(FSTAR_EXE) --ocamlenv dune build
 
 clean:
 	rm -rf _build extracted

--- a/src/cbor/pulse/det/krml/Makefile
+++ b/src/cbor/pulse/det/krml/Makefile
@@ -20,10 +20,10 @@ include $(EVERPARSE_SRC_PATH)/common.Makefile
 
 $(C_DIRECTORY)/CBORDet.c: $(filter-out %CBOR_Pulse_API_Det_Rust.krml,$(ALL_KRML_FILES))
 	mkdir -p $(dir $@)
-	$(KRML_HOME)/krml $(KRML_OPTS) -warn-error @1..27 -skip-linking -bundle 'CBOR.Spec.Constants+CBOR.Pulse.Raw.Type+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Common+CBOR.Pulse.API.Det.C=\*[rename=CBORDet]' -no-prefix CBOR.Pulse.API.Det.Common -no-prefix CBOR.Pulse.API.Det.C -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Spec.Constants -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Pulse.Raw.Type -tmpdir $(C_DIRECTORY) -header header.txt -skip-makefiles -skip-compilation $^
+	$(KRML) $(KRML_OPTS) -warn-error @1..27 -skip-linking -bundle 'CBOR.Spec.Constants+CBOR.Pulse.Raw.Type+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Common+CBOR.Pulse.API.Det.C=\*[rename=CBORDet]' -no-prefix CBOR.Pulse.API.Det.Common -no-prefix CBOR.Pulse.API.Det.C -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Spec.Constants -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Pulse.Raw.Type -tmpdir $(C_DIRECTORY) -header header.txt -skip-makefiles -skip-compilation $^
 
 $(RUST_DIRECTORY)/cbordetver.rs: $(filter-out %CBOR_Pulse_API_Det_C.krml,$(ALL_KRML_FILES))
-	$(KRML_HOME)/krml $(KRML_OPTS) -backend rust -fno-box -fkeep-tuples -fcontained-type cbor_raw_iterator -warn-error @1..27 -skip-linking -bundle 'CBOR.Pulse.API.Det.Rust=[rename=CBORDetVer]' -bundle 'CBOR.Spec.Constants+CBOR.Pulse.Raw.Type+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Common=\*[rename=CBORDetVerAux]' -no-prefix CBOR.Pulse.API.Det.Rust -tmpdir $(RUST_DIRECTORY) -skip-compilation $^
+	$(KRML) $(KRML_OPTS) -backend rust -fno-box -fkeep-tuples -fcontained-type cbor_raw_iterator -warn-error @1..27 -skip-linking -bundle 'CBOR.Pulse.API.Det.Rust=[rename=CBORDetVer]' -bundle 'CBOR.Spec.Constants+CBOR.Pulse.Raw.Type+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Common=\*[rename=CBORDetVerAux]' -no-prefix CBOR.Pulse.API.Det.Rust -tmpdir $(RUST_DIRECTORY) -skip-compilation $^
 
 extract: $(C_DIRECTORY)/CBORDet.c $(RUST_DIRECTORY)/cbordetver.rs
 

--- a/src/cbor/pulse/det/vertest/c/Makefile
+++ b/src/cbor/pulse/det/vertest/c/Makefile
@@ -23,7 +23,7 @@ $(OUTPUT_DIRECTORY)/test.exe: $(OUTPUT_DIRECTORY)/CBORTest.o
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(OUTPUT_DIRECTORY)/CBORTest.c: $(ALL_KRML_FILES)
-	$(KRML_HOME)/krml $(KRML_OPTS) -warn-error @1..27 -bundle 'FStar.\*,LowStar.\*,C.\*,PulseCore.\*,Pulse.\*[rename=fstar]' -bundle 'CBOR.Spec.Constants+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Common+CBOR.Pulse.API.Det.C=CBOR.\*[rename=CBORDetAPI]' -bundle 'CBORTest=\*' -add-include '"CBORDetAbstract.h"' -no-prefix CBOR.Pulse.API.Det.Common -no-prefix CBOR.Pulse.API.Det.C -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Spec.Constants -no-prefix CBORTest -tmpdir $(OUTPUT_DIRECTORY) -header header.txt -skip-makefiles -skip-compilation $^
+	$(KRML) $(KRML_OPTS) -warn-error @1..27 -bundle 'FStar.\*,LowStar.\*,C.\*,PulseCore.\*,Pulse.\*[rename=fstar]' -bundle 'CBOR.Spec.Constants+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Common+CBOR.Pulse.API.Det.C=CBOR.\*[rename=CBORDetAPI]' -bundle 'CBORTest=\*' -add-include '"CBORDetAbstract.h"' -no-prefix CBOR.Pulse.API.Det.Common -no-prefix CBOR.Pulse.API.Det.C -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Spec.Constants -no-prefix CBORTest -tmpdir $(OUTPUT_DIRECTORY) -header header.txt -skip-makefiles -skip-compilation $^
 
 test: extract
 	$(OUTPUT_DIRECTORY)/test.exe

--- a/src/cbor/pulse/det/vertest/common/Makefile
+++ b/src/cbor/pulse/det/vertest/common/Makefile
@@ -23,10 +23,10 @@ $(OUTPUT_DIRECTORY)/test.exe: $(OUTPUT_DIRECTORY)/CBORTest.o
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(OUTPUT_DIRECTORY)/CBORTest.c: $(ALL_KRML_FILES)
-	$(KRML_HOME)/krml $(KRML_OPTS) -warn-error @1..27 -bundle 'FStar.\*,LowStar.\*,C.\*,PulseCore.\*,Pulse.\*[rename=fstar]' -bundle 'CBOR.Spec.Constants+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Common+CBOR.Pulse.API.Det.C=CBOR.\*[rename=CBORDetAPI]' -bundle 'CBORTest.C=\*[rename=CBORTest]' -add-include '"CBORDetAbstract.h"' -no-prefix CBOR.Pulse.API.Det.Common -no-prefix CBOR.Pulse.API.Det.C -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Spec.Constants -no-prefix CBORTest.C -tmpdir $(OUTPUT_DIRECTORY) -header header.txt -skip-makefiles -skip-compilation $^
+	$(KRML) $(KRML_OPTS) -warn-error @1..27 -bundle 'FStar.\*,LowStar.\*,C.\*,PulseCore.\*,Pulse.\*[rename=fstar]' -bundle 'CBOR.Spec.Constants+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Common+CBOR.Pulse.API.Det.C=CBOR.\*[rename=CBORDetAPI]' -bundle 'CBORTest.C=\*[rename=CBORTest]' -add-include '"CBORDetAbstract.h"' -no-prefix CBOR.Pulse.API.Det.Common -no-prefix CBOR.Pulse.API.Det.C -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Spec.Constants -no-prefix CBORTest.C -tmpdir $(OUTPUT_DIRECTORY) -header header.txt -skip-makefiles -skip-compilation $^
 
 $(OUTPUT_DIRECTORY)/CBORTest.rs: $(ALL_KRML_FILES)
-	$(KRML_HOME)/krml $(KRML_OPTS) -backend rust -fno-box -fkeep-tuples -fcontained-type cbor_raw_iterator -warn-error @1..27 -bundle 'FStar.\*,LowStar.\*,C.\*,PulseCore.\*,Pulse.\*[rename=fstar]' -bundle 'CBOR.Spec.Constants+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Common+CBOR.Pulse.API.Det.C=CBOR.\*[rename=CBORDetAPI]' -bundle 'CBORTest.Rust=\*[rename=CBORTest]' -no-prefix CBOR.Pulse.API.Det.Common -no-prefix CBOR.Pulse.API.Det.C -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Spec.Constants -no-prefix CBORTest.C -tmpdir $(OUTPUT_DIRECTORY) -skip-compilation $^
+	$(KRML) $(KRML_OPTS) -backend rust -fno-box -fkeep-tuples -fcontained-type cbor_raw_iterator -warn-error @1..27 -bundle 'FStar.\*,LowStar.\*,C.\*,PulseCore.\*,Pulse.\*[rename=fstar]' -bundle 'CBOR.Spec.Constants+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Common+CBOR.Pulse.API.Det.C=CBOR.\*[rename=CBORDetAPI]' -bundle 'CBORTest.Rust=\*[rename=CBORTest]' -no-prefix CBOR.Pulse.API.Det.Common -no-prefix CBOR.Pulse.API.Det.C -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Spec.Constants -no-prefix CBORTest.C -tmpdir $(OUTPUT_DIRECTORY) -skip-compilation $^
 
 test: extract
 	$(OUTPUT_DIRECTORY)/test.exe

--- a/src/cbor/pulse/raw/extract-det-type.Makefile
+++ b/src/cbor/pulse/raw/extract-det-type.Makefile
@@ -16,4 +16,4 @@ include $(EVERPARSE_SRC_PATH)/karamel.Makefile
 .PHONY: extract
 
 extract: $(ALL_KRML_FILES)
-	$(KRML_HOME)/krml -bundle 'CBOR.Pulse.API.Det.Type=\*' -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Spec.Constants -tmpdir $(OUTPUT_DIRECTORY) -skip-compilation $^
+	$(KRML) -bundle 'CBOR.Pulse.API.Det.Type=\*' -no-prefix CBOR.Pulse.API.Det.Type -no-prefix CBOR.Spec.Constants -tmpdir $(OUTPUT_DIRECTORY) -skip-compilation $^

--- a/src/cddl/pulse/Makefile
+++ b/src/cddl/pulse/Makefile
@@ -11,7 +11,7 @@ ALREADY_CACHED := *,-CDDL.Pulse,
 include $(EVERPARSE_SRC_PATH)/pulse.Makefile
 include $(EVERPARSE_SRC_PATH)/common.Makefile
 
-# KRML=$(KRML_HOME)/krml $(KRML_OPTS)
+# KRML=$(KRML) $(KRML_OPTS)
 
 # extract: $(ALL_KRML_FILES)
 # 	$(KRML) -bundle C -bundle CBOR.Spec.Constants+CBOR.Pulse.Type+CBOR.Pulse.Extern=[rename=CBOR] -no-prefix CBOR.Spec.Constants,CBOR.Pulse.Type,CBOR.Pulse.Extern -bundle CDDLExtractionTest.Assume+CDDLExtractionTest.Bytes+CDDLExtractionTest.BytesUnwrapped+CDDLExtractionTest.Choice=*[rename=CDDLExtractionTest] -skip-linking $^ -tmpdir $(OUTPUT_DIRECTORY)

--- a/src/cddl/spec/Makefile
+++ b/src/cddl/spec/Makefile
@@ -10,7 +10,7 @@ ALREADY_CACHED := *,-CDDL.Spec,
 
 include $(EVERPARSE_SRC_PATH)/common.Makefile
 
-# KRML=$(KRML_HOME)/krml $(KRML_OPTS)
+# KRML=$(KRML) $(KRML_OPTS)
 
 # extract: $(ALL_KRML_FILES)
 # 	$(KRML) -bundle C -bundle CBOR.Spec.Constants+CBOR.Pulse.Type+CBOR.Pulse.Extern=[rename=CBOR] -no-prefix CBOR.Spec.Constants,CBOR.Pulse.Type,CBOR.Pulse.Extern -bundle CDDLExtractionTest.Assume+CDDLExtractionTest.Bytes+CDDLExtractionTest.BytesUnwrapped+CDDLExtractionTest.Choice=*[rename=CDDLExtractionTest] -skip-linking $^ -tmpdir $(OUTPUT_DIRECTORY)

--- a/src/common.Makefile
+++ b/src/common.Makefile
@@ -53,7 +53,7 @@ ifneq ($(RESOURCEMONITOR),)
 	RUNLIM=runlim -p -o $@.$(MONPREFIX)runlim
 endif
 
-FSTAR=$(RUNLIM) $(FSTAR_HOME)/bin/fstar.exe $(SIL) $(FSTAR_OPTIONS)
+FSTAR=$(RUNLIM) $(FSTAR_EXE) $(SIL) $(FSTAR_OPTIONS)
 
 FSTAR_DEP_FILE ?= .depend
 

--- a/src/fstar.Makefile
+++ b/src/fstar.Makefile
@@ -2,28 +2,16 @@ ifeq (,$(EVERPARSE_SRC_PATH))
   $(error "EVERPARSE_SRC_PATH must be set to the absolute path of the src/ subdirectory of the EverParse repository")
 endif
 
-# Find fstar.exe and the fstar.lib OCaml package
-ifeq (,$(FSTAR_HOME))
-  _check_fstar := $(shell which fstar.exe)
-  ifeq ($(.SHELLSTATUS),0)
-    FSTAR_HOME := $(realpath $(dir $(_check_fstar))/..)
-  else
-#    $(error "FSTAR_HOME is not defined and I cannot find fstar.exe in $(PATH). Please make sure fstar.exe is properly installed and in your PATH or FSTAR_HOME points to its prefix directory or the F* source repository.")
-    # assuming Everest layout
-    FSTAR_HOME := $(realpath $(EVERPARSE_SRC_PATH)/../../FStar)
-  endif
-endif
-ifeq ($(OS),Windows_NT)
-  FSTAR_HOME := $(shell cygpath -m $(FSTAR_HOME))
-endif
-export FSTAR_HOME
-ifeq ($(OS),Windows_NT)
-    OCAMLPATH := $(shell cygpath -m $(FSTAR_HOME)/lib);$(OCAMLPATH)
-else
-    OCAMLPATH := $(FSTAR_HOME)/lib:$(OCAMLPATH)
-endif
-export OCAMLPATH
-_check_fstar_lib_package := $(shell env OCAMLPATH="$(OCAMLPATH)" ocamlfind query fstar.lib)
+FSTAR_EXE ?= fstar.exe
+
+FSTAR_VERSION != $(FSTAR_EXE) --version
 ifneq ($(.SHELLSTATUS),0)
-  $(error "Cannot find fstar.lib in $(OCAMLPATH). Please make sure fstar.exe is properly installed and in your PATH or FSTAR_HOME points to its prefix directory or the F* source repository.")
+  $(error "F* version check failed (FSTAR_EXE = $(FSTAR_EXE))" )
 endif
+
+_ != $(FSTAR_EXE) --ocamlenv ocamlfind query fstar.lib
+ifneq ($(.SHELLSTATUS),0)
+  $(error "Cannot find fstar.lib (FSTAR_EXE = $(FSTAR_EXE)). Is F* properly installed?")
+endif
+
+export FSTAR_EXE

--- a/src/karamel.Makefile
+++ b/src/karamel.Makefile
@@ -2,6 +2,8 @@ ifeq (,$(EVERPARSE_SRC_PATH))
   $(error "EVERPARSE_SRC_PATH must be set to the absolute path of the src/ subdirectory of the EverParse repository")
 endif
 
+include $(EVERPARSE_SRC_PATH)/fstar.Makefile
+
 ifeq (,$(KRML_HOME))
   # assuming Everest layout
   KRML_HOME := $(realpath $(EVERPARSE_SRC_PATH)/../../karamel)
@@ -15,3 +17,6 @@ ALREADY_CACHED := C,LowStar,$(ALREADY_CACHED)
 INCLUDE_PATHS += $(KRML_HOME)/krmllib $(KRML_HOME)/krmllib/obj
 
 CFLAGS += -I $(KRML_HOME)/include -I $(KRML_HOME)/krmllib/dist/generic
+
+# Make sure krml uses the F* we set in FSTAR_EXE
+KRML := $(KRML_HOME)/krml -fstar $(FSTAR_EXE)

--- a/src/lowparse/Makefile
+++ b/src/lowparse/Makefile
@@ -8,6 +8,7 @@ all: verify
 
 EVERPARSE_SRC_PATH = $(realpath ..)
 
+include $(EVERPARSE_SRC_PATH)/fstar.Makefile
 include $(EVERPARSE_SRC_PATH)/karamel.Makefile
 
 ALREADY_CACHED := *,-LowParse,

--- a/src/package/build.ninja
+++ b/src/package/build.ninja
@@ -7,7 +7,7 @@ include vars.ninja
 
 FSTAR_OPTIONS = --cache_checked_modules --already_cached FStar,LowStar,C,Spec.Loops,LowParse --include $LOWPARSE_HOME --include $KRML_HOME/krmllib --include $KRML_HOME/krmllib/obj --include $DDD_HOME --warn_error +241 --z3rlimit_factor 4 --max_fuel 0 --max_ifuel 2 --initial_ifuel 2 --z3cliopt 'smt.qi.eager_threshold=100' --cmi
 
-FSTAR = $FSTAR_HOME/bin/fstar.exe --trace_error $FSTAR_OPTIONS
+FSTAR = $FSTAR_EXE --trace_error $FSTAR_OPTIONS
 
 # Verify the F* files
 rule checked

--- a/src/package/everparse.cmd
+++ b/src/package/everparse.cmd
@@ -2,7 +2,7 @@
 setlocal
 set mypath0=%~dp0
 set EVERPARSE_HOME=%mypath0:~0,-1%
-set FSTAR_HOME=%EVERPARSE_HOME%
+set FSTAR_EXE=%EVERPARSE_HOME%\bin\fstar.exe
 set KRML_HOME=%EVERPARSE_HOME%
 %EVERPARSE_HOME%\bin\3d.exe --__arg0 everparse.cmd --clang_format_executable %EVERPARSE_HOME%\bin\clang-format.exe %*
 exit /b %ERRORLEVEL%

--- a/src/package/everparse.sh
+++ b/src/package/everparse.sh
@@ -4,7 +4,7 @@ unset CDPATH
 export EVERPARSE_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 (cd "$EVERPARSE_HOME/bin" ; chmod +x * ) || true
 (cd "$EVERPARSE_HOME/z3-latest/bin" ; chmod +x * ) || true
-export FSTAR_HOME="$EVERPARSE_HOME"
+export FSTAR_EXE="$EVERPARSE_HOME/bin/fstar.exe"
 export KRML_HOME="$EVERPARSE_HOME"
 export PATH="$EVERPARSE_HOME/bin:$PATH" # because of z3
 export LD_LIBRARY_PATH="$EVERPARSE_HOME/bin:$LD_LIBRARY_PATH"

--- a/src/package/package.sh
+++ b/src/package/package.sh
@@ -108,6 +108,8 @@ make_everparse() {
     # Verify if F* and KaRaMeL are here
     cp0=$(which gcp >/dev/null 2>&1 && echo gcp || echo cp)
     cp="$cp0 --preserve=mode,timestamps"
+    # GM: Retaining this use of FSTAR_HOME as it is cloning and
+    # uses the repo to figure out commit metadata.
     if [[ -z "$FSTAR_HOME" ]] ; then
         if [[ -d FStar ]] ; then
             export FSTAR_HOME=$(fixpath $PWD/FStar)
@@ -120,6 +122,8 @@ make_everparse() {
     else
         export FSTAR_HOME=$(fixpath "$FSTAR_HOME")
     fi
+    export FSTAR_EXE=$FSTAR_HOME/bin/fstar.exe
+
     if [[ -z "$KRML_HOME" ]] ; then
         { [[ -d karamel ]] || git clone https://github.com/FStarLang/karamel ; }
         export KRML_HOME=$(fixpath $PWD/karamel)
@@ -144,8 +148,8 @@ make_everparse() {
         $MAKE -C "$FSTAR_HOME" "$@"
     fi
     if [[ -z "$fstar_commit_id" ]] ; then
-        fstar_commit_id=$("$FSTAR_HOME/bin/fstar.exe" --version | grep '^commit=' | sed 's!^.*=!!')
-        fstar_commit_date_hr=$("$FSTAR_HOME/bin/fstar.exe" --version | grep '^date=' | sed 's!^.*=!!')
+        fstar_commit_id=$("$FSTAR_EXE" --version | grep '^commit=' | sed 's!^.*=!!')
+        fstar_commit_date_hr=$("$FSTAR_EXE" --version | grep '^date=' | sed 's!^.*=!!')
     fi
     if $is_windows ; then
         # FIXME: krmllib cannot be built on Windows because the krmllib Makefiles use Cygwin paths, which cannot be used by the krml executable
@@ -211,11 +215,11 @@ make_everparse() {
       # we have a F* source tree
       # TODO: create some `install-minimal` rule in the F* Makefile
       everparse_package_dir=$(fixpath "$(pwd)/everparse")
-      $cp $FSTAR_HOME/bin/fstar.exe everparse/bin/
+      $cp $FSTAR_EXE everparse/bin/
       PREFIX="$everparse_package_dir" $MAKE -C $FSTAR_HOME/ulib install
     else
       # we have a F* binary package, or opam package
-      $cp $FSTAR_HOME/bin/fstar.exe everparse/bin/
+      $cp $FSTAR_EXE everparse/bin/
       mkdir everparse/lib
       $cp -r $FSTAR_HOME/lib/fstar everparse/lib/fstar
     fi

--- a/src/package/windows/everest.sh
+++ b/src/package/windows/everest.sh
@@ -521,8 +521,8 @@ OCAML
   fi
 
   magenta "Note: you *may* want to add ${xpwd}/FStar/bin and ${xpwd}/karamel to your PATH"
-  [ -n "${FSTAR_HOME}" ] || \
-    magenta "Note: you *may* want to export FSTAR_HOME=${xpwd}/FStar"
+  [ -n "${FSTAR_EXE}" ] || \
+    magenta "Note: you *may* want to export FSTAR_EXE=${xpwd}/FStar/bin/fstar.exe"
   [ -n "${KRML_HOME}" ] || \
     magenta "Note: you *may* want to export KRML_HOME=${xpwd}/karamel"
 }

--- a/src/pulse.Makefile
+++ b/src/pulse.Makefile
@@ -2,20 +2,11 @@ ifeq (,$(EVERPARSE_SRC_PATH))
   $(error "EVERPARSE_SRC_PATH must be set to the absolute path of the src/ subdirectory of the EverParse repository")
 endif
 
-ifeq (,$(PULSE_LIB))
-  ifeq (,$(PULSE_HOME))
-    PULSE_LIB := $(shell ocamlfind query pulse)
-    ifeq (,$(PULSE_LIB))
-#      $(error "Pulse should be installed and its lib/ subdirectory should be in ocamlpath; or PULSE_HOME should be defined in the enclosing Makefile as the prefix directory where Pulse was installed, or the root directory of its source repository")
-      # assuming Everest layout
-      # NOTE: $PULSE_HOME is now $PULSE_REPO/out, cf. FStarLang/pulse#246
-      PULSE_LIB := $(realpath $(EVERPARSE_SRC_PATH)/../../pulse/out/lib/pulse)
-    endif
-    PULSE_HOME := $(realpath $(PULSE_LIB)/../..)
-  else
-    PULSE_LIB := $(PULSE_HOME)/lib/pulse
-  endif
+ifeq (,$(PULSE_HOME))
+  $(error "PULSE_HOME must point to the root of a pulse installation (probably PULSE_REPO/out)")
 endif
+PULSE_LIB=$(PULSE_HOME)/lib/pulse
+
 ifeq ($(OS),Windows_NT)
     OCAMLPATH := $(PULSE_LIB);$(OCAMLPATH)
 else
@@ -28,7 +19,4 @@ export OCAMLPATH
 # MyNamespace, then you can set this variable to *,-MyNamespace
 ALREADY_CACHED := PulseCore,Pulse,$(ALREADY_CACHED)
 
-# FIXME: do we still need separate subdirectories for pledges, classes?
-INCLUDE_PATHS += $(PULSE_LIB) $(PULSE_LIB)/lib $(PULSE_LIB)/lib/class $(PULSE_LIB)/lib/pledge $(PULSE_LIB)/core
-
-FSTAR_OPTIONS += --load_cmxs pulse
+INCLUDE_PATHS += $(PULSE_HOME)/lib/pulse

--- a/tests/bitfields/Makefile.common
+++ b/tests/bitfields/Makefile.common
@@ -1,17 +1,6 @@
 EVERPARSE_HOME ?= $(realpath ../..)
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-  export FSTAR_HOME
-endif
-
+FSTAR_EXE ?= fstar.exe
 KRML_HOME ?= ../../../karamel
 LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
 
@@ -23,7 +12,7 @@ FSTAR_OPTIONS = --odir krml --cache_dir cache --cache_checked_modules \
 		--already_cached +Prims,+FStar,+LowStar,+C,+Spec.Loops,+LowParse \
 		--include $(LOWPARSE_HOME) --include $(KRML_HOME)/krmllib --include $(KRML_HOME)/krmllib/obj --cmi
 
-FSTAR = $(FSTAR_HOME)/bin/fstar.exe --trace_error $(FSTAR_OPTIONS)
+FSTAR = $(FSTAR_EXE) --trace_error $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 

--- a/tests/bitfields/Makefile.common
+++ b/tests/bitfields/Makefile.common
@@ -16,7 +16,7 @@ FSTAR = $(FSTAR_EXE) --trace_error $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
-KRML = $(KRML_HOME)/krml \
+KRML = $(KRML_HOME)/krml -fstar $(FSTAR_EXE) \
 	 -ccopt "-Ofast" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out \

--- a/tests/lowparse/Makefile
+++ b/tests/lowparse/Makefile
@@ -30,7 +30,7 @@ INTERMEDIATE_LEVEL=$(LOWPARSE_HOME)/LowParse_TestLib_SLow_c.c -ccopt -Wno-error-
 
 LOW_LEVEL=$(LOWPARSE_HOME)/LowParse_TestLib_Low_c.c
 
-MY_KRML=$(KRML_EXE) -bundle 'LowParse.\*'  -add-include '"krml/internal/compat.h"'
+MY_KRML=$(KRML_EXE) -fstar $(FSTAR_EXE) -bundle 'LowParse.\*'  -add-include '"krml/internal/compat.h"'
 
 EXAMPLES=Example Example2 Example3 Example5 Example6 Example7 Example8 Example9 Example10 Example11 Example12 ExampleMono ExamplePair ExampleDepLen ExampleConstInt32le
 

--- a/tests/lowparse/Makefile
+++ b/tests/lowparse/Makefile
@@ -4,15 +4,7 @@ LOWPARSE_HOME ?= ../../src/lowparse
 
 FSTAR_OUT_DIR?=.fstar-out
 
-ifndef FSTAR_HOME
-  FSTAR_EXE:=$(shell which fstar.exe)
-  ifneq ($(.SHELLSTATUS),0)
-    FSTAR_HOME=../../../FStar
-  endif
-endif
-ifdef FSTAR_HOME
-  FSTAR_EXE:=$(FSTAR_HOME)/bin/fstar.exe
-endif
+FSTAR_EXE ?= fstar.exe
 
 ifndef KRML_HOME
   KRMLLIB:=$(shell ocamlfind query karamel)

--- a/tests/sample/Makefile.common
+++ b/tests/sample/Makefile.common
@@ -18,7 +18,7 @@ FSTAR = $(FSTAR_EXE) --trace_error $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
-KRML = $(KRML_HOME)/krml \
+KRML = $(KRML_HOME)/krml -fstar $(FSTAR_EXE) \
 	 -ccopt "-Ofast" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out \

--- a/tests/sample/Makefile.common
+++ b/tests/sample/Makefile.common
@@ -1,20 +1,11 @@
 EVERPARSE_HOME ?= ../..
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-  export FSTAR_HOME
-endif
+FSTAR_EXE ?= fstar.exe
 
 KRML_HOME ?= ../../../karamel
 LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
 
+export FSTAR_EXE
 export LOWPARSE_HOME
 export KRML_HOME
 export EVERPARSE_HOME
@@ -23,7 +14,7 @@ FSTAR_OPTIONS = --odir krml --cache_dir cache --cache_checked_modules \
 		--already_cached +Prims,+FStar,+LowStar,+C,+Spec.Loops,+LowParse \
 		--include $(LOWPARSE_HOME) --include $(KRML_HOME)/krmllib --include $(KRML_HOME)/krmllib/obj --cmi
 
-FSTAR = $(FSTAR_HOME)/bin/fstar.exe --trace_error $(FSTAR_OPTIONS)
+FSTAR = $(FSTAR_EXE) --trace_error $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 

--- a/tests/sample0/Makefile.common
+++ b/tests/sample0/Makefile.common
@@ -16,7 +16,7 @@ FSTAR = $(FSTAR_EXE) --trace_error $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
-KRML = $(KRML_HOME)/krml \
+KRML = $(KRML_HOME)/krml -fstar $(FSTAR_EXE) \
 	 -ccopt "-Ofast" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out \

--- a/tests/sample0/Makefile.common
+++ b/tests/sample0/Makefile.common
@@ -1,9 +1,9 @@
-FSTAR_HOME ?= ../../../FStar
+FSTAR_EXE ?= fstar.exe
 KRML_HOME ?= ../../../karamel
 EVERPARSE_HOME ?= ../..
 LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
 
-export FSTAR_HOME
+export FSTAR_EXE
 export LOWPARSE_HOME
 export KRML_HOME
 export EVERPARSE_HOME
@@ -12,7 +12,7 @@ FSTAR_OPTIONS = --odir krml --cache_dir cache --cache_checked_modules \
 		--already_cached +Prims,+FStar,+LowStar,+C,+Spec.Loops,+LowParse \
 		--include $(LOWPARSE_HOME) --include $(KRML_HOME)/krmllib --include $(KRML_HOME)/krmllib/obj --cmi
 
-FSTAR = $(FSTAR_HOME)/bin/fstar.exe --trace_error $(FSTAR_OPTIONS)
+FSTAR = $(FSTAR_EXE) --trace_error $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 

--- a/tests/sample_client/Makefile
+++ b/tests/sample_client/Makefile
@@ -1,24 +1,14 @@
 PREFIX=Sample.AutoGen_
 EVERPARSE_HOME=../..
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-  export FSTAR_HOME
-endif
+FSTAR_EXE ?= fstar.exe
 
 LOWPARSE_HOME?=$(EVERPARSE_HOME)/src/lowparse
 INCLUDES=$(KRML_HOME)/krmllib \
 	$(KRML_HOME)/krmllib/obj \
 	$(LOWPARSE_HOME)
 INCLUDES_OPTS=$(addprefix --include , $(INCLUDES))
-FSTAR=$(FSTAR_HOME)/bin/fstar.exe $(INCLUDES_OPTS) $(OTHERFLAGS)
+FSTAR=$(FSTAR_EXE) $(INCLUDES_OPTS) $(OTHERFLAGS)
 
 all: verify
 

--- a/tests/sample_low/Makefile.common
+++ b/tests/sample_low/Makefile.common
@@ -18,7 +18,7 @@ FSTAR = $(FSTAR_EXE) --trace_error $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
-KRML = $(KRML_HOME)/krml \
+KRML = $(KRML_HOME)/krml -fstar $(FSTAR_EXE) \
 	 -ccopt "-Ofast" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out \

--- a/tests/sample_low/Makefile.common
+++ b/tests/sample_low/Makefile.common
@@ -1,20 +1,11 @@
 EVERPARSE_HOME ?= ../..
 
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath $(EVERPARSE_HOME)/../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-  export FSTAR_HOME
-endif
+FSTAR_EXE ?= fstar.exe
 
 KRML_HOME ?= ../../../karamel
 LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
 
+export FSTAR_EXE
 export LOWPARSE_HOME
 export KRML_HOME
 export EVERPARSE_HOME
@@ -23,7 +14,7 @@ FSTAR_OPTIONS = --odir krml --cache_dir cache --cache_checked_modules \
 		--already_cached +Prims,+FStar,+LowStar,+C,+Spec.Loops,+LowParse \
 		--include $(LOWPARSE_HOME) --include $(KRML_HOME)/krmllib --include $(KRML_HOME)/krmllib/obj --cmi
 
-FSTAR = $(FSTAR_HOME)/bin/fstar.exe --trace_error $(FSTAR_OPTIONS)
+FSTAR = $(FSTAR_EXE) --trace_error $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -26,7 +26,7 @@ FSTAR = $(FSTAR_EXE) --trace_error $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
-KRML = $(KRML_HOME)/krml \
+KRML = $(KRML_HOME)/krml -fstar $(FSTAR_EXE) \
 	 -ccopt "-Ofast" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out -I .. \

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -1,19 +1,8 @@
-ifndef FSTAR_HOME
-  FSTAR_EXE=$(shell which fstar.exe)
-  ifeq ($(FSTAR_EXE),)
-    # fstar.exe not found in PATH, assuming Everest source tree
-    FSTAR_HOME=$(realpath ../../../FStar)
-  else
-    # fstar.exe found in PATH, assuming directory ending with /bin
-    FSTAR_HOME=$(realpath $(dir $(FSTAR_EXE))/..)
-  endif
-  export FSTAR_HOME
-endif
+FSTAR_EXE ?= fstar.exe
 
 LOWPARSE_HOME ?= ../../src/lowparse
 KRML_HOME ?= ../../../karamel
 
-export FSTAR_HOME
 export LOWPARSE_HOME
 export KRML_HOME
 
@@ -33,7 +22,7 @@ FSTAR_OPTIONS = --odir krml --cache_dir $(CACHE_DIR) $(LAX_OPT) --cache_checked_
 		--already_cached +Prims,+FStar,+LowStar,+C,+Spec.Loops,+LowParse \
 		--include $(LOWPARSE_HOME) --include $(KRML_HOME)/krmllib --include $(KRML_HOME)/krmllib/obj --include .. --cmi
 
-FSTAR = $(FSTAR_HOME)/bin/fstar.exe --trace_error $(FSTAR_OPTIONS)
+FSTAR = $(FSTAR_EXE) --trace_error $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 


### PR DESCRIPTION
EDIT: Probably the right thing is to take #162 and then merge master into `_taramana_cbor` (or rebase it). Keeping open as a draft anyway, since some of the changes are not there on master (e.g. `pulse.Makefile` does not exist).