### PR TITLE
No PpxDerivingShow for AST

### DIFF
--- a/src/cddl/spec/CDDL.Spec.AST.Base.fst
+++ b/src/cddl/spec/CDDL.Spec.AST.Base.fst
@@ -987,7 +987,7 @@ let rec spec_map_group_footprint_incr
     spec_map_group_footprint_incr env env' g2
   | _ -> ()
 
-[@@base_attr; PpxDerivingShow]
+[@@base_attr]
 type ast0_wf_typ
 : typ -> Type
 = 

--- a/src/cddl/tool/ocaml/evercddl-lib/CDDL_Tool_Print.ml
+++ b/src/cddl/tool/ocaml/evercddl-lib/CDDL_Tool_Print.ml
@@ -1,7 +1,5 @@
-type result = unit CDDL_Spec_AST_Base.ast0_wf_typ CDDL_Spec_AST_Elab_Base.result [@@deriving show]
+type result = unit CDDL_Spec_AST_Base.ast0_wf_typ CDDL_Spec_AST_Elab_Base.result
 
 let typ_to_string = CDDL_Spec_AST_Base.show_typ
 
 let group_to_string = CDDL_Spec_AST_Base.show_group
-
-let ast0_wf_typ_result_to_string _ = show_result


### PR DESCRIPTION
F* extraction fixes will mean that the index of ast0_wf_typ becomes an Obj.t, and we cannot use deriving show on it.