### PR TITLE
3d tests: redirect output of negative tests

### DIFF
--- a/src/3d/tests/.gitignore
+++ b/src/3d/tests/.gitignore
@@ -4,3 +4,5 @@ out.batch-interpret
 out.fail.batch
 out.cleanup
 test-cpp.exe
+*.out
+*.err

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -75,7 +75,7 @@ batch-test-negative: $(addsuffix .negtest,$(wildcard FAIL*.3d))
 
 %.3d.negtest: %.3d
 	mkdir -p out.fail.batch
-	! $(3D) --odir out.fail.batch --batch $<
+	! $(3D) --odir out.fail.batch --batch $< >$@.out 2>$@.err
 
 batch-test:
 	mkdir -p out.batch


### PR DESCRIPTION
Hi Tahina, this is a tiny patch to reduce the errors shown in action logs.
 
In the successful case, these tests output F* errors that will then show up in logs for CI runs (e.g.
https://github.com/mtzguido/FStar/actions/runs/13357223228). Redirect the output and error output to files so they do not show up, but can still be inspected manually.

