### PR TITLE
Remove HACL* from opt/

### DIFF
--- a/.github/workflows/cbor.yml
+++ b/.github/workflows/cbor.yml
@@ -1,0 +1,17 @@
+name: Test CBOR, COSE without F*
+on:
+  push:
+    branches-ignore:
+    - _**
+  pull_request:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,15 +115,6 @@ jobs:
       - run: echo "PULSE_HOME=$(pwd)/pulse"/out | sudo tee -a $GITHUB_ENV
 
       - uses: actions/checkout@master
-        id: checkout-hacl
-        with:
-          path: hacl-star
-          repository: hacl-star/hacl-star
-          ref: main
-
-      - run: echo "HACL_HOME=$(pwd)/hacl-star" | sudo tee -a $GITHUB_ENV
-
-      - uses: actions/checkout@master
         with:
           path: everparse
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,17 @@
+name: Build 3D doc, CBOR, COSE snapshots
+on:
+  push:
+    branches-ignore:
+    - _**
+  pull_request:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@master

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ export EVERPARSE_OPT_PATH=$(realpath opt)
 export FSTAR_EXE ?= $(wildcard $(EVERPARSE_OPT_PATH)/FStar/out/bin/fstar.exe)
 export KRML_HOME ?= $(EVERPARSE_OPT_PATH)/karamel
 export PULSE_HOME ?= $(EVERPARSE_OPT_PATH)/pulse/out
-export HACL_HOME ?= $(EVERPARSE_OPT_PATH)/hacl-star
 EVEREST_HOME ?= $(EVERPARSE_OPT_PATH)/everest
 export PATH := $(EVERPARSE_OPT_PATH)/z3:$(PATH)
 

--- a/opt/.gitignore
+++ b/opt/.gitignore
@@ -3,4 +3,3 @@ FStar
 everest
 karamel
 pulse
-hacl-star

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -1,4 +1,4 @@
-all: FStar.do karamel.do pulse.do hacl-star
+all: FStar.do karamel.do pulse.do
 
 export ADMIT=1
 
@@ -7,7 +7,6 @@ export EVERPARSE_OPT_PATH=$(realpath .)
 export FSTAR_EXE  := $(EVERPARSE_OPT_PATH)/FStar/out/bin/fstar.exe
 export KRML_HOME  := $(EVERPARSE_OPT_PATH)/karamel
 export PULSE_HOME := $(EVERPARSE_OPT_PATH)/pulse/out
-export HACL_HOME := $(EVERPARSE_OPT_PATH)/hacl-star
 export PATH := $(EVERPARSE_OPT_PATH)/z3:$(PATH)
 
 include env.Makefile
@@ -27,9 +26,6 @@ pulse:
 
 everest:
 	git clone "https://github.com/project-everest/everest" $@
-
-hacl-star:
-	git clone "https://github.com/hacl-star/hacl-star" $@
 
 FStar.do: FStar
 	+$(MAKE) -C $< ADMIT=1

--- a/opt/env.Makefile
+++ b/opt/env.Makefile
@@ -3,7 +3,6 @@ env:
 	@echo export FSTAR_EXE=$(FSTAR_EXE)
 	@echo export KRML_HOME=$(KRML_HOME)
 	@echo export PULSE_HOME=$(PULSE_HOME)
-	@echo export HACL_HOME=$(HACL_HOME)
 	@if test -d $(EVERPARSE_OPT_PATH)/../_opam ; then opam env ; fi
 	@echo export PATH=$(EVERPARSE_OPT_PATH)/FStar/bin:$(EVERPARSE_OPT_PATH)/z3:\"'$$PATH'\"
 

--- a/src/cbor/pulse/det/rust/src/cbordetveraux.rs
+++ b/src/cbor/pulse/det/rust/src/cbordetveraux.rs
@@ -1918,37 +1918,37 @@ pub(crate) fn cbor_raw_map_insert(out: &mut [u8], off2: usize, off3: usize) -> b
                 {
                     let mut pn: [usize; 1] = [out2kv.len(); 1usize];
                     let mut pl: [usize; 1] = [off2.wrapping_sub(off); 1usize];
-                    let l: usize = (&pl)[0];
-                    let mut cond0: bool = l > 0usize;
+                    let __anf3172: usize = (&pl)[0];
+                    let mut cond0: bool = __anf3172 > 0usize;
                     while
                     cond0
                     {
                         let n: usize = (&pn)[0];
-                        let l0: usize = (&pl)[0];
-                        let l·: usize = n.wrapping_rem(l0);
-                        (&mut pn)[0] = l0;
+                        let l: usize = (&pl)[0];
+                        let l·: usize = n.wrapping_rem(l);
+                        (&mut pn)[0] = l;
                         (&mut pl)[0] = l·;
-                        let l1: usize = (&pl)[0];
-                        cond0 = l1 > 0usize
+                        let __anf31720: usize = (&pl)[0];
+                        cond0 = __anf31720 > 0usize
                     };
                     let d: usize = (&pn)[0];
                     let q: usize = out2kv.len().wrapping_div(d);
                     let mut pi: [usize; 1] = [0usize; 1usize];
-                    let i: usize = (&pi)[0];
-                    let mut cond1: bool = i < d;
+                    let __anf4223: usize = (&pi)[0];
+                    let mut cond1: bool = __anf4223 < d;
                     while
                     cond1
                     {
-                        let i0: usize = (&pi)[0];
-                        let save: u8 = out2kv[i0];
+                        let i: usize = (&pi)[0];
+                        let save: u8 = out2kv[i];
                         let mut pj: [usize; 1] = [0usize; 1usize];
-                        let mut pidx: [usize; 1] = [i0; 1usize];
-                        let j: usize = (&pj)[0];
-                        let mut cond2: bool = j < q.wrapping_sub(1usize);
+                        let mut pidx: [usize; 1] = [i; 1usize];
+                        let __anf6456: usize = (&pj)[0];
+                        let mut cond2: bool = __anf6456 < q.wrapping_sub(1usize);
                         while
                         cond2
                         {
-                            let j0: usize = (&pj)[0];
+                            let j: usize = (&pj)[0];
                             let idx: usize = (&pidx)[0];
                             let idx·: usize =
                                 if
@@ -1963,19 +1963,19 @@ pub(crate) fn cbor_raw_map_insert(out: &mut [u8], off2: usize, off3: usize) -> b
                                 else
                                 { idx.wrapping_add(off2.wrapping_sub(off).wrapping_sub(0usize)) };
                             let x: u8 = out2kv[idx·];
-                            let j·: usize = j0.wrapping_add(1usize);
+                            let j·: usize = j.wrapping_add(1usize);
                             out2kv[idx] = x;
                             (&mut pj)[0] = j·;
                             (&mut pidx)[0] = idx·;
-                            let j1: usize = (&pj)[0];
-                            cond2 = j1 < q.wrapping_sub(1usize)
+                            let __anf64560: usize = (&pj)[0];
+                            cond2 = __anf64560 < q.wrapping_sub(1usize)
                         };
                         let idx: usize = (&pidx)[0];
                         out2kv[idx] = save;
-                        let i·: usize = i0.wrapping_add(1usize);
+                        let i·: usize = i.wrapping_add(1usize);
                         (&mut pi)[0] = i·;
-                        let i1: usize = (&pi)[0];
-                        cond1 = i1 < d
+                        let __anf42230: usize = (&pi)[0];
+                        cond1 = __anf42230 < d
                     }
                 };
                 (&mut pres)[0] = cbor_raw_map_insert_result::CSuccess
