### PR TITLE
Avoid spurious uses of `krml --library`

### DIFF
--- a/src/3d/ocaml/Batch.ml
+++ b/src/3d/ocaml/Batch.ml
@@ -470,7 +470,7 @@ let produce_one_c_file
   let krml_args = krml_args input_stream_binding emit_output_types_defs add_include true out_dir ((file, modul) :: dep_files_and_modules) in
   let krml_args =
     krml_args@
-      List.concat (List.map (fun (_, m) -> ["-library"; Printf.sprintf "%s,%s.Types" m m]) dep_files_and_modules) @ [
+(*      List.concat (List.map (fun (_, m) -> ["-library"; Printf.sprintf "%s,%s.Types" m m]) dep_files_and_modules) @ *) [
         "-bundle" ;
         Printf.sprintf "%s=%s" modul (String.concat "," (Printf.sprintf "%s.Types" modul :: List.map (fun (_, m) -> Printf.sprintf "%s,%s.Types" m m) dep_files_and_modules));
       ]


### PR DESCRIPTION
Since FStarLang/karamel#619, the `--library` option of Karamel should not be used with modules that define `[@@CMacro]` constants. `--library` is meant only for modules whose public definitions are abstract; C macros cannot be abstract.

