### PR TITLE
Use a standalone opam root, fuse opam package build into `make -C opt`

### DIFF
--- a/.github/workflows/cbor.yml
+++ b/.github/workflows/cbor.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
+          submodules: true
           path: everparse
       - run: sudo apt update && sudo apt install -y libssl-dev
       - name: Everparse CI
@@ -32,6 +33,7 @@ jobs:
           ocaml-compiler: 5
       - uses: actions/checkout@master
         with:
+          submodules: true
           path: everparse
       - name: Everparse CI
         run: |
@@ -49,6 +51,7 @@ jobs:
           brew install bash gnu-getopt make gnu-time
       - uses: actions/checkout@master
         with:
+          submodules: true
           path: everparse
       - name: Everparse CI
         run: |
@@ -64,6 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
         with:
+          submodules: true
           path: everparse
       - name: Havoc .depend
         run: |

--- a/.github/workflows/cbor.yml
+++ b/.github/workflows/cbor.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           nproc=$(sysctl -n hw.logicalcpu)
           if [[ $nproc -gt 8 ]] ; then nproc=8 ; fi
-          cd everparse && opam exec -- gmake -j$nproc -k cddl-test
+          cd everparse && gmake -j$nproc -k cddl-test
 
   build-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
 
       - uses: actions/checkout@master
         with:
+          submodules: true
           path: everparse
 
       - name: Everparse CI

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Everparse CI
         id: cistep
         run: |
-          . $HOME/.cargo/env && env OPAMYES=1 make _opam && eval $(opam env) && make -C opt -j$(nproc) && env OTHERFLAGS='--admit_smt_queries true' make cbor-snapshot 3d-doc-snapshot -kj$(nproc) && env OTHERFLAGS='--admit_smt_queries true' make cose-snapshot -kj$(nproc)
+          . $HOME/.cargo/env && env OPAMYES=1 make -C opt -j$(nproc) && env OTHERFLAGS='--admit_smt_queries true' make cbor-snapshot 3d-doc-snapshot -kj$(nproc) && env OTHERFLAGS='--admit_smt_queries true' make cose-snapshot -kj$(nproc)
 
       - name: commit changes
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,5 @@ everparse_*.zip
 
 # make touchfiles
 .*.touch
-_opam
-_opam.tmp
+.opam
+.opam.tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile should be run from the root EverParse directory
 
 ARG ocaml_version=4.14
-FROM ocaml/opam:ubuntu-24.04-ocaml-$ocaml_version AS deps
+FROM ocaml/opam:ubuntu-24.04-ocaml-$ocaml_version AS base
 
 SHELL ["/bin/bash", "--login", "-c"]
 
