### PR TITLE
Various improvements on EverCDDL

### DIFF
--- a/src/3d/ocaml/OS.ml
+++ b/src/3d/ocaml/OS.ml
@@ -5,7 +5,7 @@ let dirname = Filename.dirname
 let mkdir dir =
   if Sys.file_exists dir && Sys.is_directory dir
   then ()
-  else Sys.mkdir dir 0o755
+  else try Sys.mkdir dir 0o755 with _ -> ()
 
 (* The filename without its path *)
 

--- a/src/cddl/tests/dpe/dpe.cddl
+++ b/src/cddl/tests/dpe/dpe.cddl
@@ -76,12 +76,13 @@ certify-key-input-args = {
   * &(tstr:uint) => any 
 } 
  
-$policy-type /= &(tcg-dice-kp-identityInit:6) ;; add a space before 6 and this file takes forever to parse
-$policy-type /= &(tcg-dice-kp-identityLoc:7)
-$policy-type /= &(tcg-dice-kp-attestInit:8)
-$policy-type /= &(tcg-dice-kp-attestLoc:9) 
-$policy-type /= &(tcg-dice-kp-assertInit:10)
-$policy-type /= &(tcg-dice-kp-assertLoc:11)
+; test various whitespaces for CDDL parsing
+$policy-type /= &(tcg-dice-kp-identityInit: 6)
+$policy-type /= &(tcg-dice-kp-identityLoc :7)
+$policy-type /= &( tcg-dice-kp-attestInit:8)
+$policy-type /= &(tcg-dice-kp-attestLoc:9 ) 
+$policy-type /= & (tcg-dice-kp-assertInit:10)
+$policy-type /= & ( tcg-dice-kp-assertLoc : 11 )
 
 certify-key-output-args = { 
   ? &(certificate:1) ^=> bytes, 

--- a/src/cddl/tests/dpe/dpe/CDDLTest.DPE.CertifyKeyOutput.fst
+++ b/src/cddl/tests/dpe/dpe/CDDLTest.DPE.CertifyKeyOutput.fst
@@ -92,8 +92,8 @@ ensures
     pts_to cert #q c
 {
   rewrite (rel_certifykeyoutputargs x hres) as
-          (rel_bytes (Some?.v x.certificate) (Some?.v hres.certificate) **
-           rel_bytes (Some?.v x.derived_public_key) (Some?.v hres.derived_public_key) **
+          ((rel_bytes (Some?.v x.certificate) (Some?.v hres.certificate) **
+           rel_bytes (Some?.v x.derived_public_key) (Some?.v hres.derived_public_key)) **
            emp);
   let xx = extract_bytes_ghost (Some?.v x.certificate) _;
   let yy = extract_bytes_ghost (Some?.v x.derived_public_key) _;

--- a/src/cddl/tests/dpe/dpe/CDDLTest.DPE.DeriveContextInput.fst
+++ b/src/cddl/tests/dpe/dpe/CDDLTest.DPE.DeriveContextInput.fst
@@ -31,10 +31,10 @@ let is_engine_record_core
       (e:engine_record)
       (wx:spec_engine_record)
 : slprop
-= rel_bytes e.l0_image_header wx.l0_image_header **
-  rel_bytes e.l0_image_header_sig wx.l0_image_header_sig **
-  rel_bytes e.l0_binary wx.l0_binary **
-  rel_bytes e.l0_binary_hash wx.l0_binary_hash **
+= (((rel_bytes e.l0_image_header wx.l0_image_header **
+  rel_bytes e.l0_image_header_sig wx.l0_image_header_sig) **
+  rel_bytes e.l0_binary wx.l0_binary) **
+  rel_bytes e.l0_binary_hash wx.l0_binary_hash) **
   rel_bytes e.l0_image_auth_pubkey wx.l0_image_auth_pubkey
 
 [@@pulse_unfold]
@@ -55,10 +55,10 @@ ensures is_engine_record x w (rel_derive_context_engine_record x w)
 
 let spec_device_id_csr_ingredients = spect_device_id_csr_ingredients
 let is_device_id_csr_ingredients_core (e:device_id_csr_ingredients) (se:spec_device_id_csr_ingredients) : slprop =
-    rel_nint e.ku se.ku **
-    rel_nint e.version se.version **
-    rel_tstr e.s_common se.s_common **
-    rel_tstr e.s_org se.s_org **
+    (((rel_nint e.ku se.ku **
+    rel_nint e.version se.version) **
+    rel_tstr e.s_common se.s_common) **
+    rel_tstr e.s_org se.s_org) **
     rel_tstr e.s_country se.s_country
 
 [@@pulse_unfold]
@@ -79,16 +79,16 @@ ensures is_device_id_csr_ingredients x w (rel_device_id_csr_ingredients x w)
 let spec_alias_key_crt_ingredients = spect_alias_key_crt_ingredients
 
 let is_alias_key_crt_ingredients_core (e:alias_key_crt_ingredients) (s:spec_alias_key_crt_ingredients) =
-  rel_nint e.version s.version **
-  rel_bytes e.serial_number s.serial_number **
-  rel_tstr e.i_common s.i_common **
-  rel_tstr e.i_org s.i_org **
-  rel_bytes e.not_before s.not_before **
-  rel_bytes e.not_after s.not_after **
-  rel_tstr e.s_common s.s_common **
-  rel_tstr e.s_org s.s_org **
-  rel_tstr e.s_country s.s_country **
-  rel_nint e.ku s.ku **
+  (((((((((rel_nint e.version s.version **
+  rel_bytes e.serial_number s.serial_number) **
+  rel_tstr e.i_common s.i_common) **
+  rel_tstr e.i_org s.i_org) **
+  rel_bytes e.not_before s.not_before) **
+  rel_bytes e.not_after s.not_after) **
+  rel_tstr e.s_common s.s_common) **
+  rel_tstr e.s_org s.s_org) **
+  rel_tstr e.s_country s.s_country) **
+  rel_nint e.ku s.ku) **
   rel_nint e.l0_version s.l0_version
 
 [@@pulse_unfold]
@@ -109,10 +109,10 @@ ensures is_alias_key_crt_ingredients x w (rel_alias_key_crt_ingredients x w)
 let l0_record = derive_context_l0_record
 let spec_l0_record = spect_derive_context_l0_record
 let is_l0_record_core (e:l0_record) (wx:spec_l0_record) : slprop =
-  rel_bytes e.fwid wx.fwid **
-  rel_bytes e.device_id_label wx.device_id_label **
-  rel_bytes e.alias_key_label wx.alias_key_label **
-  is_device_id_csr_ingredients_core e.device_id_csr_ingredients wx.device_id_csr_ingredients **
+  (((rel_bytes e.fwid wx.fwid **
+  rel_bytes e.device_id_label wx.device_id_label) **
+  rel_bytes e.alias_key_label wx.alias_key_label) **
+  is_device_id_csr_ingredients_core e.device_id_csr_ingredients wx.device_id_csr_ingredients) **
   is_alias_key_crt_ingredients_core e.alias_key_crt_ingredients wx.alias_key_crt_ingredients
 
 [@@pulse_unfold]

--- a/src/cddl/tests/dpe/dpe/CDDLTest.DPE.InitializeContextInput.fst
+++ b/src/cddl/tests/dpe/dpe/CDDLTest.DPE.InitializeContextInput.fst
@@ -60,12 +60,12 @@ fn trans_hyp_l_2
   (p1 p2 q1 q2 r: slprop)
 requires
   trade p1 p2 **
-  trade (p2 ** q1 ** q2) r
+  trade ((p2 ** q1) ** q2) r
 ensures
-  trade (p1 ** q1 ** q2) r
+  trade ((p1 ** q1) ** q2) r
 {
   slprop_equivs();
-  rewrite each (p2 ** q1 ** q2) as (p2 ** (q1 ** q2));
+  rewrite each ((p2 ** q1) ** q2) as (p2 ** (q1 ** q2));
   Trade.Util.trans_hyp_l _ _ _ r;
 }
 
@@ -78,15 +78,16 @@ fn destruct_quad
 requires 
   rel_pair (rel_pair (rel_pair r0 r1) r2) r3 x y
 ensures
-  r0 (proj_1_4 x) (proj_1_4 y) **
-  r1 (proj_2_4 x) (proj_2_4 y) **
-  r2 (proj_3_4 x) (proj_3_4 y) **
-  r3 (proj_4_4 x) (proj_4_4 y) **
-  Trade.trade (r0 (proj_1_4 x) (proj_1_4 y) **
-               r1 (proj_2_4 x) (proj_2_4 y) **
-               r2 (proj_3_4 x) (proj_3_4 y) **
-               r3 (proj_4_4 x) (proj_4_4 y))
-              (rel_pair (rel_pair (rel_pair r0 r1) r2) r3 x y)
+  (((r0 (proj_1_4 x) (proj_1_4 y) **
+  r1 (proj_2_4 x) (proj_2_4 y)) **
+  r2 (proj_3_4 x) (proj_3_4 y)) **
+  r3 (proj_4_4 x) (proj_4_4 y)) **
+  Trade.trade
+    (((r0 (proj_1_4 x) (proj_1_4 y) **
+    r1 (proj_2_4 x) (proj_2_4 y)) **
+    r2 (proj_3_4 x) (proj_3_4 y)) **
+    r3 (proj_4_4 x) (proj_4_4 y))
+    (rel_pair (rel_pair (rel_pair r0 r1) r2) r3 x y)
 {
   destruct_pair _ r3 _ _ ();
   destruct_pair _ r2 _ _ ();

--- a/src/cddl/tool/ocaml/evercddl-gen/Main.ml
+++ b/src/cddl/tool/ocaml/evercddl-gen/Main.ml
@@ -26,6 +26,11 @@ let list_is_empty = function
 
 let fstar_only = ref false
 
+let mkdir dir =
+  if Sys.file_exists dir && Sys.is_directory dir
+  then ()
+  else try Sys.mkdir dir 0o755 with _ -> ()
+
 let produce_fst_file (dir: string) : string =
   let filenames = List.rev !rev_filenames in
   match ParseFromFile.parse_from_files filenames with
@@ -42,7 +47,7 @@ let produce_fst_file (dir: string) : string =
          let basename = !mname ^ ".fst" in
          let filename = Filename.concat dir basename in
          let filename_tmp = filename ^ ".tmp" in
-         if not (Sys.file_exists dir && Sys.is_directory dir) then Sys.mkdir dir 0o755;
+         mkdir dir;
          let ch = open_out filename_tmp in
          output_string ch str;
          close_out ch;

--- a/src/cddl/tool/ocaml/evercddl-gen/Main.ml
+++ b/src/cddl/tool/ocaml/evercddl-gen/Main.ml
@@ -217,6 +217,8 @@ let rust_krml_list =
     (Filename.concat everparse_src_cddl_tool "extraction-rust")
     "rust.lst"
 
+let skip_compilation = ref false
+
 let _ =
   let argspec = ref [
       ("--admit", Arg.Unit (fun _ -> admit := true), "Admit proofs");
@@ -224,6 +226,7 @@ let _ =
       ("--mname", Arg.String (fun m -> mname := m), "Set the module name");
       ("--odir", Arg.String (fun d -> odir := d), "Set the output directory (default .)");
       ("--fstar_only", Arg.Unit (fun _ -> fstar_only := true), "Only generate F*");
+      ("--skip_compilation", Arg.Unit (fun _ -> skip_compilation := true), "Do not compile produced C files");
       ("--tmpdir", Arg.String (fun d -> tmpdir := d), "Set the temporary directory (default automatically generated)");
     ]
   in
@@ -304,7 +307,7 @@ let _ =
     else
       [
           "-warn-error"; "@1..27";
-          "-skip-compilation";
+          (if !skip_compilation then "-skip-compilation" else "-skip-linking");
           "-tmpdir"; !odir;
           "-header"; Filename.concat everparse_src_cddl_tool "noheader.txt";
         "-fstar"; fstar_exe;
@@ -316,6 +319,7 @@ let _ =
         "-bundle"; "CBOR.Spec.Constants+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.C=CBOR.\\*[rename=CBORDetAPI]";
 	"-bundle"; (!mname ^ "=\\*");
 	"-add-include"; "\"CBORDetAbstract.h\"";
+        "-I"; Filename.concat (Filename.concat everparse_src_cbor_pulse "det") "c";
         krml_file;
       ] @
         c_krml_list

--- a/src/cddl/tool/ocaml/evercddl-lib/CDDLParser.ml
+++ b/src/cddl/tool/ocaml/evercddl-lib/CDDLParser.ml
@@ -294,7 +294,7 @@ and type2 () = debug "type2" (
       concat lbrack (fun _ -> concat s (fun _ -> concat (group ()) (fun x -> concat s (fun _ -> concat rbrack (fun _ -> ret (TArray x))))));
 (* TODO: "~" s typename option(genericarg) *)
 (* TODO: "&" s "(" s group s ")" *)
-      concat amp (fun _ -> concat lparen (fun _ -> concat bareword (fun (_, name) -> concat colon (fun _ -> concat (type_ ()) (fun ty -> concat rparen (fun _ -> ret (TNamed (name, ty))))))));
+      concat amp (fun _ -> concat s (fun _ -> concat lparen (fun _ -> concat s (fun _ -> concat bareword (fun (_, name) -> concat s (fun _ -> concat colon (fun _ -> concat s (fun _ -> concat (type_ ()) (fun ty -> concat s (fun _ -> concat rparen (fun _ -> ret (TNamed (name, ty)))))))))))));
 (* TODO: "&" s groupname option(genericarg) *)
       concat pound6 (fun _ -> concat (option tag) (fun tag -> concat lparen (fun _ -> concat s (fun _ -> concat (type_ ()) (fun x -> concat s (fun _ -> concat rparen (fun _ -> ret (TTagged (tag, x)))))))));
 (* TODO: generalize "#"DIGIT option(tag) *)


### PR DESCRIPTION
* Allow whitespace in `&(a:b)` syntax
* Compile the generated code, except `--skip_compilation` is given
* Fix associativity of `**` (due to FStarLang/FStar#3984, FStarLang/pulse#468)
* Ignore errors on `Sys.mkdir` due to potential concurrent `mkdir` (e.g. from Makefiles.) This PR fixes both EverCDDL and 3d to this respect.