@@ -3331,37 +3331,37 @@ fn cbor_serialize_array·(len: raw_uint64, out: &mut [u8], off: usize) -> usize
         {
             let mut pn: [usize; 1] = [sp1.len(); 1usize];
             let mut pl: [usize; 1] = [off; 1usize];
-            let l1: usize = (&pl)[0];
-            let mut cond: bool = l1 > 0usize;
+            let __anf3172: usize = (&pl)[0];
+            let mut cond: bool = __anf3172 > 0usize;
             while
             cond
             {
                 let n: usize = (&pn)[0];
-                let l10: usize = (&pl)[0];
-                let l·: usize = n.wrapping_rem(l10);
-                (&mut pn)[0] = l10;
+                let l1: usize = (&pl)[0];
+                let l·: usize = n.wrapping_rem(l1);
+                (&mut pn)[0] = l1;
                 (&mut pl)[0] = l·;
-                let l11: usize = (&pl)[0];
-                cond = l11 > 0usize
+                let __anf31720: usize = (&pl)[0];
+                cond = __anf31720 > 0usize
             };
             let d: usize = (&pn)[0];
             let q: usize = sp1.len().wrapping_div(d);
             let mut pi: [usize; 1] = [0usize; 1usize];
-            let i: usize = (&pi)[0];
-            let mut cond0: bool = i < d;
+            let __anf4223: usize = (&pi)[0];
+            let mut cond0: bool = __anf4223 < d;
             while
             cond0
             {
-                let i0: usize = (&pi)[0];
-                let save: u8 = sp1[i0];
+                let i: usize = (&pi)[0];
+                let save: u8 = sp1[i];
                 let mut pj: [usize; 1] = [0usize; 1usize];
-                let mut pidx: [usize; 1] = [i0; 1usize];
-                let j: usize = (&pj)[0];
-                let mut cond1: bool = j < q.wrapping_sub(1usize);
+                let mut pidx: [usize; 1] = [i; 1usize];
+                let __anf6456: usize = (&pj)[0];
+                let mut cond1: bool = __anf6456 < q.wrapping_sub(1usize);
                 while
                 cond1
                 {
-                    let j0: usize = (&pj)[0];
+                    let j: usize = (&pj)[0];
                     let idx: usize = (&pidx)[0];
                     let idx·: usize =
                         if idx.wrapping_sub(0usize) >= sp1.len().wrapping_sub(off)
@@ -3369,19 +3369,19 @@ fn cbor_serialize_array·(len: raw_uint64, out: &mut [u8], off: usize) -> usize
                         else
                         { idx.wrapping_add(off.wrapping_sub(0usize)) };
                     let x: u8 = sp1[idx·];
-                    let j·: usize = j0.wrapping_add(1usize);
+                    let j·: usize = j.wrapping_add(1usize);
                     sp1[idx] = x;
                     (&mut pj)[0] = j·;
                     (&mut pidx)[0] = idx·;
-                    let j1: usize = (&pj)[0];
-                    cond1 = j1 < q.wrapping_sub(1usize)
+                    let __anf64560: usize = (&pj)[0];
+                    cond1 = __anf64560 < q.wrapping_sub(1usize)
                 };
                 let idx: usize = (&pidx)[0];
                 sp1[idx] = save;
-                let i·: usize = i0.wrapping_add(1usize);
+                let i·: usize = i.wrapping_add(1usize);
                 (&mut pi)[0] = i·;
-                let i1: usize = (&pi)[0];
-                cond0 = i1 < d
+                let __anf42230: usize = (&pi)[0];
+                cond0 = __anf42230 < d
             }
         };
         llen
@@ -3410,37 +3410,37 @@ pub(crate) fn cbor_serialize_string(ty: u8, off: raw_uint64, out: &mut [u8]) -> 
         {
             let mut pn: [usize; 1] = [sp1.len(); 1usize];
             let mut pl: [usize; 1] = [soff; 1usize];
-            let l: usize = (&pl)[0];
-            let mut cond: bool = l > 0usize;
+            let __anf3172: usize = (&pl)[0];
+            let mut cond: bool = __anf3172 > 0usize;
             while
             cond
             {
                 let n: usize = (&pn)[0];
-                let l0: usize = (&pl)[0];
-                let l·: usize = n.wrapping_rem(l0);
-                (&mut pn)[0] = l0;
+                let l: usize = (&pl)[0];
+                let l·: usize = n.wrapping_rem(l);
+                (&mut pn)[0] = l;
                 (&mut pl)[0] = l·;
-                let l1: usize = (&pl)[0];
-                cond = l1 > 0usize
+                let __anf31720: usize = (&pl)[0];
+                cond = __anf31720 > 0usize
             };
             let d: usize = (&pn)[0];
             let q: usize = sp1.len().wrapping_div(d);
             let mut pi: [usize; 1] = [0usize; 1usize];
-            let i: usize = (&pi)[0];
-            let mut cond0: bool = i < d;
+            let __anf4223: usize = (&pi)[0];
+            let mut cond0: bool = __anf4223 < d;
             while
             cond0
             {
-                let i0: usize = (&pi)[0];
-                let save: u8 = sp1[i0];
+                let i: usize = (&pi)[0];
+                let save: u8 = sp1[i];
                 let mut pj: [usize; 1] = [0usize; 1usize];
-                let mut pidx: [usize; 1] = [i0; 1usize];
-                let j: usize = (&pj)[0];
-                let mut cond1: bool = j < q.wrapping_sub(1usize);
+                let mut pidx: [usize; 1] = [i; 1usize];
+                let __anf6456: usize = (&pj)[0];
+                let mut cond1: bool = __anf6456 < q.wrapping_sub(1usize);
                 while
                 cond1
                 {
-                    let j0: usize = (&pj)[0];
+                    let j: usize = (&pj)[0];
                     let idx: usize = (&pidx)[0];
                     let idx·: usize =
                         if idx.wrapping_sub(0usize) >= sp1.len().wrapping_sub(soff)
@@ -3448,19 +3448,19 @@ pub(crate) fn cbor_serialize_string(ty: u8, off: raw_uint64, out: &mut [u8]) -> 
                         else
                         { idx.wrapping_add(soff.wrapping_sub(0usize)) };
                     let x: u8 = sp1[idx·];
-                    let j·: usize = j0.wrapping_add(1usize);
+                    let j·: usize = j.wrapping_add(1usize);
                     sp1[idx] = x;
                     (&mut pj)[0] = j·;
                     (&mut pidx)[0] = idx·;
-                    let j1: usize = (&pj)[0];
-                    cond1 = j1 < q.wrapping_sub(1usize)
+                    let __anf64560: usize = (&pj)[0];
+                    cond1 = __anf64560 < q.wrapping_sub(1usize)
                 };
                 let idx: usize = (&pidx)[0];
                 sp1[idx] = save;
-                let i·: usize = i0.wrapping_add(1usize);
+                let i·: usize = i.wrapping_add(1usize);
                 (&mut pi)[0] = i·;
-                let i1: usize = (&pi)[0];
-                cond0 = i1 < d
+                let __anf42230: usize = (&pi)[0];
+                cond0 = __anf42230 < d
             }
         };
         llen
@@ -3485,37 +3485,37 @@ fn cbor_serialize_map·(len: raw_uint64, out: &mut [u8], off: usize) -> usize
         {
             let mut pn: [usize; 1] = [sp1.len(); 1usize];
             let mut pl: [usize; 1] = [off; 1usize];
-            let l1: usize = (&pl)[0];
-            let mut cond: bool = l1 > 0usize;
+            let __anf3172: usize = (&pl)[0];
+            let mut cond: bool = __anf3172 > 0usize;
             while
             cond
             {
                 let n: usize = (&pn)[0];
-                let l10: usize = (&pl)[0];
-                let l·: usize = n.wrapping_rem(l10);
-                (&mut pn)[0] = l10;
+                let l1: usize = (&pl)[0];
+                let l·: usize = n.wrapping_rem(l1);
+                (&mut pn)[0] = l1;
                 (&mut pl)[0] = l·;
-                let l11: usize = (&pl)[0];
-                cond = l11 > 0usize
+                let __anf31720: usize = (&pl)[0];
+                cond = __anf31720 > 0usize
             };
             let d: usize = (&pn)[0];
             let q: usize = sp1.len().wrapping_div(d);
             let mut pi: [usize; 1] = [0usize; 1usize];
-            let i: usize = (&pi)[0];
-            let mut cond0: bool = i < d;
+            let __anf4223: usize = (&pi)[0];
+            let mut cond0: bool = __anf4223 < d;
             while
             cond0
             {
-                let i0: usize = (&pi)[0];
-                let save: u8 = sp1[i0];
+                let i: usize = (&pi)[0];
+                let save: u8 = sp1[i];
                 let mut pj: [usize; 1] = [0usize; 1usize];
-                let mut pidx: [usize; 1] = [i0; 1usize];
-                let j: usize = (&pj)[0];
-                let mut cond1: bool = j < q.wrapping_sub(1usize);
+                let mut pidx: [usize; 1] = [i; 1usize];
+                let __anf6456: usize = (&pj)[0];
+                let mut cond1: bool = __anf6456 < q.wrapping_sub(1usize);
                 while
                 cond1
                 {
-                    let j0: usize = (&pj)[0];
+                    let j: usize = (&pj)[0];
                     let idx: usize = (&pidx)[0];
                     let idx·: usize =
                         if idx.wrapping_sub(0usize) >= sp1.len().wrapping_sub(off)
@@ -3523,19 +3523,19 @@ fn cbor_serialize_map·(len: raw_uint64, out: &mut [u8], off: usize) -> usize
                         else
                         { idx.wrapping_add(off.wrapping_sub(0usize)) };
                     let x: u8 = sp1[idx·];
-                    let j·: usize = j0.wrapping_add(1usize);
+                    let j·: usize = j.wrapping_add(1usize);
                     sp1[idx] = x;
                     (&mut pj)[0] = j·;
                     (&mut pidx)[0] = idx·;
-                    let j1: usize = (&pj)[0];
-                    cond1 = j1 < q.wrapping_sub(1usize)
+                    let __anf64560: usize = (&pj)[0];
+                    cond1 = __anf64560 < q.wrapping_sub(1usize)
                 };
                 let idx: usize = (&pidx)[0];
                 sp1[idx] = save;
-                let i·: usize = i0.wrapping_add(1usize);
+                let i·: usize = i.wrapping_add(1usize);
                 (&mut pi)[0] = i·;
-                let i1: usize = (&pi)[0];
-                cond0 = i1 < d
+                let __anf42230: usize = (&pi)[0];
+                cond0 = __anf42230 < d
             }
         };
         llen