@@ -23,6 +23,8 @@ RUN echo "source $HOME/.cargo/env" >> $(if test -f $HOME/.bash_profile ; then ec
 ADD --chown=opam:opam ./ /mnt/everparse/
 WORKDIR /mnt/everparse
 RUN git clean -ffdx || true
+
+FROM base AS deps
 
 ARG CI_THREADS
 RUN sudo apt-get update && env OPAMYES=1 make -j"$(if test -z "$CI_THREADS" ; then nproc ; else echo $CI_THREADS ; fi)" -C opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN git clean -ffdx || true
 
 # Build and publish the release
 ARG CI_THREADS=24
-RUN sudo apt-get update && . "$HOME/.cargo/env" && env OPAMYES=1 make _opam && eval $(opam env) && make -j $CI_THREADS -C opt && env OTHERFLAGS='--admit_smt_queries true' make -j $CI_THREADS all cbor-test cddl-test cose-test
+RUN sudo apt-get update && . "$HOME/.cargo/env" && env OPAMYES=1 make -j $CI_THREADS -C opt && env OTHERFLAGS='--admit_smt_queries true' make -j $CI_THREADS all cbor-test cddl-test cose-test
 
 ENTRYPOINT ["/mnt/everparse/opt/shell.sh", "--login", "-c"]
 CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,16 @@ asn1-test: asn1
 lowparse-bitfields-test: lowparse
 	+$(MAKE) -C tests/bitfields
 
-lowparse-test: lowparse-unit-test lowparse-bitfields-test
+ifeq (,$(NO_PULSE))
+lowparse-pulse-test:
+else
+lowparse-pulse-test: lowparse
+	+$(MAKE) -C tests/pulse
+endif
+
+.PHONY: lowparse-pulse-test
+
+lowparse-test: lowparse-unit-test lowparse-bitfields-test lowparse-pulse-test
 
 quackyducky-unit-test: gen-test lowparse
 	+$(MAKE) -C tests/unit

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 all: package-subset asn1 cbor cddl cbor-interface cose
 
 export EVERPARSE_OPT_PATH=$(realpath opt)
+-include $(EVERPARSE_OPT_PATH)/opam-env.Makefile
+
 export FSTAR_EXE ?= $(wildcard $(EVERPARSE_OPT_PATH)/FStar/out/bin/fstar.exe)
 export KRML_HOME ?= $(EVERPARSE_OPT_PATH)/karamel
 export PULSE_HOME ?= $(EVERPARSE_OPT_PATH)/pulse/out
@@ -15,10 +17,6 @@ include $(EVERPARSE_OPT_PATH)/env.Makefile
 
 $(EVERPARSE_OPT_PATH)/everest:
 	+$(MAKE) -C $(EVERPARSE_OPT_PATH) everest
-
-_opam: $(EVEREST_HOME)
-	rm -rf $@.tmp
-	if opam init --bare --no-setup && opam switch create ./ ocaml-base-compiler.5.3.0 && opam exec $(EVEREST_HOME)/everest opam ; then true ; else mv $@ $@.tmp ; exit 1 ; fi
 
 package-subset: quackyducky lowparse 3d
 

--- a/build-evercddl.sh
+++ b/build-evercddl.sh
@@ -4,8 +4,7 @@ set -x
 unset CDPATH
 MAKE=$(which gmake >/dev/null 2>&1 && echo gmake || echo make)
 cd "$( dirname "${BASH_SOURCE[0]}" )"
-"$MAKE" _opam
 nproc=$(nproc) || nproc=$(sysctl -n hw.logicalcpu) || nproc=1
 if [[ $nproc -gt 8 ]] ; then nproc=8 ; fi # to prevent OOM during extraction
-opam exec -- "$MAKE" -j$nproc -C opt
-OTHERFLAGS='--admit_smt_queries true' opam exec -- "$MAKE" -j$nproc -k cddl
+"$MAKE" -j$nproc -C opt
+OTHERFLAGS='--admit_smt_queries true' "$MAKE" -j$nproc -k cddl

--- a/git.Dockerfile
+++ b/git.Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /mnt/everparse
 
 # Build and publish the release
 ARG CI_THREADS=24
-RUN sudo apt-get update && . "$HOME/.cargo/env" && env OPAMYES=1 make _opam && eval $(opam env) && make -j $CI_THREADS -C opt && env OTHERFLAGS='--admit_smt_queries true' make -j $CI_THREADS all cbor-test cddl-test cose-test
+RUN sudo apt-get update && . "$HOME/.cargo/env" && env OPAMYES=1 make -j $CI_THREADS -C opt && env OTHERFLAGS='--admit_smt_queries true' make -j $CI_THREADS all cbor-test cddl-test cose-test
 
 ENTRYPOINT ["/mnt/everparse/opt/shell.sh", "--login", "-c"]
 CMD ["/bin/bash"]

--- a/git.Dockerfile
+++ b/git.Dockerfile
@@ -3,8 +3,6 @@
 ARG ocaml_version=4.14
 FROM ocaml/opam:ubuntu-24.04-ocaml-$ocaml_version AS base
 
-SHELL ["/bin/bash", "--login", "-c"]
-
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends llvm-dev libclang-dev clang libgmp-dev pkg-config \
@@ -16,8 +14,8 @@ RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends ll
   time \
   wget
 
-# Set up Rust environment
-RUN echo "source $HOME/.cargo/env" >> $(if test -f $HOME/.bash_profile ; then echo $HOME/.bash_profile ; else echo $HOME/.profile ; fi)
+# Automatically set up Rust environment
+SHELL ["/usr/bin/env", "BASH_ENV=/home/opam/.cargo/env", "/bin/bash", "-c"]
 
 # Bring in the contents
 ARG CACHE_BUST
@@ -31,14 +29,15 @@ FROM base AS deps
 ARG CI_THREADS
 RUN sudo apt-get update && env OPAMYES=1 make -j"$(if test -z "$CI_THREADS" ; then nproc ; else echo $CI_THREADS ; fi)" -C opt
 
-ENTRYPOINT ["/mnt/everparse/opt/shell.sh", "--login", "-c"]
-CMD ["/bin/bash"]
-SHELL ["/mnt/everparse/opt/shell.sh", "--login", "-c"]
+# Automatically set up Rust environment
+ENTRYPOINT ["/usr/bin/env", "BASH_ENV=/home/opam/.cargo/env", "/mnt/everparse/opt/shell.sh", "-c"]
+CMD ["/bin/bash", "-i"]
+SHELL ["/usr/bin/env", "BASH_ENV=/home/opam/.cargo/env", "/mnt/everparse/opt/shell.sh", "-c"]
 
-FROM deps AS all
+FROM deps AS build
 
 RUN OTHERFLAGS='--admit_smt_queries true' make -j"$(if test -z "$CI_THREADS" ; then nproc ; else echo $CI_THREADS ; fi)" all
 
-FROM all AS test
+FROM build AS test
 
 RUN OTHERFLAGS='--admit_smt_queries true' make -j"$(if test -z "$CI_THREADS" ; then nproc ; else echo $CI_THREADS ; fi)" test

--- a/git.Dockerfile
+++ b/git.Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile should be run from the root EverParse directory
 
 ARG ocaml_version=4.14
-FROM ocaml/opam:ubuntu-24.04-ocaml-$ocaml_version
+FROM ocaml/opam:ubuntu-24.04-ocaml-$ocaml_version AS base
 
 SHELL ["/bin/bash", "--login", "-c"]
 
@@ -25,6 +25,8 @@ RUN sudo mkdir /mnt/everparse && sudo chown opam:opam /mnt/everparse
 ARG CI_BRANCH=master
 RUN git clone --recurse-submodules --branch CI_BRANCH https://github.com/project-everest/everparse /mnt/everparse && echo $CACHE_BUST
 WORKDIR /mnt/everparse
+
+FROM base AS deps
 
 ARG CI_THREADS
 RUN sudo apt-get update && env OPAMYES=1 make -j"$(if test -z "$CI_THREADS" ; then nproc ; else echo $CI_THREADS ; fi)" -C opt

--- a/git.Dockerfile
+++ b/git.Dockerfile
@@ -23,7 +23,7 @@ RUN echo "source $HOME/.cargo/env" >> $(if test -f $HOME/.bash_profile ; then ec
 ARG CACHE_BUST
 RUN sudo mkdir /mnt/everparse && sudo chown opam:opam /mnt/everparse
 ARG CI_BRANCH=master
-RUN git clone --recurse-submodules --branch CI_BRANCH https://github.com/project-everest/everparse /mnt/everparse && echo $CACHE_BUST
+RUN git clone --recurse-submodules --branch $CI_BRANCH https://github.com/project-everest/everparse /mnt/everparse && echo $CACHE_BUST
 WORKDIR /mnt/everparse
 
 FROM base AS deps

--- a/git.Dockerfile
+++ b/git.Dockerfile
@@ -21,7 +21,8 @@ RUN sudo apt-get install --yes \
 # Bring in the contents
 ARG CACHE_BUST
 RUN sudo mkdir /mnt/everparse && sudo chown opam:opam /mnt/everparse
-RUN git clone https://github.com/project-everest/everparse /mnt/everparse && echo $CACHE_BUST
+ARG CI_BRANCH=master
+RUN git clone --recurse-submodules --branch CI_BRANCH https://github.com/project-everest/everparse /mnt/everparse && echo $CACHE_BUST
 WORKDIR /mnt/everparse
 
 # Build and publish the release

--- a/git.Dockerfile
+++ b/git.Dockerfile
@@ -3,13 +3,11 @@
 ARG ocaml_version=4.14
 FROM ocaml/opam:ubuntu-24.04-ocaml-$ocaml_version
 
+SHELL ["/bin/bash", "--login", "-c"]
+
 # install rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends llvm-dev libclang-dev clang libgmp-dev pkg-config
-RUN . "$HOME/.cargo/env" && rustup component add rustfmt && cargo install bindgen-cli
-
-# Install other dependencies
-RUN sudo apt-get install --yes \
+RUN sudo apt-get update && sudo apt-get install --yes --no-install-recommends llvm-dev libclang-dev clang libgmp-dev pkg-config \
   libssl-dev \
   cmake \
   python-is-python3 \
@@ -18,6 +16,9 @@ RUN sudo apt-get install --yes \
   time \
   wget
 
+# Set up Rust environment
+RUN echo "source $HOME/.cargo/env" >> $(if test -f $HOME/.bash_profile ; then echo $HOME/.bash_profile ; else echo $HOME/.profile ; fi)
+
 # Bring in the contents
 ARG CACHE_BUST
 RUN sudo mkdir /mnt/everparse && sudo chown opam:opam /mnt/everparse
@@ -25,9 +26,17 @@ ARG CI_BRANCH=master
 RUN git clone --recurse-submodules --branch CI_BRANCH https://github.com/project-everest/everparse /mnt/everparse && echo $CACHE_BUST
 WORKDIR /mnt/everparse
 
-# Build and publish the release
-ARG CI_THREADS=24
-RUN sudo apt-get update && . "$HOME/.cargo/env" && env OPAMYES=1 make -j $CI_THREADS -C opt && env OTHERFLAGS='--admit_smt_queries true' make -j $CI_THREADS all cbor-test cddl-test cose-test
+ARG CI_THREADS
+RUN sudo apt-get update && env OPAMYES=1 make -j"$(if test -z "$CI_THREADS" ; then nproc ; else echo $CI_THREADS ; fi)" -C opt
 
 ENTRYPOINT ["/mnt/everparse/opt/shell.sh", "--login", "-c"]
 CMD ["/bin/bash"]
+SHELL ["/mnt/everparse/opt/shell.sh", "--login", "-c"]
+
+FROM deps AS all
+
+RUN OTHERFLAGS='--admit_smt_queries true' make -j"$(if test -z "$CI_THREADS" ; then nproc ; else echo $CI_THREADS ; fi)" all
+
+FROM all AS test
+
+RUN OTHERFLAGS='--admit_smt_queries true' make -j"$(if test -z "$CI_THREADS" ; then nproc ; else echo $CI_THREADS ; fi)" test

--- a/opt/.gitignore
+++ b/opt/.gitignore
@@ -3,3 +3,5 @@ FStar
 everest
 karamel
 pulse
+opam
+opam-env.Makefile

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -4,7 +4,7 @@ all: FStar.do karamel.do pulse.do z3
 
 export EVERPARSE_OPT_PATH=$(realpath .)
 
-ifeq (,$(OPAMROOT))
+ifeq (,$(EVERPARSE_USE_OPAMROOT))
 opam-env.Makefile: everest
 	opam init --no-setup --root=opam --compiler=5.3.0
 	opam exec --root=opam --set-root -- everest/everest opam
@@ -17,7 +17,7 @@ endif
 	echo env: opam-env >> $@.tmp
 	echo .PHONY: opam-env >> $@.tmp
 	echo opam-env: >> $@.tmp
-	echo "	OPAMROOT=\"$(OPAMROOT)\" \"$(EVERPARSE_OPT_PATH)\"/opam-env.sh --shell" >> $@.tmp
+	echo "	\"$(EVERPARSE_OPT_PATH)\"/opam-env.sh --shell" >> $@.tmp
 	mv $@.tmp $@
 
 include opam-env.Makefile

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -21,17 +21,7 @@ export PATH := $(EVERPARSE_OPT_PATH)/z3:$(PATH)
 
 include env.Makefile
 
-FStar:
-	git clone "https://github.com/FStarLang/FStar" $@
-
-karamel:
-	git clone "https://github.com/FStarLang/karamel" $@
-
-pulse:
-	git clone "https://github.com/FStarLang/pulse" $@
-
-everest:
-	git clone "https://github.com/project-everest/everest" $@
+include git-clone.Makefile
 
 FStar.do: FStar
 	+$(MAKE) -C $< ADMIT=1

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -2,12 +2,23 @@ all: FStar.do karamel.do pulse.do z3
 
 .PHONY: all %.do
 
+export EVERPARSE_OPT_PATH=$(realpath .)
+
+ifeq (,$(OPAMROOT))
 opam-env.Makefile: everest
 	opam init --no-setup --root=opam --compiler=5.3.0
 	opam exec --root=opam --set-root -- everest/everest opam
-	./opam-env.sh > $@
-
-export EVERPARSE_OPT_PATH=$(realpath .)
+else
+opam-env.Makefile:
+endif
+	rm -rf $@.tmp
+	./opam-env.sh > $@.tmp
+	echo >> $@.tmp
+	echo env: opam-env >> $@.tmp
+	echo .PHONY: opam-env >> $@.tmp
+	echo opam-env: >> $@.tmp
+	echo "	OPAMROOT=\"$(OPAMROOT)\" \"$(EVERPARSE_OPT_PATH)\"/opam-env.sh --shell" >> $@.tmp
+	mv $@.tmp $@
 
 include opam-env.Makefile
 

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -4,7 +4,7 @@ all: FStar.do karamel.do pulse.do z3
 
 opam-env.Makefile: everest
 	opam init --no-setup --root=opam
-	opam exec --root=opam --set-root -- env OPAMNODEPEXTS=1 everest/everest opam
+	opam exec --root=opam --set-root -- everest/everest opam
 	./opam-env.sh > $@
 
 export EVERPARSE_OPT_PATH=$(realpath .)

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -1,9 +1,18 @@
 all: FStar.do karamel.do pulse.do z3
 
-export ADMIT=1
-export OTHERFLAGS=--admit_smt_queries true # because Karamel Makefiles do not honor ADMIT
+.PHONY: all %.do
+
+opam-env.Makefile: everest
+	opam init --no-setup --root=opam
+	opam exec --root=opam --set-root -- env OPAMNODEPEXTS=1 everest/everest opam
+	./opam-env.sh > $@
 
 export EVERPARSE_OPT_PATH=$(realpath .)
+
+include opam-env.Makefile
+
+export ADMIT=1
+export OTHERFLAGS=--admit_smt_queries true # because Karamel Makefiles do not honor ADMIT
 
 export FSTAR_EXE  := $(EVERPARSE_OPT_PATH)/FStar/out/bin/fstar.exe
 export KRML_HOME  := $(EVERPARSE_OPT_PATH)/karamel
@@ -11,10 +20,6 @@ export PULSE_HOME := $(EVERPARSE_OPT_PATH)/pulse/out
 export PATH := $(EVERPARSE_OPT_PATH)/z3:$(PATH)
 
 include env.Makefile
-
-submodules:
-	git submodule init
-	git submodule update
 
 FStar:
 	git clone "https://github.com/FStarLang/FStar" $@
@@ -31,7 +36,7 @@ everest:
 FStar.do: FStar
 	+$(MAKE) -C $< ADMIT=1
 
-z3: FStar.do
+z3: FStar
 	mkdir -p $@
 	FStar/.scripts/get_fstar_z3.sh $(realpath .)/$@
 	rm -rf $@/z3-4.8.5
@@ -41,5 +46,3 @@ karamel.do: karamel FStar.do
 
 pulse.do: pulse FStar.do
 	+$(MAKE) -C $< ADMIT=1
-
-.PHONY: all submodules %.do

--- a/opt/Makefile
+++ b/opt/Makefile
@@ -3,7 +3,7 @@ all: FStar.do karamel.do pulse.do z3
 .PHONY: all %.do
 
 opam-env.Makefile: everest
-	opam init --no-setup --root=opam
+	opam init --no-setup --root=opam --compiler=5.3.0
 	opam exec --root=opam --set-root -- everest/everest opam
 	./opam-env.sh > $@
 

--- a/opt/env.Makefile
+++ b/opt/env.Makefile
@@ -3,7 +3,6 @@ env:
 	@echo export FSTAR_EXE=$(FSTAR_EXE)
 	@echo export KRML_HOME=$(KRML_HOME)
 	@echo export PULSE_HOME=$(PULSE_HOME)
-	@if test -d $(EVERPARSE_OPT_PATH)/opam ; then opam env --root=$(EVERPARSE_OPT_PATH)/opam --set-root ; fi
 	@echo export PATH=$(EVERPARSE_OPT_PATH)/FStar/bin:$(EVERPARSE_OPT_PATH)/z3:\"'$$PATH'\"
 
 .PHONY: env

--- a/opt/env.Makefile
+++ b/opt/env.Makefile
@@ -3,7 +3,7 @@ env:
 	@echo export FSTAR_EXE=$(FSTAR_EXE)
 	@echo export KRML_HOME=$(KRML_HOME)
 	@echo export PULSE_HOME=$(PULSE_HOME)
-	@if test -d $(EVERPARSE_OPT_PATH)/opam ; then opam env --root=$(EVERPARSE_OPT_PATH)/opam ; fi
+	@if test -d $(EVERPARSE_OPT_PATH)/opam ; then opam env --root=$(EVERPARSE_OPT_PATH)/opam --set-root ; fi
 	@echo export PATH=$(EVERPARSE_OPT_PATH)/FStar/bin:$(EVERPARSE_OPT_PATH)/z3:\"'$$PATH'\"
 
 .PHONY: env

--- a/opt/env.Makefile
+++ b/opt/env.Makefile
@@ -3,7 +3,7 @@ env:
 	@echo export FSTAR_EXE=$(FSTAR_EXE)
 	@echo export KRML_HOME=$(KRML_HOME)
 	@echo export PULSE_HOME=$(PULSE_HOME)
-	@if test -d $(EVERPARSE_OPT_PATH)/../_opam ; then opam env ; fi
+	@if test -d $(EVERPARSE_OPT_PATH)/opam ; then opam env --root=$(EVERPARSE_OPT_PATH)/opam ; fi
 	@echo export PATH=$(EVERPARSE_OPT_PATH)/FStar/bin:$(EVERPARSE_OPT_PATH)/z3:\"'$$PATH'\"
 
 .PHONY: env

--- a/opt/git-clone.Makefile
+++ b/opt/git-clone.Makefile
@@ -1,0 +1,16 @@
+# dummy first rule
+git-clone:
+
+.PHONY: git-clone
+
+FStar:
+	git clone "https://github.com/FStarLang/FStar" $@
+
+karamel:
+	git clone "https://github.com/FStarLang/karamel" $@
+
+pulse:
+	git clone "https://github.com/FStarLang/pulse" $@
+
+everest:
+	git clone "https://github.com/project-everest/everest" $@

--- a/opt/opam-env.sh
+++ b/opt/opam-env.sh
@@ -2,4 +2,5 @@
 unset CDPATH
 SED=$(which gsed >/dev/null 2>&1 && echo gsed || echo sed)
 # Print OPAM environment in GNU Makefile format
-opam env --root=opam --set-root --shell=sh | $SED 's!^\([^=]*\)='"'"'\(.*\)'"'"'; export [^;]*;$!export \1 := \2!'
+opam env --root=opam --set-root --shell=sh | grep -v '^PATH=' | $SED 's!^\([^=]*\)='"'"'\(.*\)'"'"'; export [^;]*;$!export \1 := \2!'
+echo 'export PATH := '"$(pwd)/opam/default/bin"':$(PATH)'

--- a/opt/opam-env.sh
+++ b/opt/opam-env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+unset CDPATH
+SED=$(which gsed >/dev/null 2>&1 && echo gsed || echo sed)
+# Print OPAM environment in GNU Makefile format
+opam env --root=opam --set-root --shell=sh | $SED 's!^\([^=]*\)='"'"'\(.*\)'"'"'; export [^;]*;$!export \1 := \2!'

--- a/opt/opam-env.sh
+++ b/opt/opam-env.sh
@@ -3,4 +3,4 @@ unset CDPATH
 SED=$(which gsed >/dev/null 2>&1 && echo gsed || echo sed)
 # Print OPAM environment in GNU Makefile format
 opam env --root=opam --set-root --shell=sh | grep -v '^PATH=' | $SED 's!^\([^=]*\)='"'"'\(.*\)'"'"'; export [^;]*;$!export \1 := \2!'
-echo 'export PATH := '"$(pwd)/opam/default/bin"':$(PATH)'
+echo 'export PATH := '"$(pwd)/opam/$(opam switch --root=opam show)/bin"':$(PATH)'

--- a/opt/opam-env.sh
+++ b/opt/opam-env.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 unset CDPATH
 SED=$(which gsed >/dev/null 2>&1 && echo gsed || echo sed)
-if [[ -z "$OPAMROOT" ]] ; then
+if [[ -z "$EVERPARSE_USE_OPAMROOT" ]] ; then
     OPAMROOT=$(pwd)/opam
     root_opam=--root=opam
 else
+    if [[ -z "$OPAMROOT" ]] ; then
+	OPAMROOT="$(opam var root)"
+    fi
     root_opam="--root=$OPAMROOT"
 fi
 opam env "$root_opam" --set-root --shell=sh | grep -v '^PATH=' |

--- a/opt/opam-env.sh
+++ b/opt/opam-env.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 unset CDPATH
+cd "$( dirname "${BASH_SOURCE[0]}" )"
 SED=$(which gsed >/dev/null 2>&1 && echo gsed || echo sed)
 if [[ -z "$EVERPARSE_USE_OPAMROOT" ]] ; then
-    OPAMROOT=$(pwd)/opam
-    root_opam=--root=opam
-else
-    if [[ -z "$OPAMROOT" ]] ; then
+        OPAMROOT="$(pwd)/opam"
+elif [[ -z "$OPAMROOT" ]] ; then
 	OPAMROOT="$(opam var root)"
-    fi
-    root_opam="--root=$OPAMROOT"
 fi
+root_opam="--root=$OPAMROOT"
 opam env "$root_opam" --set-root --shell=sh | grep -v '^PATH=' |
     if [[ "$1" = --shell ]] ; then
 	cat

--- a/opt/opam-env.sh
+++ b/opt/opam-env.sh
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
 unset CDPATH
 SED=$(which gsed >/dev/null 2>&1 && echo gsed || echo sed)
-# Print OPAM environment in GNU Makefile format
-opam env --root=opam --set-root --shell=sh | grep -v '^PATH=' | $SED 's!^\([^=]*\)='"'"'\(.*\)'"'"'; export [^;]*;$!export \1 := \2!'
-echo 'export PATH := '"$(pwd)/opam/$(opam switch --root=opam show)/bin"':$(PATH)'
+if [[ -z "$OPAMROOT" ]] ; then
+    OPAMROOT=$(pwd)/opam
+    root_opam=--root=opam
+else
+    root_opam="--root=$OPAMROOT"
+fi
+opam env "$root_opam" --set-root --shell=sh | grep -v '^PATH=' |
+    if [[ "$1" = --shell ]] ; then
+	cat
+    else
+	$SED 's!^\([^=]*\)='"'"'\(.*\)'"'"'; export [^;]*;$!export \1 := \2!'
+    fi
+if [[ "$1" = --shell ]] ; then
+    equal="='"
+    epath="'"':"$PATH"'
+else
+    equal=':='
+    epath=':$(PATH)'
+fi
+echo 'export PATH'$equal"$OPAMROOT/$(opam switch "$root_opam" show)/bin$epath"

--- a/opt/shell.sh
+++ b/opt/shell.sh
@@ -2,5 +2,5 @@
 set -e
 unset CDPATH
 OPT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-eval $(make -s -C "$OPT" env)
+eval "$(make -s -C "$OPT" env)"
 exec bash "$@"

--- a/src/cose/verifiedinterop/test/Makefile
+++ b/src/cose/verifiedinterop/test/Makefile
@@ -26,7 +26,7 @@ $(CURDIR)/hacl-star:
 	mv $@.tmp $@
 
 $(EVERPARSE_PATH)/opt/karamel:
-	+$(MAKE) -C $(dir $@) $(notdir $@)
+	+$(MAKE) -C $(dir $@) -f git-clone.Makefile $(notdir $@)
 
 COSE_EVERCRYPT_O=../../c/COSE_EverCrypt.o
 COSE_FORMAT_O=../../c/COSE_Format.o


### PR DESCRIPTION
Currently, the user needs to run `make _opam && eval $(opam env) && make -C opt` to build EverParse dependencies. Moreover, `make _opam` touches the user's `.opam` by registering a switch.

This PR fixes all of those issues. Now, the user only needs to run `make -C opt` to build all EverParse dependencies at once, including opam packages. To perform the latter, `make -C opt` now creates a standalone opam root in `opt/opam`.

Moreover, `make -C opt` now creates `opt/opam-env.Makefile`, which is automatically included by the main `Makefile` to set up the opam environment in addition to `FSTAR_EXE`, etc. when invoking one of its rules. Thus, the user no longer needs to run `eval $(opam env)`.

As before, if the user needs to work beyond the main Makefile rules, a single invocation of `eval $(make -s env)` is enough to set up both opam and EverParse environments at once.
