### PR TITLE
3d: use custom `.clang-format` assumed to exist in output directory

### DIFF
--- a/src/3d/Batch.fsti
+++ b/src/3d/Batch.fsti
@@ -73,6 +73,7 @@ val postprocess_fst
   (add_include: list string)
   (clang_format: bool)
   (clang_format_executable: string)
+  (copy_clang_format_opt: bool)
   (skip_c_makefiles: bool)
   (cleanup: bool)
   (no_everparse_h: bool)

--- a/src/3d/GenMakefile.fst
+++ b/src/3d/GenMakefile.fst
@@ -497,9 +497,10 @@ let produce_static_assertions_o_rule
 
 let produce_clang_format_rule
   (clang_format: bool)
+  (copy_clang_format_opt: bool)
 : Tot (list rule_t)
 =
-  if clang_format
+  if clang_format && copy_clang_format_opt
   then [{
    ty = EverParse;
    from = [];
@@ -540,6 +541,7 @@ let produce_makefile
   (emit_output_types_defs: bool)
   (skip_o_rules: bool)
   (clang_format: bool)
+  (copy_clang_format_opt: bool)
   (files: list string)
 : FStar.All.ML produce_makefile_res
 =
@@ -548,7 +550,7 @@ let produce_makefile
   let all_modules = List.map Options.get_module_name all_files in
   let rules =
     produce_everparse_h_rule everparse_h `List.Tot.append`
-    produce_clang_format_rule clang_format `List.Tot.append`
+    produce_clang_format_rule clang_format copy_clang_format_opt `List.Tot.append`
     (if skip_o_rules then [] else
       List.Tot.concatMap (produce_wrapper_o_rule mtype everparse_h g) all_modules `List.Tot.append`
       List.Tot.concatMap (produce_static_assertions_o_rule mtype everparse_h g) all_modules `List.Tot.append`
@@ -578,13 +580,14 @@ let write_makefile
   (emit_output_types_defs: bool)
   (skip_o_rules: bool)
   (clang_format: bool)
+  (copy_clang_format_opt: bool)
   (files: list string)
 : FStar.All.ML unit
 =
   let makefile_final = Options.get_makefile_name () in
   let makefile_tmp = makefile_final ^ ".tmp" in
   let file = FStar.IO.open_write_file makefile_tmp in
-  let {graph = g; rules; all_files} = produce_makefile mtype everparse_h emit_output_types_defs skip_o_rules clang_format files in
+  let {graph = g; rules; all_files} = produce_makefile mtype everparse_h emit_output_types_defs skip_o_rules clang_format copy_clang_format_opt files in
   FStar.IO.write_string file (String.concat "" (List.Tot.map (print_make_rule mtype everparse_h input_stream_binding) rules));
   let write_all_ext_files (ext_cap: string) (ext: string) : FStar.All.ML unit =
     let ln =

--- a/src/3d/GenMakefile.fsti
+++ b/src/3d/GenMakefile.fsti
@@ -7,5 +7,6 @@ val write_makefile
   (emit_output_types_defs: bool)
   (skip_o_rules: bool)
   (clang_format: bool)
+  (copy_clang_format_opt: bool)
   (files: list string)
 : FStar.All.ML unit

--- a/src/3d/Main.fst
+++ b/src/3d/Main.fst
@@ -650,6 +650,7 @@ let go () : ML unit =
       (Options.get_emit_output_types_defs ())
       (Options.get_skip_o_rules ())
       (Options.get_clang_format ())
+      (not (Options.get_clang_format_use_custom_config ()))
       cmd_line_files
   | None ->
   (* Special mode: --__produce_c_from_existing_krml *)
@@ -722,6 +723,7 @@ let go () : ML unit =
         (Options.get_add_include ())
         (Options.get_clang_format ())
         (Options.get_clang_format_executable ())
+        (not (Options.get_clang_format_use_custom_config ()))
         (Options.get_skip_c_makefiles ())
         (Options.get_cleanup ())
         (Options.get_no_everparse_h ())

--- a/src/3d/Options.fst
+++ b/src/3d/Options.fst
@@ -27,6 +27,7 @@ let add_include : ref (list vstring) = alloc []
 let batch : ref bool = alloc false
 let clang_format : ref bool = alloc false
 let clang_format_executable : ref (option vstring) = alloc None
+let clang_format_use_custom_config : ref bool = alloc false
 let cleanup : ref bool = alloc false
 let config_file : ref (option (valid_string check_config_file_name)) = alloc None
 let debug : ref bool = alloc false
@@ -337,6 +338,7 @@ let (display_usage_2, compute_options_2, fstar_options) =
     CmdOption "check_inplace_hash" (OptList "file.3d=file.h" always_valid inplace_hashes) "Check hashes stored in one .h/.c file" [];
     CmdOption "clang_format" (OptBool clang_format) "Call clang-format on extracted .c/.h files" [];
     CmdOption "clang_format_executable" (OptStringOption "clang-format full path" always_valid clang_format_executable) "Set the path to clang-format if not reachable through PATH" ["clang_format"];
+    CmdOption "clang_format_use_custom_config" (OptBool clang_format) "Skip copying .clang-format from EverParse, use existing one instead" ["clang_format"];
     CmdOption "cleanup" (OptBool cleanup) "Remove *.fst*, *.krml and krml-args.rsp (--batch only)" [];
     CmdOption "config" (OptStringOption "config file" check_config_file_name config_file) "The name of a JSON formatted file containing configuration options" [];    
     CmdOption "emit_output_types_defs" (OptBool emit_output_types_defs) "Emit definitions of output types in a .h file" [];
@@ -425,6 +427,9 @@ let get_clang_format_executable () =
   match !clang_format_executable with
   | None -> ""
   | Some s -> s
+
+let get_clang_format_use_custom_config () =
+  !clang_format_use_custom_config
 
 let get_cleanup () =
   !cleanup

--- a/src/3d/Options.fst
+++ b/src/3d/Options.fst
@@ -336,8 +336,8 @@ let (display_usage_2, compute_options_2, fstar_options) =
     CmdOption "batch" (OptBool batch) "Verify the generated F* code and extract C code" [];
     CmdOption "check_hashes" (OptStringOption "weak|strong|inplace" valid_check_hashes check_hashes) "Check hashes" ["batch"];
     CmdOption "check_inplace_hash" (OptList "file.3d=file.h" always_valid inplace_hashes) "Check hashes stored in one .h/.c file" [];
-    CmdOption "clang_format" (OptBool clang_format) "Call clang-format on extracted .c/.h files" [];
-    CmdOption "clang_format_executable" (OptStringOption "clang-format full path" always_valid clang_format_executable) "Set the path to clang-format if not reachable through PATH" ["clang_format"];
+    CmdOption "clang_format" (OptBool clang_format) "Call clang-format on extracted .c/.h files (--batch only)" ["batch"];
+    CmdOption "clang_format_executable" (OptStringOption "clang-format full path" always_valid clang_format_executable) "Set the path to clang-format if not reachable through PATH" ["batch"; "clang_format"];
     CmdOption "clang_format_use_custom_config" (OptBool clang_format) "Skip copying .clang-format from EverParse, use existing one instead" ["clang_format"];
     CmdOption "cleanup" (OptBool cleanup) "Remove *.fst*, *.krml and krml-args.rsp (--batch only)" [];
     CmdOption "config" (OptStringOption "config file" check_config_file_name config_file) "The name of a JSON formatted file containing configuration options" [];    

--- a/src/3d/Options.fst
+++ b/src/3d/Options.fst
@@ -338,7 +338,7 @@ let (display_usage_2, compute_options_2, fstar_options) =
     CmdOption "check_inplace_hash" (OptList "file.3d=file.h" always_valid inplace_hashes) "Check hashes stored in one .h/.c file" [];
     CmdOption "clang_format" (OptBool clang_format) "Call clang-format on extracted .c/.h files (--batch only)" ["batch"];
     CmdOption "clang_format_executable" (OptStringOption "clang-format full path" always_valid clang_format_executable) "Set the path to clang-format if not reachable through PATH" ["batch"; "clang_format"];
-    CmdOption "clang_format_use_custom_config" (OptBool clang_format) "Skip copying .clang-format from EverParse, use existing one instead" ["clang_format"];
+    CmdOption "clang_format_use_custom_config" (OptBool clang_format) "Skip copying .clang-format from EverParse, use existing one instead" ["batch"; "clang_format"];
     CmdOption "cleanup" (OptBool cleanup) "Remove *.fst*, *.krml and krml-args.rsp (--batch only)" [];
     CmdOption "config" (OptStringOption "config file" check_config_file_name config_file) "The name of a JSON formatted file containing configuration options" [];    
     CmdOption "emit_output_types_defs" (OptBool emit_output_types_defs) "Emit definitions of output types in a .h file" [];

--- a/src/3d/Options.fst
+++ b/src/3d/Options.fst
@@ -335,8 +335,8 @@ let (display_usage_2, compute_options_2, fstar_options) =
     CmdOption "batch" (OptBool batch) "Verify the generated F* code and extract C code" [];
     CmdOption "check_hashes" (OptStringOption "weak|strong|inplace" valid_check_hashes check_hashes) "Check hashes" ["batch"];
     CmdOption "check_inplace_hash" (OptList "file.3d=file.h" always_valid inplace_hashes) "Check hashes stored in one .h/.c file" [];
-    CmdOption "clang_format" (OptBool clang_format) "Call clang-format on extracted .c/.h files (--batch only)" ["batch"];
-    CmdOption "clang_format_executable" (OptStringOption "clang-format full path" always_valid clang_format_executable) "Set the path to clang-format if not reachable through PATH" ["batch"; "clang_format"];
+    CmdOption "clang_format" (OptBool clang_format) "Call clang-format on extracted .c/.h files" [];
+    CmdOption "clang_format_executable" (OptStringOption "clang-format full path" always_valid clang_format_executable) "Set the path to clang-format if not reachable through PATH" ["clang_format"];
     CmdOption "cleanup" (OptBool cleanup) "Remove *.fst*, *.krml and krml-args.rsp (--batch only)" [];
     CmdOption "config" (OptStringOption "config file" check_config_file_name config_file) "The name of a JSON formatted file containing configuration options" [];    
     CmdOption "emit_output_types_defs" (OptBool emit_output_types_defs) "Emit definitions of output types in a .h file" [];

--- a/src/3d/Options.fsti
+++ b/src/3d/Options.fsti
@@ -22,6 +22,8 @@ val get_clang_format : unit -> ML bool
 
 val get_clang_format_executable : unit -> ML string
 
+val get_clang_format_use_custom_config: unit -> ML bool
+
 val get_cleanup : unit -> ML bool
 
 val get_skip_c_makefiles : unit -> ML bool

--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -781,6 +781,7 @@ let produce_and_postprocess_c
       (add_include: string list)
       (clang_format: bool)
       (clang_format_executable: string)
+      (copy_clang_format_opt: bool)
       (skip_c_makefiles: bool)
       (cleanup: bool)
       (no_everparse_h: bool)
@@ -795,7 +796,7 @@ let produce_and_postprocess_c
   if Sys.file_exists (filename_concat out_dir "EverParse.h") && not everparse_h_existed_before
   then failwith "krml produced some EverParse.h, should not have happened";
   (* postprocess the produced C files *)
-  postprocess_c input_stream_binding true true clang_format clang_format_executable true skip_c_makefiles cleanup no_everparse_h save_hashes_opt out_dir files_and_modules
+  postprocess_c input_stream_binding true true clang_format clang_format_executable copy_clang_format_opt skip_c_makefiles cleanup no_everparse_h save_hashes_opt out_dir files_and_modules
 
 let produce_and_postprocess_one_c
       input_stream_binding
@@ -834,6 +835,7 @@ let postprocess_fst
       (add_include: string list)
       (clang_format: bool)
       (clang_format_executable: string)
+      (copy_clang_format_opt: bool)
       (skip_c_makefiles: bool)
       (cleanup: bool)
       (no_everparse_h: bool)
@@ -846,7 +848,7 @@ let postprocess_fst
      FIXME: modules can be processed in parallel *)
   List.iter (verify_and_extract_module fstar_exe input_stream_binding out_dir) files_and_modules;
   (* produce the .c and .h files and format them *)
-  produce_and_postprocess_c input_stream_binding emit_output_types_defs add_include clang_format clang_format_executable skip_c_makefiles cleanup no_everparse_h save_hashes_opt out_dir files_and_modules
+  produce_and_postprocess_c input_stream_binding emit_output_types_defs add_include clang_format clang_format_executable copy_clang_format_opt skip_c_makefiles cleanup no_everparse_h save_hashes_opt out_dir files_and_modules
 
 let check_all_hashes
       (ch: check_hashes_t)


### PR DESCRIPTION
So far with `--clang_format`, 3D copies the style configuration file from https://github.com/project-everest/everparse/blob/master/src/3d/.clang-format into the output directory specified by `--odir`.

This PR introduces `--clang_format_use_custom_config` to skip that copy. Instead, 3D will assume that a `.clang-format` file already exists in the output directory. In particular, the Makefile generated by `--makefile` will still add `.clang-format` to the prerequisites of `.c` and `.h` files, but will no longer generate a rule to produce/copy it.
