### PR TITLE
More compiler flags for tests to accommodate Clang on MacOS

### DIFF
--- a/tests/unit.Makefile
+++ b/tests/unit.Makefile
@@ -31,9 +31,11 @@ FSTAR = $(FSTAR_EXE) $(FSTAR_OPTIONS)
 
 HEADERS = $(addprefix -add-include ,'"krml/internal/compat.h"')
 
+# -Wno-tautological-overlap-compare because of T32
 KRML = $(KRML_HOME)/krml \
 	 -fstar $(FSTAR_EXE) \
 	 -ccopt "-O3" -ccopt "-ffast-math" \
+	 -ccopt "-Wno-tautological-overlap-compare" \
 	 -drop 'FStar.Tactics.\*' -drop FStar.Tactics -drop 'FStar.Reflection.\*' \
 	 -tmpdir out -I .. \
 	 -bundle 'LowParse.\*' \


### PR DESCRIPTION
Enable -Wno-tautological-overlap-compare for T32