### PR TITLE
3D test case generation on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Everparse CI
         id: cistep
-        run: make -C everparse ci -skj$(nproc)
+        run: make -C everparse ci 3D_Z3_EXECUTABLE=z3-4.13.3 -skj$(nproc)
 
       # I'm leaving this disabled as I do not get good incrementality
       # when trying this out by hand due to dependence hash mismatches

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -187,3 +187,7 @@ jobs:
         shell: cmd
         run: |
           ${{ github.workspace }}\test\everparse.cmd ${{ github.workspace }}\everparse\src\3d\tests\Arithmetic.3d ${{ github.workspace }}\everparse\src\3d\tests\FieldDependence0.3d && ${{ github.workspace }}\test\everparse.cmd ${{ github.workspace }}\everparse\src\3d\tests\Comments.3d && ${{ github.workspace }}\test\everparse.cmd --check_hashes inplace ${{ github.workspace }}\everparse\src\3d\tests\Comments.3d
+      - name: Test EverParse test case generation
+        shell: cmd
+        run: |
+          ${{ github.workspace }}\test\everparse.cmd ${{ github.workspace }}\everparse\src\3d\tests\ELFTestGen.3d --odir ${{ github.workspace }}\test-elf --z3_test ELFTestGen._ELFTestGen --z3_witnesses 10 --z3_branch_depth 5

--- a/src/3d/Batch.fsti
+++ b/src/3d/Batch.fsti
@@ -2,6 +2,8 @@ module Batch
 open HashingOptions
 open FStar.All
 