@@ -4266,37 +4266,37 @@ pub(crate) fn cbor_raw_sort_aux(a: &mut [cbor_map_entry]) -> bool
                         {
                             let mut pn: [usize; 1] = [ac1.len(); 1usize];
                             let mut pl: [usize; 1] = [i20.wrapping_sub(i10); 1usize];
-                            let l3: usize = (&pl)[0];
-                            let mut cond0: bool = l3 > 0usize;
+                            let __anf3172: usize = (&pl)[0];
+                            let mut cond0: bool = __anf3172 > 0usize;
                             while
                             cond0
                             {
                                 let n: usize = (&pn)[0];
-                                let l30: usize = (&pl)[0];
-                                let l·: usize = n.wrapping_rem(l30);
-                                (&mut pn)[0] = l30;
+                                let l3: usize = (&pl)[0];
+                                let l·: usize = n.wrapping_rem(l3);
+                                (&mut pn)[0] = l3;
                                 (&mut pl)[0] = l·;
-                                let l31: usize = (&pl)[0];
-                                cond0 = l31 > 0usize
+                                let __anf31720: usize = (&pl)[0];
+                                cond0 = __anf31720 > 0usize
                             };
                             let d: usize = (&pn)[0];
                             let q: usize = ac1.len().wrapping_div(d);
                             let mut pi: [usize; 1] = [0usize; 1usize];
-                            let i: usize = (&pi)[0];
-                            let mut cond1: bool = i < d;
+                            let __anf4223: usize = (&pi)[0];
+                            let mut cond1: bool = __anf4223 < d;
                             while
                             cond1
                             {
-                                let i0: usize = (&pi)[0];
-                                let save: cbor_map_entry = ac1[i0];
+                                let i: usize = (&pi)[0];
+                                let save: cbor_map_entry = ac1[i];
                                 let mut pj: [usize; 1] = [0usize; 1usize];
-                                let mut pidx: [usize; 1] = [i0; 1usize];
-                                let j: usize = (&pj)[0];
-                                let mut cond2: bool = j < q.wrapping_sub(1usize);
+                                let mut pidx: [usize; 1] = [i; 1usize];
+                                let __anf6456: usize = (&pj)[0];
+                                let mut cond2: bool = __anf6456 < q.wrapping_sub(1usize);
                                 while
                                 cond2
                                 {
-                                    let j0: usize = (&pj)[0];
+                                    let j: usize = (&pj)[0];
                                     let idx: usize = (&pidx)[0];
                                     let idx·: usize =
                                         if
@@ -4315,19 +4315,19 @@ pub(crate) fn cbor_raw_sort_aux(a: &mut [cbor_map_entry]) -> bool
                                             )
                                         };
                                     let x: cbor_map_entry = ac1[idx·];
-                                    let j·: usize = j0.wrapping_add(1usize);
+                                    let j·: usize = j.wrapping_add(1usize);
                                     ac1[idx] = x;
                                     (&mut pj)[0] = j·;
                                     (&mut pidx)[0] = idx·;
-                                    let j1: usize = (&pj)[0];
-                                    cond2 = j1 < q.wrapping_sub(1usize)
+                                    let __anf64560: usize = (&pj)[0];
+                                    cond2 = __anf64560 < q.wrapping_sub(1usize)
                                 };
                                 let idx: usize = (&pidx)[0];
                                 ac1[idx] = save;
-                                let i·: usize = i0.wrapping_add(1usize);
+                                let i·: usize = i.wrapping_add(1usize);
                                 (&mut pi)[0] = i·;
-                                let i3: usize = (&pi)[0];
-                                cond1 = i3 < d
+                                let __anf42230: usize = (&pi)[0];
+                                cond1 = __anf42230 < d
                             }
                         };
                         let i1·: usize = i10.wrapping_add(1usize);

--- a/src/cbor/pulse/det/rust/target/doc/src/cborrs/cbordetveraux.rs.html
+++ b/src/cbor/pulse/det/rust/target/doc/src/cborrs/cbordetveraux.rs.html
@@ -6304,37 +6304,37 @@
                 {
                     <span class="kw">let </span><span class="kw-2">mut </span>pn: [usize; <span class="number">1</span>] = [out2kv.len(); <span class="number">1usize</span>];
                     <span class="kw">let </span><span class="kw-2">mut </span>pl: [usize; <span class="number">1</span>] = [off2.wrapping_sub(off); <span class="number">1usize</span>];
-                    <span class="kw">let </span>l: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                    <span class="kw">let </span><span class="kw-2">mut </span>cond0: bool = l &gt; <span class="number">0usize</span>;
+                    <span class="kw">let </span>__anf3172: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                    <span class="kw">let </span><span class="kw-2">mut </span>cond0: bool = __anf3172 &gt; <span class="number">0usize</span>;
                     <span class="kw">while
                     </span>cond0
                     {
                         <span class="kw">let </span>n: usize = (<span class="kw-2">&amp;</span>pn)[<span class="number">0</span>];
-                        <span class="kw">let </span>l0: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                        <span class="kw">let </span>l·: usize = n.wrapping_rem(l0);
-                        (<span class="kw-2">&amp;mut </span>pn)[<span class="number">0</span>] = l0;
+                        <span class="kw">let </span>l: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                        <span class="kw">let </span>l·: usize = n.wrapping_rem(l);
+                        (<span class="kw-2">&amp;mut </span>pn)[<span class="number">0</span>] = l;
                         (<span class="kw-2">&amp;mut </span>pl)[<span class="number">0</span>] = l·;
-                        <span class="kw">let </span>l1: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                        cond0 = l1 &gt; <span class="number">0usize
+                        <span class="kw">let </span>__anf31720: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                        cond0 = __anf31720 &gt; <span class="number">0usize
                     </span>};
                     <span class="kw">let </span>d: usize = (<span class="kw-2">&amp;</span>pn)[<span class="number">0</span>];
                     <span class="kw">let </span>q: usize = out2kv.len().wrapping_div(d);
                     <span class="kw">let </span><span class="kw-2">mut </span>pi: [usize; <span class="number">1</span>] = [<span class="number">0usize</span>; <span class="number">1usize</span>];
-                    <span class="kw">let </span>i: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                    <span class="kw">let </span><span class="kw-2">mut </span>cond1: bool = i &lt; d;
+                    <span class="kw">let </span>__anf4223: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                    <span class="kw">let </span><span class="kw-2">mut </span>cond1: bool = __anf4223 &lt; d;
                     <span class="kw">while
                     </span>cond1
                     {
-                        <span class="kw">let </span>i0: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                        <span class="kw">let </span>save: u8 = out2kv[i0];
+                        <span class="kw">let </span>i: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                        <span class="kw">let </span>save: u8 = out2kv[i];
                         <span class="kw">let </span><span class="kw-2">mut </span>pj: [usize; <span class="number">1</span>] = [<span class="number">0usize</span>; <span class="number">1usize</span>];
-                        <span class="kw">let </span><span class="kw-2">mut </span>pidx: [usize; <span class="number">1</span>] = [i0; <span class="number">1usize</span>];
-                        <span class="kw">let </span>j: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
-                        <span class="kw">let </span><span class="kw-2">mut </span>cond2: bool = j &lt; q.wrapping_sub(<span class="number">1usize</span>);
+                        <span class="kw">let </span><span class="kw-2">mut </span>pidx: [usize; <span class="number">1</span>] = [i; <span class="number">1usize</span>];
+                        <span class="kw">let </span>__anf6456: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                        <span class="kw">let </span><span class="kw-2">mut </span>cond2: bool = __anf6456 &lt; q.wrapping_sub(<span class="number">1usize</span>);
                         <span class="kw">while
                         </span>cond2
                         {
-                            <span class="kw">let </span>j0: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                            <span class="kw">let </span>j: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
                             <span class="kw">let </span>idx: usize = (<span class="kw-2">&amp;</span>pidx)[<span class="number">0</span>];
                             <span class="kw">let </span>idx·: usize =
                                 <span class="kw">if
@@ -6349,19 +6349,19 @@
                                 <span class="kw">else
                                 </span>{ idx.wrapping_add(off2.wrapping_sub(off).wrapping_sub(<span class="number">0usize</span>)) };
                             <span class="kw">let </span>x: u8 = out2kv[idx·];
-                            <span class="kw">let </span>j·: usize = j0.wrapping_add(<span class="number">1usize</span>);
+                            <span class="kw">let </span>j·: usize = j.wrapping_add(<span class="number">1usize</span>);
                             out2kv[idx] = x;
                             (<span class="kw-2">&amp;mut </span>pj)[<span class="number">0</span>] = j·;
                             (<span class="kw-2">&amp;mut </span>pidx)[<span class="number">0</span>] = idx·;
-                            <span class="kw">let </span>j1: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
-                            cond2 = j1 &lt; q.wrapping_sub(<span class="number">1usize</span>)
+                            <span class="kw">let </span>__anf64560: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                            cond2 = __anf64560 &lt; q.wrapping_sub(<span class="number">1usize</span>)
                         };
                         <span class="kw">let </span>idx: usize = (<span class="kw-2">&amp;</span>pidx)[<span class="number">0</span>];
                         out2kv[idx] = save;
-                        <span class="kw">let </span>i·: usize = i0.wrapping_add(<span class="number">1usize</span>);
+                        <span class="kw">let </span>i·: usize = i.wrapping_add(<span class="number">1usize</span>);
                         (<span class="kw-2">&amp;mut </span>pi)[<span class="number">0</span>] = i·;
-                        <span class="kw">let </span>i1: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                        cond1 = i1 &lt; d
+                        <span class="kw">let </span>__anf42230: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                        cond1 = __anf42230 &lt; d
                     }
                 };
                 (<span class="kw-2">&amp;mut </span>pres)[<span class="number">0</span>] = cbor_raw_map_insert_result::CSuccess
