### PR TITLE
CI: test as much as possible on MacOS

### DIFF
--- a/.github/workflows/cbor.yml
+++ b/.github/workflows/cbor.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           nproc=$(sysctl -n hw.logicalcpu)
           if [[ $nproc -gt 8 ]] ; then nproc=8 ; fi
-          cd everparse && gmake -j$nproc -k all cddl-test
+          cd everparse && gmake -j$nproc -k all test
 
   build-docker:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,13 @@ include nofstar.Makefile
 
 include deps.Makefile
 
+ifneq ($(OS),Windows_NT)
+package-subset: cddl
+endif
+ifneq ($(OS),Darwin)
+all: cose
+endif
+
 ifeq (,$(NO_PULSE))
 all: cddl cbor-interface
 endif

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ include deps.Makefile
 ifneq ($(OS),Windows_NT)
 package-subset: cddl
 endif
+
+# Disable COSE on MacOS because we don't know how to link with OpenSSL
 ifneq ($(OS),Darwin)
 all: cose
 endif
@@ -81,15 +83,10 @@ lowparse-unit-test: lowparse
 	+$(MAKE) -C tests/lowparse
 
 3d-unit-test: 3d $(NEED_Z3_TESTGEN)
-ifneq ($(OS),Darwin)
 	+$(MAKE) -C src/3d test
-endif
-
 
 3d-doc-test: 3d
-ifneq ($(OS),Darwin)
 	+$(MAKE) -C doc 3d-test
-endif
 
 3d-test: 3d-unit-test 3d-doc-test
 
@@ -113,8 +110,15 @@ lowparse-test: lowparse-unit-test lowparse-bitfields-test lowparse-pulse-test
 quackyducky-test: quackyducky
 	+$(MAKE) -C tests
 
-test: all lowparse-test quackyducky-test 3d-test asn1-test cbor-test cddl-test
+test: all lowparse-test quackyducky-test asn1-test cbor-test cddl-test
 
+# Disable 3d-unit-test on MacOS because there is a loop in Makefiles
+# Disable 3d-doc-test on MacOS because sphinx is not available
+ifneq ($(OS),Darwin)
+test: 3d-test
+endif
+
+# Disable COSE tests on MacOS because we don't know how to link with OpenSSL
 ifneq ($(OS),Darwin)
 test: cose-test
 endif

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,11 @@ ifneq ($(OS),Darwin)
 	+$(MAKE) -C src/3d test
 endif
 
+
 3d-doc-test: 3d
+ifneq ($(OS),Darwin)
 	+$(MAKE) -C doc 3d-test
+endif
 
 3d-test: 3d-unit-test 3d-doc-test
 

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,11 @@ lowparse-test: lowparse-unit-test lowparse-bitfields-test lowparse-pulse-test
 quackyducky-test: quackyducky
 	+$(MAKE) -C tests
 
-test: all lowparse-test quackyducky-test 3d-test asn1-test cbor-test cddl-test cose-test
+test: all lowparse-test quackyducky-test 3d-test asn1-test cbor-test cddl-test
+
+ifneq ($(OS),Darwin)
+test: cose-test
+endif
 
 submodules:
 	$(MAKE) -C $(EVERPARSE_OPT_PATH) submodules

--- a/deps.Makefile
+++ b/deps.Makefile
@@ -5,12 +5,6 @@ deps:
 ifeq (,$(OS))
 export OS := $(shell uname)
 endif
-ifneq ($(OS),Windows_NT)
-package-subset: cddl
-endif
-ifneq ($(OS),Darwin)
-all: cose
-endif
 
 export EVERPARSE_OPT_PATH := $(realpath opt)
 ifeq ($(OS),Windows_NT)

--- a/src/cbor/pulse/det/c/example/Makefile
+++ b/src/cbor/pulse/det/c/example/Makefile
@@ -5,7 +5,8 @@ EVERPARSE_SRC_PATH = $(realpath ../../../../..)
 CBOR_LIB_PATH = $(realpath ..)
 CBOR_INCLUDE_PATH = $(realpath ..)
 
-CFLAGS += -Werror -I $(CBOR_INCLUDE_PATH) -g
+# -Wno-pointer-sign because of string to uint8_t* conversion
+CFLAGS += -Werror -I $(CBOR_INCLUDE_PATH) -g -Wno-pointer-sign
 
 .PHONY: all
 

--- a/tests/bitfields/Makefile.common
+++ b/tests/bitfields/Makefile.common
@@ -21,10 +21,9 @@ FSTAR = $(FSTAR_EXE) $(FSTAR_OPTIONS)
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
 KRML = $(KRML_HOME)/krml -fstar $(FSTAR_EXE) \
-	 -ccopt "-Ofast" \
+	 -ccopt "-O3" -ccopt "-ffast-math" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out \
 	 -bundle 'LowParse.\*' \
 	 $(HEADERS) \
 	 -warn-error -9
-

--- a/tests/sample/Makefile.common
+++ b/tests/sample/Makefile.common
@@ -22,7 +22,7 @@ HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
 KRML = $(KRML_HOME)/krml \
 	 -fstar $(FSTAR_EXE) \
-	 -ccopt "-Ofast" \
+	 -ccopt "-O3" -ccopt "-ffast-math" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out \
 	 -bundle 'LowParse.\*' \

--- a/tests/sample0/Makefile.common
+++ b/tests/sample0/Makefile.common
@@ -22,7 +22,7 @@ HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
 KRML = $(KRML_HOME)/krml \
 	 -fstar $(FSTAR_EXE) \
-	 -ccopt "-Ofast" \
+	 -ccopt "-O3" -ccopt "-ffast-math" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out \
 	 -bundle 'LowParse.\*' \

--- a/tests/sample_low/Makefile.common
+++ b/tests/sample_low/Makefile.common
@@ -22,7 +22,7 @@ HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
 KRML = $(KRML_HOME)/krml \
 	 -fstar $(FSTAR_EXE) \
-	 -ccopt "-Ofast" \
+	 -ccopt "-O3" -ccopt "-ffast-math" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out \
 	 -bundle 'LowParse.\*' \

--- a/tests/unit.Makefile
+++ b/tests/unit.Makefile
@@ -33,7 +33,7 @@ HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
 KRML = $(KRML_HOME)/krml \
 	 -fstar $(FSTAR_EXE) \
-	 -ccopt "-Ofast" \
+	 -ccopt "-O3" -ccopt "-ffast-math" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out -I .. \
 	 -bundle 'LowParse.\*' \


### PR DESCRIPTION
Remaining things disabled on MacOS:
* `cose`, `cose-test`: disabled because we don't know how to link with OpenSSL
* `3d-unit-test`: disabled because there seems to be a loop in Makefiles
* `3d-doc-test`: disabled because sphinx is not available
