### PR TITLE
3d hash checking: use `really_input`

### DIFF
--- a/src/3d/ocaml/Hashing.ml
+++ b/src/3d/ocaml/Hashing.ml
@@ -20,7 +20,7 @@ let hex_of_bytes buf =
     ) buf;
   Bytes.to_string hex
 
-let hash_debug = true
+let hash_debug = false
 
 let hash_debug_print s =
   if hash_debug

--- a/src/3d/ocaml/Hashing.ml
+++ b/src/3d/ocaml/Hashing.ml
@@ -56,7 +56,7 @@ let hash_file h f =
   hash_int h len;
   hash_debug_print (Printf.sprintf "hash_file %s" f);
   let buf = Bytes.create len in
-  let _ = input ch buf 0 len in
+  let _ = really_input ch buf 0 len in
   close_in ch;
   hash_update h buf
 

--- a/src/3d/ocaml/sha/HashingBase.ml
+++ b/src/3d/ocaml/sha/HashingBase.ml
@@ -5,3 +5,7 @@ let init () = Sha256.init ()
 let update h b = Sha256.update_string h (Bytes.to_string b)
 
 let finish h = Bytes.of_string (Sha256.to_bin (Sha256.finalize h))
+
+let get_current_digest h =
+  let h' = Sha256.copy h in
+  finish h'

--- a/src/3d/ocaml/sha/HashingBase.mli
+++ b/src/3d/ocaml/sha/HashingBase.mli
@@ -9,3 +9,5 @@ val init : unit -> t
 val update : t -> Bytes.t -> unit
 
 val finish : t -> Bytes.t
+
+val get_current_digest : t -> Bytes.t

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -22,7 +22,7 @@ INCLUDES=$(EVERPARSE_HOME)/src/3d/prelude $(EVERPARSE_HOME)/src/3d/prelude/buffe
 
 FSTAR_OPTIONS=$(addprefix --include , $(INCLUDES))
 
-positive_tests=$(filter-out $(wildcard FAIL*.3d) FieldDependence0.3d ActAndCheck.3d ELF.3d,$(wildcard *.3d))
+positive_tests=$(filter-out $(wildcard FAIL*.3d) FieldDependence0.3d ActAndCheck.3d,$(wildcard *.3d))
 positive_tests_nosuffix=$(basename $(positive_tests))
 modules_or_wrappers=$(positive_tests_nosuffix) $(addsuffix Wrapper,$(positive_tests_nosuffix))
 modules_static_assertions=TestFieldPtrStaticAssertions.c AlignStaticAssertions.c
@@ -40,9 +40,7 @@ all: batch-test batch-test-negative batch-cleanup-test inplace-hash-test modules
 iter:
 	+$(MAKE) -C $@
 
-#AR: TODO: remove ELF.3d from here
-
-INTERPRETABLE_FILES=$(filter-out FAIL%.3d ELF.3d, $(wildcard *.3d))
+INTERPRETABLE_FILES=$(filter-out FAIL%.3d, $(wildcard *.3d))
 INTERPRETABLE_MODULES=$(basename $(INTERPRETABLE_FILES))
 interpret_all: $(addsuffix .interpret, $(INTERPRETABLE_MODULES))
 


### PR DESCRIPTION
With this PR, hash checking now hashes whole files with `Stdlib.really_input` instead of input. With that, hash checking for ELF.3d now works and has been re-enabled in 3d tests.