@@ -7717,37 +7717,37 @@
         {
             <span class="kw">let </span><span class="kw-2">mut </span>pn: [usize; <span class="number">1</span>] = [sp1.len(); <span class="number">1usize</span>];
             <span class="kw">let </span><span class="kw-2">mut </span>pl: [usize; <span class="number">1</span>] = [off; <span class="number">1usize</span>];
-            <span class="kw">let </span>l1: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-            <span class="kw">let </span><span class="kw-2">mut </span>cond: bool = l1 &gt; <span class="number">0usize</span>;
+            <span class="kw">let </span>__anf3172: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+            <span class="kw">let </span><span class="kw-2">mut </span>cond: bool = __anf3172 &gt; <span class="number">0usize</span>;
             <span class="kw">while
             </span>cond
             {
                 <span class="kw">let </span>n: usize = (<span class="kw-2">&amp;</span>pn)[<span class="number">0</span>];
-                <span class="kw">let </span>l10: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                <span class="kw">let </span>l·: usize = n.wrapping_rem(l10);
-                (<span class="kw-2">&amp;mut </span>pn)[<span class="number">0</span>] = l10;
+                <span class="kw">let </span>l1: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                <span class="kw">let </span>l·: usize = n.wrapping_rem(l1);
+                (<span class="kw-2">&amp;mut </span>pn)[<span class="number">0</span>] = l1;
                 (<span class="kw-2">&amp;mut </span>pl)[<span class="number">0</span>] = l·;
-                <span class="kw">let </span>l11: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                cond = l11 &gt; <span class="number">0usize
+                <span class="kw">let </span>__anf31720: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                cond = __anf31720 &gt; <span class="number">0usize
             </span>};
             <span class="kw">let </span>d: usize = (<span class="kw-2">&amp;</span>pn)[<span class="number">0</span>];
             <span class="kw">let </span>q: usize = sp1.len().wrapping_div(d);
             <span class="kw">let </span><span class="kw-2">mut </span>pi: [usize; <span class="number">1</span>] = [<span class="number">0usize</span>; <span class="number">1usize</span>];
-            <span class="kw">let </span>i: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-            <span class="kw">let </span><span class="kw-2">mut </span>cond0: bool = i &lt; d;
+            <span class="kw">let </span>__anf4223: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+            <span class="kw">let </span><span class="kw-2">mut </span>cond0: bool = __anf4223 &lt; d;
             <span class="kw">while
             </span>cond0
             {
-                <span class="kw">let </span>i0: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                <span class="kw">let </span>save: u8 = sp1[i0];
+                <span class="kw">let </span>i: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                <span class="kw">let </span>save: u8 = sp1[i];
                 <span class="kw">let </span><span class="kw-2">mut </span>pj: [usize; <span class="number">1</span>] = [<span class="number">0usize</span>; <span class="number">1usize</span>];
-                <span class="kw">let </span><span class="kw-2">mut </span>pidx: [usize; <span class="number">1</span>] = [i0; <span class="number">1usize</span>];
-                <span class="kw">let </span>j: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
-                <span class="kw">let </span><span class="kw-2">mut </span>cond1: bool = j &lt; q.wrapping_sub(<span class="number">1usize</span>);
+                <span class="kw">let </span><span class="kw-2">mut </span>pidx: [usize; <span class="number">1</span>] = [i; <span class="number">1usize</span>];
+                <span class="kw">let </span>__anf6456: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                <span class="kw">let </span><span class="kw-2">mut </span>cond1: bool = __anf6456 &lt; q.wrapping_sub(<span class="number">1usize</span>);
                 <span class="kw">while
                 </span>cond1
                 {
-                    <span class="kw">let </span>j0: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                    <span class="kw">let </span>j: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
                     <span class="kw">let </span>idx: usize = (<span class="kw-2">&amp;</span>pidx)[<span class="number">0</span>];
                     <span class="kw">let </span>idx·: usize =
                         <span class="kw">if </span>idx.wrapping_sub(<span class="number">0usize</span>) &gt;= sp1.len().wrapping_sub(off)
@@ -7755,19 +7755,19 @@
                         <span class="kw">else
                         </span>{ idx.wrapping_add(off.wrapping_sub(<span class="number">0usize</span>)) };
                     <span class="kw">let </span>x: u8 = sp1[idx·];
-                    <span class="kw">let </span>j·: usize = j0.wrapping_add(<span class="number">1usize</span>);
+                    <span class="kw">let </span>j·: usize = j.wrapping_add(<span class="number">1usize</span>);
                     sp1[idx] = x;
                     (<span class="kw-2">&amp;mut </span>pj)[<span class="number">0</span>] = j·;
                     (<span class="kw-2">&amp;mut </span>pidx)[<span class="number">0</span>] = idx·;
-                    <span class="kw">let </span>j1: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
-                    cond1 = j1 &lt; q.wrapping_sub(<span class="number">1usize</span>)
+                    <span class="kw">let </span>__anf64560: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                    cond1 = __anf64560 &lt; q.wrapping_sub(<span class="number">1usize</span>)
                 };
                 <span class="kw">let </span>idx: usize = (<span class="kw-2">&amp;</span>pidx)[<span class="number">0</span>];
                 sp1[idx] = save;
-                <span class="kw">let </span>i·: usize = i0.wrapping_add(<span class="number">1usize</span>);
+                <span class="kw">let </span>i·: usize = i.wrapping_add(<span class="number">1usize</span>);
                 (<span class="kw-2">&amp;mut </span>pi)[<span class="number">0</span>] = i·;
-                <span class="kw">let </span>i1: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                cond0 = i1 &lt; d
+                <span class="kw">let </span>__anf42230: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                cond0 = __anf42230 &lt; d
             }
         };
         llen