+val cl_wrapper: unit -> ML string
+
 (* The --print_in_place step has to be performed at source generation
    time, not at verification time, because if the user requests files
    to be processed by a Makefile, they must not be modified again

--- a/src/3d/Main.fst
+++ b/src/3d/Main.fst
@@ -468,7 +468,7 @@ let build_test_exe
   if OS.is_windows ()
   then begin
     let cl_wrapper = Batch.cl_wrapper () in
-    OS.run_cmd "cmd" ("/C" :: "call" :: cl_wrapper :: "/Fe:" :: OS.concat out_dir "test.exe" :: testcases_c_file out_dir :: List.Tot.map (OS.concat out_dir) (List.Tot.map (fun x -> x ^ ".c") modules))
+    OS.run_cmd "cmd" ("/C" :: "cd" :: out_dir :: "&&" :: "call" :: cl_wrapper :: "/Fe:" :: OS.concat "." "test.exe" :: testcases_c_file "." :: List.Tot.map (fun x -> x ^ ".c") modules)
   end else
   if not (Options.get_skip_c_makefiles ())
   then begin

--- a/src/3d/Main.fst
+++ b/src/3d/Main.fst
@@ -461,7 +461,8 @@ let build_test_exe
 =
   if not (Options.get_skip_c_makefiles ())
   then begin
-    OS.run_cmd "make" ["-C"; out_dir; "-f"; "Makefile.basic"; "USER_TARGET=test.exe"; "USER_CFLAGS=-Wno-type-limits"]
+    if not (OS.is_windows ())
+    then OS.run_cmd "make" ["-C"; out_dir; "-f"; "Makefile.basic"; "USER_TARGET=test.exe"; "USER_CFLAGS=-Wno-type-limits"]
   end
 
 let build_and_run_test_exe
@@ -470,8 +471,11 @@ let build_and_run_test_exe
 =
   if not (Options.get_skip_c_makefiles ())
   then begin
-    build_test_exe out_dir;
-    OS.run_cmd (OS.concat out_dir "test.exe") []
+    if not (OS.is_windows ())
+    then begin
+        build_test_exe out_dir;
+    	OS.run_cmd (OS.concat out_dir "test.exe") []
+    end
   end
 
 let with_z3_thread_or

--- a/src/3d/Main.fst
+++ b/src/3d/Main.fst
@@ -624,6 +624,7 @@ let go () : ML unit =
   then let _ = Options.display_usage () in exit 1
   else
   let out_dir = Options.get_output_dir () in
+  let _ = OS.mkdir out_dir in
   (* Special mode: --__micro_step *)
   match micro_step with
   | Some step ->

--- a/src/3d/OS.fsti
+++ b/src/3d/OS.fsti
@@ -1,5 +1,7 @@
 module OS
 
+val is_windows : unit -> FStar.All.ML bool
+
 val dirname : string -> Tot string
 
 (* The filename without its path *)

--- a/src/3d/OS.fsti
+++ b/src/3d/OS.fsti
@@ -2,6 +2,8 @@ module OS
 
 val is_windows : unit -> FStar.All.ML bool
 
+val mkdir : string -> FStar.All.ML unit
+
 val dirname : string -> Tot string
 
 (* The filename without its path *)

--- a/src/3d/OS.fsti
+++ b/src/3d/OS.fsti
@@ -29,6 +29,8 @@ val file_exists: string -> FStar.All.ML bool
 
 val file_contents: string -> FStar.All.ML string
 
+val overwrite_file: string -> FStar.All.ML unit
+
 (* Write a witness into a binary file *)
 
 val write_witness_to_file: list int -> string -> FStar.All.ML unit

--- a/src/3d/Options.fst
+++ b/src/3d/Options.fst
@@ -34,6 +34,7 @@ let inplace_hashes : ref (list vstring) = alloc []
 let input_file : ref (list string) = alloc []
 let json : ref bool = alloc false
 let no_copy_everparse_h : ref bool = alloc false
+let no_produce_testcases_c : ref bool = alloc false
 let output_dir : ref (option vstring) = alloc None
 let save_hashes : ref bool = alloc false
 let save_z3_transcript: ref (option vstring) = alloc None
@@ -361,6 +362,7 @@ let (display_usage_2, compute_options_2, fstar_options) =
     CmdOption "z3_diff_test" (OptStringOption "parser1,parser2" valid_equate_types z3_diff_test) "produce differential tests for two parsers" [];
     CmdOption "z3_executable" (OptStringOption "path/to/z3" always_valid z3_executable) "z3 executable for test case generation (default `z3`; does not affect verification of generated F* code)" [];
     CmdOption "z3_options" (OptStringOption "'options to z3'" always_valid z3_options) "command-line options to pass to z3 for test case generation (does not affect verification of generated F* code)" [];
+    CmdOption "no_z3_produce_testcases_c" (OptBool no_produce_testcases_c) "Do not write the generated test cases to <output directory>/testcases.c" [];
     CmdOption "z3_test" (OptStringOption "parser name" always_valid z3_test) "produce positive and/or negative test cases for a given parser" [];
     CmdOption "z3_test_mode" (OptStringOption "pos|neg|all" valid_z3_test_mode z3_test_mode) "produce positive, negative, or all kinds of test cases (default all)" [];
     CmdOption "z3_witnesses" (OptStringOption "nb" always_valid z3_witnesses) "ask for nb distinct test witnesses per branch case (default 1)" [];
@@ -590,6 +592,9 @@ let get_z3_options () : ML string =
   match !z3_options with
   | None -> ""
   | Some s -> s
+
+let get_produce_testcases_c () : ML bool =
+  not !no_produce_testcases_c
 
 let get_fstar_exe () : ML string =
   match !fstar_exe with

--- a/src/3d/Options.fst
+++ b/src/3d/Options.fst
@@ -362,7 +362,7 @@ let (display_usage_2, compute_options_2, fstar_options) =
     CmdOption "z3_diff_test" (OptStringOption "parser1,parser2" valid_equate_types z3_diff_test) "produce differential tests for two parsers" [];
     CmdOption "z3_executable" (OptStringOption "path/to/z3" always_valid z3_executable) "z3 executable for test case generation (default `z3`; does not affect verification of generated F* code)" [];
     CmdOption "z3_options" (OptStringOption "'options to z3'" always_valid z3_options) "command-line options to pass to z3 for test case generation (does not affect verification of generated F* code)" [];
-    CmdOption "no_z3_produce_testcases_c" (OptBool no_produce_testcases_c) "Do not write the generated test cases to <output directory>/testcases.c" [];
+    CmdOption "z3_skip_testcases_c" (OptBool no_produce_testcases_c) "skip generating test cases to <output directory>/testcases.c" [];
     CmdOption "z3_test" (OptStringOption "parser name" always_valid z3_test) "produce positive and/or negative test cases for a given parser" [];
     CmdOption "z3_test_mode" (OptStringOption "pos|neg|all" valid_z3_test_mode z3_test_mode) "produce positive, negative, or all kinds of test cases (default all)" [];
     CmdOption "z3_witnesses" (OptStringOption "nb" always_valid z3_witnesses) "ask for nb distinct test witnesses per branch case (default 1)" [];

--- a/src/3d/Options.fsti
+++ b/src/3d/Options.fsti
@@ -82,4 +82,6 @@ val get_test_checker: unit -> ML (option string)
 
 val get_z3_branch_depth: unit -> ML nat
 
+val get_produce_testcases_c: unit -> ML bool
+
 val get_fstar_exe: unit -> ML string

--- a/src/3d/Z3TestGen.fst
+++ b/src/3d/Z3TestGen.fst
@@ -1284,7 +1284,7 @@ let rec print_outparameter
   | ArgBool
   | ArgInt _ ->
     out "
-  printf(\"";
+  printf(\"// ";
     out expr;
     out " = %ld\\n\", ((uint64_t) (";
     out expr;

--- a/src/3d/Z3TestGen.fst
+++ b/src/3d/Z3TestGen.fst
@@ -1267,7 +1267,7 @@ let alloc_ptr_arg
 Printf.sprintf "
   %s _contents_%s;
   %s *%s = &_contents_%s;
-  bzero((void*)%s, sizeof(%s));
+  memset((void*)%s, 0, sizeof(%s));
 "
   ty arg_var
   ty arg_var arg_var

--- a/src/3d/Z3TestGen.fst
+++ b/src/3d/Z3TestGen.fst
@@ -1376,18 +1376,28 @@ let print_witness_as_c_aux
   (num: nat)
 : ML unit
 =
-  out "  uint8_t witness";
-  out (string_of_int num);
-  out "[";
-  out (string_of_int len);
-  out "] = {";
-  begin match Seq.seq_to_list witness with
-  | [] -> ()
-  | a :: q ->
-    out (string_of_int a);
-    List.iter (fun i -> out ", "; out (string_of_int i)) q
+  let layer_name = "witness" ^ string_of_int num in
+  out "  uint8_t ";
+  if len > 0
+  then begin
+    out layer_name;
+    out "[";
+    out (string_of_int len);
+    out "] = {";
+    begin match Seq.seq_to_list witness with
+    | [] -> ()
+    | a :: q ->
+      out (string_of_int a);
+      List.iter (fun i -> out ", "; out (string_of_int i)) q
+    end;
+    out "};"
+  end
+  else begin
+    out "*";
+    out layer_name;
+    out " = NULL;"
   end;
-  out "};"
+  ()
 
 let print_witness_as_c_gen
   (out: (string -> ML unit))

--- a/src/3d/Z3TestGen.fst
+++ b/src/3d/Z3TestGen.fst
@@ -1352,11 +1352,12 @@ let print_witness_call_as_c
       result = consumes_all_bytes_if_successful;
     }
     if (result) {
-      printf (\"ACCEPTED\\n\\n\");
+      printf (\"ACCEPTED\\n\");
 ";
   print_outparameters out p arg_types;
   out
 "
+      printf (\"\\n\");
     }
     else if (!consumes_all_bytes_if_successful)
       printf (\"REJECTED (not all bytes consumed)\\n\\n\");

--- a/src/3d/Z3TestGen.fst
+++ b/src/3d/Z3TestGen.fst
@@ -1340,7 +1340,7 @@ let print_witness_call_as_c
     uint64_t output = ";
   print_witness_call_as_c_aux out validator_name arg_types witness_length args num;
   out "
-    printf(\"  ";
+    printf(\"  // ";
   print_witness_call_as_c_aux out validator_name arg_types witness_length args num;
   out " // \");
     BOOLEAN result = !EverParseIsError(output);

--- a/src/3d/Z3TestGen.fst
+++ b/src/3d/Z3TestGen.fst
@@ -1706,9 +1706,9 @@ static void TestErrorHandler (
   (void) error_code;
   (void) input;
   if (*context) {
-    printf(\"Reached from position %ld: type name %s, field name %s\\n\", start_pos, typename_s, fieldname);
+    printf(\"// Reached from position %ld: type name %s, field name %s\\n\", start_pos, typename_s, fieldname);
   } else {
-    printf(\"Parsing failed at position %ld: type name %s, field name %s. Reason: %s\\n\", start_pos, typename_s, fieldname, reason);
+    printf(\"// Parsing failed at position %ld: type name %s, field name %s. Reason: %s\\n\", start_pos, typename_s, fieldname, reason);
     *context = 1;
   }
 }
@@ -1913,14 +1913,14 @@ int main(int argc, char** argv) {
     munmap(vbuf, len);
   close(testfile);
   if (EverParseIsError(result)) {
-    printf(\"Witness from %s REJECTED because validator failed\\n\", filename);
+    printf(\"// Witness from %s REJECTED because validator failed\\n\", filename);
     return 2;
   };
   if (result != (uint64_t) len) { // consistent with the postcondition of validate_with_action_t' (see also valid_length)
-    printf(\"Witness from %s REJECTED because validator only consumed %ld out of %ld bytes\\n\", filename, result, len);
+    printf(\"// Witness from %s REJECTED because validator only consumed %ld out of %ld bytes\\n\", filename, result, len);
     return 1;
   }
-  printf(\"Witness from %s ACCEPTED\\n\", filename);
+  printf(\"// Witness from %s ACCEPTED\\n\", filename);
   "^outparameters^"
   return 0;
 }

--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -9,6 +9,8 @@ let lowparse_home = filename_concat (filename_concat everparse_home "src") "lowp
 let ddd_home = filename_concat (filename_concat everparse_home "src") "3d"
 let ddd_prelude_home = filename_concat (filename_concat (filename_concat everparse_home "src") "3d") "prelude"
 
+let cl_wrapper () = filename_concat krml_home (filename_concat "misc" "cl-wrapper.bat")
+
 let ddd_actions_home input_stream_binding =
   let input_stream_dir =
     match string_of_input_stream_binding input_stream_binding with

--- a/src/3d/ocaml/OS.ml
+++ b/src/3d/ocaml/OS.ml
@@ -2,6 +2,11 @@ let is_windows () = Sys.win32
 
 let dirname = Filename.dirname
 
+let mkdir dir =
+  if Sys.file_exists dir && Sys.is_directory dir
+  then ()
+  else Sys.mkdir dir 0o755
+
 (* The filename without its path *)
 
 let basename = Filename.basename

--- a/src/3d/ocaml/OS.ml
+++ b/src/3d/ocaml/OS.ml
@@ -127,6 +127,9 @@ let file_contents f =
   close_in ic;
   s
 
+let overwrite_file filename =
+  BatFile.with_file_out filename (fun _ -> ())
+
 let write_witness_to_file w filename =
   BatFile.with_file_out filename (fun out ->
     List.iter

--- a/src/3d/ocaml/OS.ml
+++ b/src/3d/ocaml/OS.ml
@@ -1,3 +1,5 @@
+let is_windows () = Sys.win32
+
 let dirname = Filename.dirname
 
 (* The filename without its path *)

--- a/src/3d/ocaml/Z3.ml
+++ b/src/3d/ocaml/Z3.ml
@@ -32,6 +32,7 @@ let with_z3 (debug: bool) (transcript: string option) (f: (z3 -> 'a)) : 'a =
         is_from := true
       end;
       let s = input_line ch_from_z3 in
+      let s = String.trim s in (* eliminate remaining line ending on Windows *)
       if debug then print_endline s;
       maybe_output_string ch_transcript "; ";
       maybe_output_line ch_transcript s;

--- a/src/3d/ocaml/Z3.ml
+++ b/src/3d/ocaml/Z3.ml
@@ -68,14 +68,29 @@ let with_z3 (debug: bool) (transcript: string option) (f: (z3 -> 'a)) : 'a =
 type z3_thread = int
 
 let with_z3_thread (debug: bool) (transcript: string option) (f: (z3 -> unit)) : z3_thread =
-  let pid = Unix.fork () in
-  if pid = 0
-  then begin
-    with_z3 debug transcript f;
-    exit 0
-  end
-  else pid
-
+  let phi () = with_z3 debug transcript f in
+  if Sys.win32
+  then
+    begin
+      phi ();
+      0
+    end
+  else
+    begin
+      let pid = Unix.fork () in
+      if pid = 0
+      then begin
+          phi ();
+          exit 0
+        end
+      else pid
+    end
+      
 let wait_for_z3_thread pid =
-  print_endline "Waiting for Z3...";
-  ignore (Unix.waitpid [] pid)
+  if Sys.win32
+  then ()
+  else
+    begin
+      print_endline "Waiting for Z3...";
+      ignore (Unix.waitpid [] pid)
+    end

--- a/src/3d/tests/.gitignore
+++ b/src/3d/tests/.gitignore
@@ -3,6 +3,7 @@ out.batch
 out.batch-interpret
 out.fail.batch
 out.cleanup
+out.z3-testgen
 test-cpp.exe
 *.out
 *.err

--- a/src/3d/tests/ELF.3d
+++ b/src/3d/tests/ELF.3d
@@ -377,6 +377,7 @@ casetype _SECTION_HEADER_TABLE_OPT (OFFSET PhTableEnd,
   * UINT64 ElfFileSize: the size of the ELF file
   --*/
 
+export
 entrypoint
 typedef struct _ELF (UINT64 ElfFileSize)
 {

--- a/src/3d/tests/ELFTestGen.3d
+++ b/src/3d/tests/ELFTestGen.3d
@@ -1,0 +1,5 @@
+entrypoint
+typedef struct _ELFTestGen
+{
+  ELF::ELF(256) elf;
+} ELFTestGen;

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -10,7 +10,7 @@ FSTAR_EXE ?= fstar.exe
 
 3D=$(EVERPARSE_HOME)/bin/3d.exe --fstar $(FSTAR_EXE)
 
-3D_Z3_EXECUTABLE ?= z3
+3D_Z3_EXECUTABLE ?= z3-4.13.3
 
 ifeq (,$(KRML_HOME))
   KRML_HOME := $(realpath ../../../../karamel)

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -10,6 +10,8 @@ FSTAR_EXE ?= fstar.exe
 
 3D=$(EVERPARSE_HOME)/bin/3d.exe --fstar $(FSTAR_EXE)
 
+3D_Z3_EXECUTABLE ?= z3
+
 ifeq (,$(KRML_HOME))
   KRML_HOME := $(realpath ../../../../karamel)
 endif
@@ -33,7 +35,7 @@ clean_out_files=\
 
 OTHER_HEADERS=TestFieldPtrBase.h AlignC.h
 
-all: batch-test batch-test-negative batch-cleanup-test inplace-hash-test modules tcpip extern output-types batch-interpret-test elf-test static funptr ifdefs probe iter
+all: batch-test batch-test-negative batch-cleanup-test inplace-hash-test modules tcpip extern output-types batch-interpret-test elf-test static funptr ifdefs probe iter z3-testgen-test
 
 .PHONY: iter
 
@@ -93,6 +95,12 @@ elf-test: ELF.3d
 	mkdir -p out.batch
 	$(3D) --odir out.batch --batch ELF.3d
 	$(CXX) -o out.batch/elf-test -I out.batch $(addprefix out.batch/, ELF.c ELFWrapper.c) TestELF.cpp
+
+z3-testgen-test: ELF.3d
+	mkdir -p out.z3-testgen
+	$(3D) --z3_executable $(3D_Z3_EXECUTABLE) --batch --odir out.z3-testgen ELF.3d --z3_test ELF._ELF --z3_witnesses 2 --z3_branch_depth 2
+
+.PHONY: z3-testgen-test
 
 %-test: %.3d
 	mkdir -p out.batch

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -98,7 +98,7 @@ elf-test: ELF.3d
 
 z3-testgen-test: ELF.3d
 	mkdir -p out.z3-testgen
-	$(3D) --z3_executable $(3D_Z3_EXECUTABLE) --batch --odir out.z3-testgen ELF.3d --z3_test ELF._ELF --z3_witnesses 2 --z3_branch_depth 2
+	$(3D) --z3_executable $(3D_Z3_EXECUTABLE) --batch --odir out.z3-testgen ELFTestGen.3d --z3_test ELFTestGen._ELFTestGen --z3_witnesses 10 --z3_branch_depth 5
 
 .PHONY: z3-testgen-test
 

--- a/src/package/everparse.cmd
+++ b/src/package/everparse.cmd
@@ -3,5 +3,5 @@ setlocal
 set mypath0=%~dp0
 set EVERPARSE_HOME=%mypath0:~0,-1%
 set KRML_HOME=%EVERPARSE_HOME%
-%EVERPARSE_HOME%\bin\3d.exe --__arg0 everparse.cmd --fstar %EVERPARSE_HOME%\bin\fstar.exe --clang_format_executable %EVERPARSE_HOME%\bin\clang-format.exe %*
+%EVERPARSE_HOME%\bin\3d.exe --__arg0 everparse.cmd --fstar %EVERPARSE_HOME%\bin\fstar.exe --z3_executable %EVERPARSE_HOME%\z3-latest\bin\z3 --clang_format_executable %EVERPARSE_HOME%\bin\clang-format.exe %*
 exit /b %ERRORLEVEL%

--- a/src/package/package.sh
+++ b/src/package/package.sh
@@ -308,6 +308,11 @@ make_everparse() {
         popd
     fi
 
+    # Set executable permissions on EXE and DLL on Windows
+    if $is_windows ; then
+        chmod a+x everparse/bin/*.exe everparse/bin/*.dll everparse/z3-latest/bin/*.exe everparse/z3-latest/bin/*.dll
+    fi
+
     # licenses
     mkdir -p everparse/licenses
     $cp $FSTAR_PKG_ROOT/LICENSE everparse/licenses/FStar
@@ -336,12 +341,7 @@ EOF
         download https://www.gnu.org/licenses/gpl-3.0.txt everparse/licenses/gnugplv3
         cat everparse/licenses/gnugplv3 >> everparse/licenses/libgmp10
         rm everparse/licenses/gnugplv3
-    fi
-    
-    # Reset permissions and build the package
-    if $is_windows ; then
-        chmod a+x everparse/bin/*.exe everparse/bin/*.dll everparse/z3-latest/bin/*.exe everparse/z3-latest/bin/*.dll
-    fi
+    fi    
 }
 
 zip_everparse() {

--- a/src/package/package.sh
+++ b/src/package/package.sh
@@ -46,6 +46,12 @@ else
     exe=
 fi
 
+download () {
+    source="$1"
+    target="$2"
+    curl -L -o "$target" "$source"
+}
+
 platform=$(uname -m)
 z3=z3$exe
 if ! Z3_DIR=$(dirname $(which $z3)) ; then
@@ -53,7 +59,7 @@ if ! Z3_DIR=$(dirname $(which $z3)) ; then
         if ! [[ -d z3 ]] ; then
             z3_tagged=Z3-4.8.5
             z3_archive=z3-4.8.5-x64-win.zip
-            wget --output-document=$z3_archive https://github.com/Z3Prover/z3/releases/download/$z3_tagged/$z3_archive
+            download https://github.com/Z3Prover/z3/releases/download/$z3_tagged/$z3_archive $z3_archive
             unzip $z3_archive
             mv z3-4.8.5-x64-win z3
             chmod +x z3/bin/z3.exe
@@ -66,7 +72,7 @@ if ! Z3_DIR=$(dirname $(which $z3)) ; then
             # Download a dependency-free z3
             z3_tagged=z3-4.8.5-linux-clang
             z3_archive=$z3_tagged-$platform.tar.gz
-            wget --output-document=$z3_archive https://github.com/tahina-pro/z3/releases/download/$z3_tagged/$z3_archive
+            download https://github.com/tahina-pro/z3/releases/download/$z3_tagged/$z3_archive $z3_archive
             tar xzf $z3_archive
         fi
         Z3_DIR="$PWD/z3"
@@ -277,7 +283,7 @@ make_everparse() {
 
     # Download and copy clang-format
     if $is_windows ; then
-        wget --output-document=everparse/bin/clang-format.exe https://prereleases.llvm.org/win-snapshots/clang-format-2663a25f.exe
+        download https://prereleases.llvm.org/win-snapshots/clang-format-2663a25f.exe everparse/bin/clang-format.exe
     fi
 
     # Download and build the latest z3 for test case generation purposes
@@ -286,7 +292,7 @@ make_everparse() {
 	z3_basename=z3-$Z3_LATEST_VERSION-x64-win
 	! [[ -e $z3_basename ]]
         z3_archive=$z3_basename.zip
-	[[ -f $z3_archive ]] ||	wget --output-document=$z3_archive https://github.com/Z3Prover/z3/releases/download/$z3_tagged/$z3_archive
+	[[ -f $z3_archive ]] ||	download https://github.com/Z3Prover/z3/releases/download/$z3_tagged/$z3_archive $z3_archive
         unzip $z3_archive
         mv $z3_basename "$PWD/everparse/z3-latest"
     else
@@ -308,10 +314,10 @@ make_everparse() {
     $cp $KRML_HOME/LICENSE-APACHE everparse/licenses/KaRaMeL-Apache
     $cp $KRML_HOME/LICENSE-MIT everparse/licenses/KaRaMeL-MIT
     $cp $EVERPARSE_HOME/LICENSE everparse/licenses/EverParse
-    wget --output-document=everparse/licenses/z3 https://raw.githubusercontent.com/Z3Prover/z3/master/LICENSE.txt
-    wget --output-document=everparse/licenses/libffi6 https://raw.githubusercontent.com/libffi/libffi/master/LICENSE
+    download https://raw.githubusercontent.com/Z3Prover/z3/master/LICENSE.txt everparse/licenses/z3
+    download https://raw.githubusercontent.com/libffi/libffi/master/LICENSE everparse/licenses/libffi6
     if $is_windows ; then
-        wget --output-document=everparse/licenses/clang-format https://raw.githubusercontent.com/llvm/llvm-project/main/clang/LICENSE.TXT
+        download https://raw.githubusercontent.com/llvm/llvm-project/main/clang/LICENSE.TXT everparse/licenses/clang-format
     fi
     if $is_windows ; then
         {
@@ -324,10 +330,10 @@ in accordance with Section 4.d.1 of the GNU LGPL v3.
 
 EOF
         }
-        wget --output-document=everparse/licenses/gnulgplv3 https://www.gnu.org/licenses/lgpl-3.0.txt
+        download https://www.gnu.org/licenses/lgpl-3.0.txt everparse/licenses/gnulgplv3
         cat everparse/licenses/gnulgplv3 >> everparse/licenses/libgmp10
         rm everparse/licenses/gnulgplv3
-        wget --output-document=everparse/licenses/gnugplv3 https://www.gnu.org/licenses/gpl-3.0.txt
+        download https://www.gnu.org/licenses/gpl-3.0.txt everparse/licenses/gnugplv3
         cat everparse/licenses/gnugplv3 >> everparse/licenses/libgmp10
         rm everparse/licenses/gnugplv3
     fi
@@ -388,7 +394,7 @@ nuget_everparse() {
 
         # Download nuget.exe to create the package
         nuget_exe_url=https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
-        wget $nuget_exe_url
+        download $nuget_exe_url nuget.exe
         chmod a+x nuget.exe
 
         # Run the pack command

--- a/src/package/package.sh
+++ b/src/package/package.sh
@@ -7,6 +7,8 @@ SED=$(which gsed >/dev/null 2>&1 && echo gsed || echo sed)
 MAKE="$(which gmake >/dev/null 2>&1 && echo gmake || echo make) $EVERPARSE_MAKE_OPTS"
 DATE=$(which gdate >/dev/null 2>&1 && echo gdate || echo date)
 
+Z3_LATEST_VERSION=4.13.0
+
 # We do not read any of these from the environment. This builds a
 # package from the current master branches, or the existing checkouts in
 # FStar/ and karamel/.
@@ -279,9 +281,17 @@ make_everparse() {
     fi
 
     # Download and build the latest z3 for test case generation purposes
-    if ! $is_windows ; then
+    if $is_windows ; then
+        z3_tagged=z3-$Z3_LATEST_VERSION
+	z3_basename=z3-$Z3_LATEST_VERSION-x64-win
+	! [[ -e $z3_basename ]]
+        z3_archive=$z3_basename.zip
+	[[ -f $z3_archive ]] ||	wget --output-document=$z3_archive https://github.com/Z3Prover/z3/releases/download/$z3_tagged/$z3_archive
+        unzip $z3_archive
+        mv $z3_basename "$PWD/everparse/z3-latest"
+    else
         if ! [[ -d z3-latest ]] ; then
-            git clone --branch z3-4.13.0 https://github.com/Z3Prover/z3 z3-latest
+            git clone --branch z3-$Z3_LATEST_VERSION https://github.com/Z3Prover/z3 z3-latest
         fi
         z3_latest_dir="$PWD/everparse/z3-latest"
         mkdir -p "$z3_latest_dir"
@@ -324,7 +334,7 @@ EOF
     
     # Reset permissions and build the package
     if $is_windows ; then
-        chmod a+x everparse/bin/*.exe everparse/bin/*.dll
+        chmod a+x everparse/bin/*.exe everparse/bin/*.dll everparse/z3-latest/bin/*.exe everparse/z3-latest/bin/*.dll
     fi
 }
 

--- a/src/package/package.sh
+++ b/src/package/package.sh
@@ -294,6 +294,7 @@ make_everparse() {
         z3_archive=$z3_basename.zip
 	[[ -f $z3_archive ]] ||	download https://github.com/Z3Prover/z3/releases/download/$z3_tagged/$z3_archive $z3_archive
         unzip $z3_archive
+        rm -rf $z3_basename/bin/*.pdb
         mv $z3_basename "$PWD/everparse/z3-latest"
     else
         if ! [[ -d z3-latest ]] ; then


### PR DESCRIPTION
* When doing test case generation on Windows, 3D now runs Z3 sequentially, since native Windows does not support `Unix.fork`
* With --z3_test and --z3_diff_test, the test case executable is now compiled and run also on Windows, thanks to FStarLang/karamel#535

Other improvements not related to Windows:

* In test case generation mode (--z3_test or _z3_diff_test), 3D now produces a C test case module by default, testcases.c, even with --no_batch. To avoid producing this test case module, 3D accepts the new option `--z3_skip_testcases_c`
* The test case executable now prints the test case definitions as C global variables with everything else commented out
* Use C11 `memset` instead of BSD/non-POSIX `bzero` to initialize outparameters
* Use `NULL` instead of zero-sized stack arrays
* `--odir`: create output directory if it does not exist