@@ -7796,37 +7796,37 @@
         {
             <span class="kw">let </span><span class="kw-2">mut </span>pn: [usize; <span class="number">1</span>] = [sp1.len(); <span class="number">1usize</span>];
             <span class="kw">let </span><span class="kw-2">mut </span>pl: [usize; <span class="number">1</span>] = [soff; <span class="number">1usize</span>];
-            <span class="kw">let </span>l: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-            <span class="kw">let </span><span class="kw-2">mut </span>cond: bool = l &gt; <span class="number">0usize</span>;
+            <span class="kw">let </span>__anf3172: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+            <span class="kw">let </span><span class="kw-2">mut </span>cond: bool = __anf3172 &gt; <span class="number">0usize</span>;
             <span class="kw">while
             </span>cond
             {
                 <span class="kw">let </span>n: usize = (<span class="kw-2">&amp;</span>pn)[<span class="number">0</span>];
-                <span class="kw">let </span>l0: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                <span class="kw">let </span>l·: usize = n.wrapping_rem(l0);
-                (<span class="kw-2">&amp;mut </span>pn)[<span class="number">0</span>] = l0;
+                <span class="kw">let </span>l: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                <span class="kw">let </span>l·: usize = n.wrapping_rem(l);
+                (<span class="kw-2">&amp;mut </span>pn)[<span class="number">0</span>] = l;
                 (<span class="kw-2">&amp;mut </span>pl)[<span class="number">0</span>] = l·;
-                <span class="kw">let </span>l1: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                cond = l1 &gt; <span class="number">0usize
+                <span class="kw">let </span>__anf31720: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                cond = __anf31720 &gt; <span class="number">0usize
             </span>};
             <span class="kw">let </span>d: usize = (<span class="kw-2">&amp;</span>pn)[<span class="number">0</span>];
             <span class="kw">let </span>q: usize = sp1.len().wrapping_div(d);
             <span class="kw">let </span><span class="kw-2">mut </span>pi: [usize; <span class="number">1</span>] = [<span class="number">0usize</span>; <span class="number">1usize</span>];
-            <span class="kw">let </span>i: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-            <span class="kw">let </span><span class="kw-2">mut </span>cond0: bool = i &lt; d;
+            <span class="kw">let </span>__anf4223: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+            <span class="kw">let </span><span class="kw-2">mut </span>cond0: bool = __anf4223 &lt; d;
             <span class="kw">while
             </span>cond0
             {
-                <span class="kw">let </span>i0: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                <span class="kw">let </span>save: u8 = sp1[i0];
+                <span class="kw">let </span>i: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                <span class="kw">let </span>save: u8 = sp1[i];
                 <span class="kw">let </span><span class="kw-2">mut </span>pj: [usize; <span class="number">1</span>] = [<span class="number">0usize</span>; <span class="number">1usize</span>];
-                <span class="kw">let </span><span class="kw-2">mut </span>pidx: [usize; <span class="number">1</span>] = [i0; <span class="number">1usize</span>];
-                <span class="kw">let </span>j: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
-                <span class="kw">let </span><span class="kw-2">mut </span>cond1: bool = j &lt; q.wrapping_sub(<span class="number">1usize</span>);
+                <span class="kw">let </span><span class="kw-2">mut </span>pidx: [usize; <span class="number">1</span>] = [i; <span class="number">1usize</span>];
+                <span class="kw">let </span>__anf6456: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                <span class="kw">let </span><span class="kw-2">mut </span>cond1: bool = __anf6456 &lt; q.wrapping_sub(<span class="number">1usize</span>);
                 <span class="kw">while
                 </span>cond1
                 {
-                    <span class="kw">let </span>j0: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                    <span class="kw">let </span>j: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
                     <span class="kw">let </span>idx: usize = (<span class="kw-2">&amp;</span>pidx)[<span class="number">0</span>];
                     <span class="kw">let </span>idx·: usize =
                         <span class="kw">if </span>idx.wrapping_sub(<span class="number">0usize</span>) &gt;= sp1.len().wrapping_sub(soff)
@@ -7834,19 +7834,19 @@
                         <span class="kw">else
                         </span>{ idx.wrapping_add(soff.wrapping_sub(<span class="number">0usize</span>)) };
                     <span class="kw">let </span>x: u8 = sp1[idx·];
-                    <span class="kw">let </span>j·: usize = j0.wrapping_add(<span class="number">1usize</span>);
+                    <span class="kw">let </span>j·: usize = j.wrapping_add(<span class="number">1usize</span>);
                     sp1[idx] = x;
                     (<span class="kw-2">&amp;mut </span>pj)[<span class="number">0</span>] = j·;
                     (<span class="kw-2">&amp;mut </span>pidx)[<span class="number">0</span>] = idx·;
-                    <span class="kw">let </span>j1: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
-                    cond1 = j1 &lt; q.wrapping_sub(<span class="number">1usize</span>)
+                    <span class="kw">let </span>__anf64560: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                    cond1 = __anf64560 &lt; q.wrapping_sub(<span class="number">1usize</span>)
                 };
                 <span class="kw">let </span>idx: usize = (<span class="kw-2">&amp;</span>pidx)[<span class="number">0</span>];
                 sp1[idx] = save;
-                <span class="kw">let </span>i·: usize = i0.wrapping_add(<span class="number">1usize</span>);
+                <span class="kw">let </span>i·: usize = i.wrapping_add(<span class="number">1usize</span>);
                 (<span class="kw-2">&amp;mut </span>pi)[<span class="number">0</span>] = i·;
-                <span class="kw">let </span>i1: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                cond0 = i1 &lt; d
+                <span class="kw">let </span>__anf42230: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                cond0 = __anf42230 &lt; d
             }
         };
         llen
@@ -7871,37 +7871,37 @@
         {
             <span class="kw">let </span><span class="kw-2">mut </span>pn: [usize; <span class="number">1</span>] = [sp1.len(); <span class="number">1usize</span>];
             <span class="kw">let </span><span class="kw-2">mut </span>pl: [usize; <span class="number">1</span>] = [off; <span class="number">1usize</span>];
-            <span class="kw">let </span>l1: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-            <span class="kw">let </span><span class="kw-2">mut </span>cond: bool = l1 &gt; <span class="number">0usize</span>;
+            <span class="kw">let </span>__anf3172: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+            <span class="kw">let </span><span class="kw-2">mut </span>cond: bool = __anf3172 &gt; <span class="number">0usize</span>;
             <span class="kw">while
             </span>cond
             {
                 <span class="kw">let </span>n: usize = (<span class="kw-2">&amp;</span>pn)[<span class="number">0</span>];
-                <span class="kw">let </span>l10: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                <span class="kw">let </span>l·: usize = n.wrapping_rem(l10);
-                (<span class="kw-2">&amp;mut </span>pn)[<span class="number">0</span>] = l10;
+                <span class="kw">let </span>l1: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                <span class="kw">let </span>l·: usize = n.wrapping_rem(l1);
+                (<span class="kw-2">&amp;mut </span>pn)[<span class="number">0</span>] = l1;
                 (<span class="kw-2">&amp;mut </span>pl)[<span class="number">0</span>] = l·;
-                <span class="kw">let </span>l11: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                cond = l11 &gt; <span class="number">0usize
+                <span class="kw">let </span>__anf31720: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                cond = __anf31720 &gt; <span class="number">0usize
             </span>};
             <span class="kw">let </span>d: usize = (<span class="kw-2">&amp;</span>pn)[<span class="number">0</span>];
             <span class="kw">let </span>q: usize = sp1.len().wrapping_div(d);
             <span class="kw">let </span><span class="kw-2">mut </span>pi: [usize; <span class="number">1</span>] = [<span class="number">0usize</span>; <span class="number">1usize</span>];
-            <span class="kw">let </span>i: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-            <span class="kw">let </span><span class="kw-2">mut </span>cond0: bool = i &lt; d;
+            <span class="kw">let </span>__anf4223: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+            <span class="kw">let </span><span class="kw-2">mut </span>cond0: bool = __anf4223 &lt; d;
             <span class="kw">while
             </span>cond0
             {
-                <span class="kw">let </span>i0: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                <span class="kw">let </span>save: u8 = sp1[i0];
+                <span class="kw">let </span>i: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                <span class="kw">let </span>save: u8 = sp1[i];
                 <span class="kw">let </span><span class="kw-2">mut </span>pj: [usize; <span class="number">1</span>] = [<span class="number">0usize</span>; <span class="number">1usize</span>];
-                <span class="kw">let </span><span class="kw-2">mut </span>pidx: [usize; <span class="number">1</span>] = [i0; <span class="number">1usize</span>];
-                <span class="kw">let </span>j: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
-                <span class="kw">let </span><span class="kw-2">mut </span>cond1: bool = j &lt; q.wrapping_sub(<span class="number">1usize</span>);
+                <span class="kw">let </span><span class="kw-2">mut </span>pidx: [usize; <span class="number">1</span>] = [i; <span class="number">1usize</span>];
+                <span class="kw">let </span>__anf6456: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                <span class="kw">let </span><span class="kw-2">mut </span>cond1: bool = __anf6456 &lt; q.wrapping_sub(<span class="number">1usize</span>);
                 <span class="kw">while
                 </span>cond1
                 {
-                    <span class="kw">let </span>j0: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                    <span class="kw">let </span>j: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
                     <span class="kw">let </span>idx: usize = (<span class="kw-2">&amp;</span>pidx)[<span class="number">0</span>];
                     <span class="kw">let </span>idx·: usize =
                         <span class="kw">if </span>idx.wrapping_sub(<span class="number">0usize</span>) &gt;= sp1.len().wrapping_sub(off)
@@ -7909,19 +7909,19 @@
                         <span class="kw">else
                         </span>{ idx.wrapping_add(off.wrapping_sub(<span class="number">0usize</span>)) };
                     <span class="kw">let </span>x: u8 = sp1[idx·];
-                    <span class="kw">let </span>j·: usize = j0.wrapping_add(<span class="number">1usize</span>);
+                    <span class="kw">let </span>j·: usize = j.wrapping_add(<span class="number">1usize</span>);
                     sp1[idx] = x;
                     (<span class="kw-2">&amp;mut </span>pj)[<span class="number">0</span>] = j·;
                     (<span class="kw-2">&amp;mut </span>pidx)[<span class="number">0</span>] = idx·;
-                    <span class="kw">let </span>j1: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
-                    cond1 = j1 &lt; q.wrapping_sub(<span class="number">1usize</span>)
+                    <span class="kw">let </span>__anf64560: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                    cond1 = __anf64560 &lt; q.wrapping_sub(<span class="number">1usize</span>)
                 };
                 <span class="kw">let </span>idx: usize = (<span class="kw-2">&amp;</span>pidx)[<span class="number">0</span>];
                 sp1[idx] = save;
-                <span class="kw">let </span>i·: usize = i0.wrapping_add(<span class="number">1usize</span>);
+                <span class="kw">let </span>i·: usize = i.wrapping_add(<span class="number">1usize</span>);
                 (<span class="kw-2">&amp;mut </span>pi)[<span class="number">0</span>] = i·;
-                <span class="kw">let </span>i1: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                cond0 = i1 &lt; d
+                <span class="kw">let </span>__anf42230: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                cond0 = __anf42230 &lt; d
             }
         };
         llen
@@ -8652,37 +8652,37 @@
                         {
                             <span class="kw">let </span><span class="kw-2">mut </span>pn: [usize; <span class="number">1</span>] = [ac1.len(); <span class="number">1usize</span>];
                             <span class="kw">let </span><span class="kw-2">mut </span>pl: [usize; <span class="number">1</span>] = [i20.wrapping_sub(i10); <span class="number">1usize</span>];
-                            <span class="kw">let </span>l3: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                            <span class="kw">let </span><span class="kw-2">mut </span>cond0: bool = l3 &gt; <span class="number">0usize</span>;
+                            <span class="kw">let </span>__anf3172: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                            <span class="kw">let </span><span class="kw-2">mut </span>cond0: bool = __anf3172 &gt; <span class="number">0usize</span>;
                             <span class="kw">while
                             </span>cond0
                             {
                                 <span class="kw">let </span>n: usize = (<span class="kw-2">&amp;</span>pn)[<span class="number">0</span>];
-                                <span class="kw">let </span>l30: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                                <span class="kw">let </span>l·: usize = n.wrapping_rem(l30);
-                                (<span class="kw-2">&amp;mut </span>pn)[<span class="number">0</span>] = l30;
+                                <span class="kw">let </span>l3: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                                <span class="kw">let </span>l·: usize = n.wrapping_rem(l3);
+                                (<span class="kw-2">&amp;mut </span>pn)[<span class="number">0</span>] = l3;
                                 (<span class="kw-2">&amp;mut </span>pl)[<span class="number">0</span>] = l·;
-                                <span class="kw">let </span>l31: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
-                                cond0 = l31 &gt; <span class="number">0usize
+                                <span class="kw">let </span>__anf31720: usize = (<span class="kw-2">&amp;</span>pl)[<span class="number">0</span>];
+                                cond0 = __anf31720 &gt; <span class="number">0usize
                             </span>};
                             <span class="kw">let </span>d: usize = (<span class="kw-2">&amp;</span>pn)[<span class="number">0</span>];
                             <span class="kw">let </span>q: usize = ac1.len().wrapping_div(d);
                             <span class="kw">let </span><span class="kw-2">mut </span>pi: [usize; <span class="number">1</span>] = [<span class="number">0usize</span>; <span class="number">1usize</span>];
-                            <span class="kw">let </span>i: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                            <span class="kw">let </span><span class="kw-2">mut </span>cond1: bool = i &lt; d;
+                            <span class="kw">let </span>__anf4223: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                            <span class="kw">let </span><span class="kw-2">mut </span>cond1: bool = __anf4223 &lt; d;
                             <span class="kw">while
                             </span>cond1
                             {
-                                <span class="kw">let </span>i0: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                                <span class="kw">let </span>save: cbor_map_entry = ac1[i0];
+                                <span class="kw">let </span>i: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                                <span class="kw">let </span>save: cbor_map_entry = ac1[i];
                                 <span class="kw">let </span><span class="kw-2">mut </span>pj: [usize; <span class="number">1</span>] = [<span class="number">0usize</span>; <span class="number">1usize</span>];
-                                <span class="kw">let </span><span class="kw-2">mut </span>pidx: [usize; <span class="number">1</span>] = [i0; <span class="number">1usize</span>];
-                                <span class="kw">let </span>j: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
-                                <span class="kw">let </span><span class="kw-2">mut </span>cond2: bool = j &lt; q.wrapping_sub(<span class="number">1usize</span>);
+                                <span class="kw">let </span><span class="kw-2">mut </span>pidx: [usize; <span class="number">1</span>] = [i; <span class="number">1usize</span>];
+                                <span class="kw">let </span>__anf6456: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                                <span class="kw">let </span><span class="kw-2">mut </span>cond2: bool = __anf6456 &lt; q.wrapping_sub(<span class="number">1usize</span>);
                                 <span class="kw">while
                                 </span>cond2
                                 {
-                                    <span class="kw">let </span>j0: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                                    <span class="kw">let </span>j: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
                                     <span class="kw">let </span>idx: usize = (<span class="kw-2">&amp;</span>pidx)[<span class="number">0</span>];
                                     <span class="kw">let </span>idx·: usize =
                                         <span class="kw">if
@@ -8701,19 +8701,19 @@
                                             )
                                         };
                                     <span class="kw">let </span>x: cbor_map_entry = ac1[idx·];
-                                    <span class="kw">let </span>j·: usize = j0.wrapping_add(<span class="number">1usize</span>);
+                                    <span class="kw">let </span>j·: usize = j.wrapping_add(<span class="number">1usize</span>);
                                     ac1[idx] = x;
                                     (<span class="kw-2">&amp;mut </span>pj)[<span class="number">0</span>] = j·;
                                     (<span class="kw-2">&amp;mut </span>pidx)[<span class="number">0</span>] = idx·;
-                                    <span class="kw">let </span>j1: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
-                                    cond2 = j1 &lt; q.wrapping_sub(<span class="number">1usize</span>)
+                                    <span class="kw">let </span>__anf64560: usize = (<span class="kw-2">&amp;</span>pj)[<span class="number">0</span>];
+                                    cond2 = __anf64560 &lt; q.wrapping_sub(<span class="number">1usize</span>)
                                 };
                                 <span class="kw">let </span>idx: usize = (<span class="kw-2">&amp;</span>pidx)[<span class="number">0</span>];
                                 ac1[idx] = save;
-                                <span class="kw">let </span>i·: usize = i0.wrapping_add(<span class="number">1usize</span>);
+                                <span class="kw">let </span>i·: usize = i.wrapping_add(<span class="number">1usize</span>);
                                 (<span class="kw-2">&amp;mut </span>pi)[<span class="number">0</span>] = i·;
-                                <span class="kw">let </span>i3: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
-                                cond1 = i3 &lt; d
+                                <span class="kw">let </span>__anf42230: usize = (<span class="kw-2">&amp;</span>pi)[<span class="number">0</span>];
+                                cond1 = __anf42230 &lt; d
                             }
                         };
                         <span class="kw">let </span>i1·: usize = i10.wrapping_add(<span class="number">1usize</span>);

--- a/src/cose/Makefile
+++ b/src/cose/Makefile
@@ -37,12 +37,8 @@ test-interop: build-c .venv
 	+$(MAKE) -C interop
 
 .PHONY: test-verified-interop
-ifeq (,$(HACL_HOME))
-test-verified-interop:
-else
 test-verified-interop: build-c .venv
 	+$(MAKE) -C verifiedinterop/test
-endif
 
 test-rust: build-rust
 	cd rust && cargo test

--- a/src/cose/rust/src/cbordetveraux.rs
+++ b/src/cose/rust/src/cbordetveraux.rs
@@ -1918,37 +1918,37 @@ pub(crate) fn cbor_raw_map_insert(out: &mut [u8], off2: usize, off3: usize) -> b
                 {
                     let mut pn: [usize; 1] = [out2kv.len(); 1usize];
                     let mut pl: [usize; 1] = [off2.wrapping_sub(off); 1usize];
-                    let l: usize = (&pl)[0];
-                    let mut cond0: bool = l > 0usize;
+                    let __anf3172: usize = (&pl)[0];
+                    let mut cond0: bool = __anf3172 > 0usize;
                     while
                     cond0
                     {
                         let n: usize = (&pn)[0];
-                        let l0: usize = (&pl)[0];
-                        let l·: usize = n.wrapping_rem(l0);
-                        (&mut pn)[0] = l0;
+                        let l: usize = (&pl)[0];
+                        let l·: usize = n.wrapping_rem(l);
+                        (&mut pn)[0] = l;
                         (&mut pl)[0] = l·;
-                        let l1: usize = (&pl)[0];
-                        cond0 = l1 > 0usize
+                        let __anf31720: usize = (&pl)[0];
+                        cond0 = __anf31720 > 0usize
                     };
                     let d: usize = (&pn)[0];
                     let q: usize = out2kv.len().wrapping_div(d);
                     let mut pi: [usize; 1] = [0usize; 1usize];
-                    let i: usize = (&pi)[0];
-                    let mut cond1: bool = i < d;
+                    let __anf4223: usize = (&pi)[0];
+                    let mut cond1: bool = __anf4223 < d;
                     while
                     cond1
                     {
-                        let i0: usize = (&pi)[0];
-                        let save: u8 = out2kv[i0];
+                        let i: usize = (&pi)[0];
+                        let save: u8 = out2kv[i];
                         let mut pj: [usize; 1] = [0usize; 1usize];
-                        let mut pidx: [usize; 1] = [i0; 1usize];
-                        let j: usize = (&pj)[0];
-                        let mut cond2: bool = j < q.wrapping_sub(1usize);
+                        let mut pidx: [usize; 1] = [i; 1usize];
+                        let __anf6456: usize = (&pj)[0];
+                        let mut cond2: bool = __anf6456 < q.wrapping_sub(1usize);
                         while
                         cond2
                         {
-                            let j0: usize = (&pj)[0];
+                            let j: usize = (&pj)[0];
                             let idx: usize = (&pidx)[0];
                             let idx·: usize =
                                 if
@@ -1963,19 +1963,19 @@ pub(crate) fn cbor_raw_map_insert(out: &mut [u8], off2: usize, off3: usize) -> b
                                 else
                                 { idx.wrapping_add(off2.wrapping_sub(off).wrapping_sub(0usize)) };
                             let x: u8 = out2kv[idx·];
-                            let j·: usize = j0.wrapping_add(1usize);
+                            let j·: usize = j.wrapping_add(1usize);
                             out2kv[idx] = x;
                             (&mut pj)[0] = j·;
                             (&mut pidx)[0] = idx·;
-                            let j1: usize = (&pj)[0];
-                            cond2 = j1 < q.wrapping_sub(1usize)
+                            let __anf64560: usize = (&pj)[0];
+                            cond2 = __anf64560 < q.wrapping_sub(1usize)
                         };
                         let idx: usize = (&pidx)[0];
                         out2kv[idx] = save;
-                        let i·: usize = i0.wrapping_add(1usize);
+                        let i·: usize = i.wrapping_add(1usize);
                         (&mut pi)[0] = i·;
-                        let i1: usize = (&pi)[0];
-                        cond1 = i1 < d
+                        let __anf42230: usize = (&pi)[0];
+                        cond1 = __anf42230 < d
                     }
                 };
                 (&mut pres)[0] = cbor_raw_map_insert_result::CSuccess
@@ -3331,37 +3331,37 @@ fn cbor_serialize_array·(len: raw_uint64, out: &mut [u8], off: usize) -> usize
         {
             let mut pn: [usize; 1] = [sp1.len(); 1usize];
             let mut pl: [usize; 1] = [off; 1usize];
-            let l1: usize = (&pl)[0];
-            let mut cond: bool = l1 > 0usize;
+            let __anf3172: usize = (&pl)[0];
+            let mut cond: bool = __anf3172 > 0usize;
             while
             cond
             {
                 let n: usize = (&pn)[0];
-                let l10: usize = (&pl)[0];
-                let l·: usize = n.wrapping_rem(l10);
-                (&mut pn)[0] = l10;
+                let l1: usize = (&pl)[0];
+                let l·: usize = n.wrapping_rem(l1);
+                (&mut pn)[0] = l1;
                 (&mut pl)[0] = l·;
-                let l11: usize = (&pl)[0];
-                cond = l11 > 0usize
+                let __anf31720: usize = (&pl)[0];
+                cond = __anf31720 > 0usize
             };
             let d: usize = (&pn)[0];
             let q: usize = sp1.len().wrapping_div(d);
             let mut pi: [usize; 1] = [0usize; 1usize];
-            let i: usize = (&pi)[0];
-            let mut cond0: bool = i < d;
+            let __anf4223: usize = (&pi)[0];
+            let mut cond0: bool = __anf4223 < d;
             while
             cond0
             {
-                let i0: usize = (&pi)[0];
-                let save: u8 = sp1[i0];
+                let i: usize = (&pi)[0];
+                let save: u8 = sp1[i];
                 let mut pj: [usize; 1] = [0usize; 1usize];
-                let mut pidx: [usize; 1] = [i0; 1usize];
-                let j: usize = (&pj)[0];
-                let mut cond1: bool = j < q.wrapping_sub(1usize);
+                let mut pidx: [usize; 1] = [i; 1usize];
+                let __anf6456: usize = (&pj)[0];
+                let mut cond1: bool = __anf6456 < q.wrapping_sub(1usize);
                 while
                 cond1
                 {
-                    let j0: usize = (&pj)[0];
+                    let j: usize = (&pj)[0];
                     let idx: usize = (&pidx)[0];
                     let idx·: usize =
                         if idx.wrapping_sub(0usize) >= sp1.len().wrapping_sub(off)
@@ -3369,19 +3369,19 @@ fn cbor_serialize_array·(len: raw_uint64, out: &mut [u8], off: usize) -> usize
                         else
                         { idx.wrapping_add(off.wrapping_sub(0usize)) };
                     let x: u8 = sp1[idx·];
-                    let j·: usize = j0.wrapping_add(1usize);
+                    let j·: usize = j.wrapping_add(1usize);
                     sp1[idx] = x;
                     (&mut pj)[0] = j·;
                     (&mut pidx)[0] = idx·;
-                    let j1: usize = (&pj)[0];
-                    cond1 = j1 < q.wrapping_sub(1usize)
+                    let __anf64560: usize = (&pj)[0];
+                    cond1 = __anf64560 < q.wrapping_sub(1usize)
                 };
                 let idx: usize = (&pidx)[0];
                 sp1[idx] = save;
-                let i·: usize = i0.wrapping_add(1usize);
+                let i·: usize = i.wrapping_add(1usize);
                 (&mut pi)[0] = i·;
-                let i1: usize = (&pi)[0];
-                cond0 = i1 < d
+                let __anf42230: usize = (&pi)[0];
+                cond0 = __anf42230 < d
             }
         };
         llen
@@ -3410,37 +3410,37 @@ pub(crate) fn cbor_serialize_string(ty: u8, off: raw_uint64, out: &mut [u8]) -> 
         {
             let mut pn: [usize; 1] = [sp1.len(); 1usize];
             let mut pl: [usize; 1] = [soff; 1usize];
-            let l: usize = (&pl)[0];
-            let mut cond: bool = l > 0usize;
+            let __anf3172: usize = (&pl)[0];
+            let mut cond: bool = __anf3172 > 0usize;
             while
             cond
             {
                 let n: usize = (&pn)[0];
-                let l0: usize = (&pl)[0];
-                let l·: usize = n.wrapping_rem(l0);
-                (&mut pn)[0] = l0;
+                let l: usize = (&pl)[0];
+                let l·: usize = n.wrapping_rem(l);
+                (&mut pn)[0] = l;
                 (&mut pl)[0] = l·;
-                let l1: usize = (&pl)[0];
-                cond = l1 > 0usize
+                let __anf31720: usize = (&pl)[0];
+                cond = __anf31720 > 0usize
             };
             let d: usize = (&pn)[0];
             let q: usize = sp1.len().wrapping_div(d);
             let mut pi: [usize; 1] = [0usize; 1usize];
-            let i: usize = (&pi)[0];
-            let mut cond0: bool = i < d;
+            let __anf4223: usize = (&pi)[0];
+            let mut cond0: bool = __anf4223 < d;
             while
             cond0
             {
-                let i0: usize = (&pi)[0];
-                let save: u8 = sp1[i0];
+                let i: usize = (&pi)[0];
+                let save: u8 = sp1[i];
                 let mut pj: [usize; 1] = [0usize; 1usize];
-                let mut pidx: [usize; 1] = [i0; 1usize];
-                let j: usize = (&pj)[0];
-                let mut cond1: bool = j < q.wrapping_sub(1usize);
+                let mut pidx: [usize; 1] = [i; 1usize];
+                let __anf6456: usize = (&pj)[0];
+                let mut cond1: bool = __anf6456 < q.wrapping_sub(1usize);
                 while
                 cond1
                 {
-                    let j0: usize = (&pj)[0];
+                    let j: usize = (&pj)[0];
                     let idx: usize = (&pidx)[0];
                     let idx·: usize =
                         if idx.wrapping_sub(0usize) >= sp1.len().wrapping_sub(soff)
@@ -3448,19 +3448,19 @@ pub(crate) fn cbor_serialize_string(ty: u8, off: raw_uint64, out: &mut [u8]) -> 
                         else
                         { idx.wrapping_add(soff.wrapping_sub(0usize)) };
                     let x: u8 = sp1[idx·];
-                    let j·: usize = j0.wrapping_add(1usize);
+                    let j·: usize = j.wrapping_add(1usize);
                     sp1[idx] = x;
                     (&mut pj)[0] = j·;
                     (&mut pidx)[0] = idx·;
-                    let j1: usize = (&pj)[0];
-                    cond1 = j1 < q.wrapping_sub(1usize)
+                    let __anf64560: usize = (&pj)[0];
+                    cond1 = __anf64560 < q.wrapping_sub(1usize)
                 };
                 let idx: usize = (&pidx)[0];
                 sp1[idx] = save;
-                let i·: usize = i0.wrapping_add(1usize);
+                let i·: usize = i.wrapping_add(1usize);
                 (&mut pi)[0] = i·;
-                let i1: usize = (&pi)[0];
-                cond0 = i1 < d
+                let __anf42230: usize = (&pi)[0];
+                cond0 = __anf42230 < d
             }
         };
         llen
@@ -3485,37 +3485,37 @@ fn cbor_serialize_map·(len: raw_uint64, out: &mut [u8], off: usize) -> usize
         {
             let mut pn: [usize; 1] = [sp1.len(); 1usize];
             let mut pl: [usize; 1] = [off; 1usize];
-            let l1: usize = (&pl)[0];
-            let mut cond: bool = l1 > 0usize;
+            let __anf3172: usize = (&pl)[0];
+            let mut cond: bool = __anf3172 > 0usize;
             while
             cond
             {
                 let n: usize = (&pn)[0];
-                let l10: usize = (&pl)[0];
-                let l·: usize = n.wrapping_rem(l10);
-                (&mut pn)[0] = l10;
+                let l1: usize = (&pl)[0];
+                let l·: usize = n.wrapping_rem(l1);
+                (&mut pn)[0] = l1;
                 (&mut pl)[0] = l·;
-                let l11: usize = (&pl)[0];
-                cond = l11 > 0usize
+                let __anf31720: usize = (&pl)[0];
+                cond = __anf31720 > 0usize
             };
             let d: usize = (&pn)[0];
             let q: usize = sp1.len().wrapping_div(d);
             let mut pi: [usize; 1] = [0usize; 1usize];
-            let i: usize = (&pi)[0];
-            let mut cond0: bool = i < d;
+            let __anf4223: usize = (&pi)[0];
+            let mut cond0: bool = __anf4223 < d;
             while
             cond0
             {
-                let i0: usize = (&pi)[0];
-                let save: u8 = sp1[i0];
+                let i: usize = (&pi)[0];
+                let save: u8 = sp1[i];
                 let mut pj: [usize; 1] = [0usize; 1usize];
-                let mut pidx: [usize; 1] = [i0; 1usize];
-                let j: usize = (&pj)[0];
-                let mut cond1: bool = j < q.wrapping_sub(1usize);
+                let mut pidx: [usize; 1] = [i; 1usize];
+                let __anf6456: usize = (&pj)[0];
+                let mut cond1: bool = __anf6456 < q.wrapping_sub(1usize);
                 while
                 cond1
                 {
-                    let j0: usize = (&pj)[0];
+                    let j: usize = (&pj)[0];
                     let idx: usize = (&pidx)[0];
                     let idx·: usize =
                         if idx.wrapping_sub(0usize) >= sp1.len().wrapping_sub(off)
@@ -3523,19 +3523,19 @@ fn cbor_serialize_map·(len: raw_uint64, out: &mut [u8], off: usize) -> usize
                         else
                         { idx.wrapping_add(off.wrapping_sub(0usize)) };
                     let x: u8 = sp1[idx·];
-                    let j·: usize = j0.wrapping_add(1usize);
+                    let j·: usize = j.wrapping_add(1usize);
                     sp1[idx] = x;
                     (&mut pj)[0] = j·;
                     (&mut pidx)[0] = idx·;
-                    let j1: usize = (&pj)[0];
-                    cond1 = j1 < q.wrapping_sub(1usize)
+                    let __anf64560: usize = (&pj)[0];
+                    cond1 = __anf64560 < q.wrapping_sub(1usize)
                 };
                 let idx: usize = (&pidx)[0];
                 sp1[idx] = save;
-                let i·: usize = i0.wrapping_add(1usize);
+                let i·: usize = i.wrapping_add(1usize);
                 (&mut pi)[0] = i·;
-                let i1: usize = (&pi)[0];
-                cond0 = i1 < d
+                let __anf42230: usize = (&pi)[0];
+                cond0 = __anf42230 < d
             }
         };
         llen
@@ -4266,37 +4266,37 @@ pub(crate) fn cbor_raw_sort_aux(a: &mut [cbor_map_entry]) -> bool
                         {
                             let mut pn: [usize; 1] = [ac1.len(); 1usize];
                             let mut pl: [usize; 1] = [i20.wrapping_sub(i10); 1usize];
-                            let l3: usize = (&pl)[0];
-                            let mut cond0: bool = l3 > 0usize;
+                            let __anf3172: usize = (&pl)[0];
+                            let mut cond0: bool = __anf3172 > 0usize;
                             while
                             cond0
                             {
                                 let n: usize = (&pn)[0];
-                                let l30: usize = (&pl)[0];
-                                let l·: usize = n.wrapping_rem(l30);
-                                (&mut pn)[0] = l30;
+                                let l3: usize = (&pl)[0];
+                                let l·: usize = n.wrapping_rem(l3);
+                                (&mut pn)[0] = l3;
                                 (&mut pl)[0] = l·;
-                                let l31: usize = (&pl)[0];
-                                cond0 = l31 > 0usize
+                                let __anf31720: usize = (&pl)[0];
+                                cond0 = __anf31720 > 0usize
                             };
                             let d: usize = (&pn)[0];
                             let q: usize = ac1.len().wrapping_div(d);
                             let mut pi: [usize; 1] = [0usize; 1usize];
-                            let i: usize = (&pi)[0];
-                            let mut cond1: bool = i < d;
+                            let __anf4223: usize = (&pi)[0];
+                            let mut cond1: bool = __anf4223 < d;
                             while
                             cond1
                             {
-                                let i0: usize = (&pi)[0];
-                                let save: cbor_map_entry = ac1[i0];
+                                let i: usize = (&pi)[0];
+                                let save: cbor_map_entry = ac1[i];
                                 let mut pj: [usize; 1] = [0usize; 1usize];
-                                let mut pidx: [usize; 1] = [i0; 1usize];
-                                let j: usize = (&pj)[0];
-                                let mut cond2: bool = j < q.wrapping_sub(1usize);
+                                let mut pidx: [usize; 1] = [i; 1usize];
+                                let __anf6456: usize = (&pj)[0];
+                                let mut cond2: bool = __anf6456 < q.wrapping_sub(1usize);
                                 while
                                 cond2
                                 {
-                                    let j0: usize = (&pj)[0];
+                                    let j: usize = (&pj)[0];
                                     let idx: usize = (&pidx)[0];
                                     let idx·: usize =
                                         if
@@ -4315,19 +4315,19 @@ pub(crate) fn cbor_raw_sort_aux(a: &mut [cbor_map_entry]) -> bool
                                             )
                                         };
                                     let x: cbor_map_entry = ac1[idx·];
-                                    let j·: usize = j0.wrapping_add(1usize);
+                                    let j·: usize = j.wrapping_add(1usize);
                                     ac1[idx] = x;
                                     (&mut pj)[0] = j·;
                                     (&mut pidx)[0] = idx·;
-                                    let j1: usize = (&pj)[0];
-                                    cond2 = j1 < q.wrapping_sub(1usize)
+                                    let __anf64560: usize = (&pj)[0];
+                                    cond2 = __anf64560 < q.wrapping_sub(1usize)
                                 };
                                 let idx: usize = (&pidx)[0];
                                 ac1[idx] = save;
-                                let i·: usize = i0.wrapping_add(1usize);
+                                let i·: usize = i.wrapping_add(1usize);
                                 (&mut pi)[0] = i·;
-                                let i3: usize = (&pi)[0];
-                                cond1 = i3 < d
+                                let __anf42230: usize = (&pi)[0];
+                                cond1 = __anf42230 < d
                             }
                         };
                         let i1·: usize = i10.wrapping_add(1usize);

--- a/src/cose/verifiedinterop/.gitignore
+++ b/src/cose/verifiedinterop/.gitignore
@@ -1,0 +1,1 @@
+hacl-star

--- a/src/cose/verifiedinterop/test/Makefile
+++ b/src/cose/verifiedinterop/test/Makefile
@@ -5,7 +5,7 @@ all: signtest verifytest test
 EVERPARSE_SRC_PATH = $(realpath ../../..)
 EVERPARSE_PATH = $(realpath $(EVERPARSE_SRC_PATH)/..)
 ifeq (,$(HACL_HOME))
-  HACL_HOME := $(EVERPARSE_PATH)/opt/hacl-star
+  HACL_HOME := $(CURDIR)/hacl-star
 endif
 export HACL_HOME
 
@@ -13,8 +13,13 @@ SANFLAGS = -fsanitize=address -fsanitize=undefined
 
 CFLAGS += -I $(EVERPARSE_SRC_PATH)/cbor/pulse/det/c -I ../../c
 
-$(HACL_HOME)/dist/gcc-compatible/libevercrypt.a:
+$(HACL_HOME)/dist/gcc-compatible/libevercrypt.a: $(HACL_HOME)
 	$(MAKE) -C $(dir $@)
+
+$(CURDIR)/hacl-star:
+	rm -rf $@.tmp
+	git clone https://github.com/hacl-star/hacl-star $@.tmp
+	mv $@.tmp $@
 
 COSE_EVERCRYPT_O=../../c/COSE_EverCrypt.o
 COSE_FORMAT_O=../../c/COSE_Format.o


### PR DESCRIPTION
This PR removes HACL* from ` opt/`, since it is not needed to build EverCOSE. Rather, this PR makes HACL* local to the COSE verified interop test: just like qcbor and tinycbor, HACL* is now downloaded by that test, and only then; and it is skipped if `HACL_HOME` is set.
