### PR TITLE
Backport #270, round 2

### DIFF
--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Nondet.Gen.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Nondet.Gen.fst
@@ -332,7 +332,7 @@ let impl_check_equiv_list_with_bound_t
 
 #pop-options
 
-#push-options "--z3rlimit 128"
+#push-options "--z3rlimit 256"
 
 inline_for_extraction
 fn impl_check_equiv_list
@@ -467,6 +467,7 @@ fn impl_check_equiv_list
             pts_to_serialized_nlist_append serialize_raw_data_item tl1' _ _;
             Trade.trans_hyp_r _ _ _ (pts_to_serialized (serialize_nlist (SZ.v n) serialize_raw_data_item) l1' #p1 gl1');
             pts_to_serialized_length _ tl1';
+            LowParse.Spec.VCList.parse_nlist_kind_low (remaining_data_items_header h1 + (SZ.v n - 1)) parse_raw_data_item_kind;
             assert (pure (remaining_data_items_header h1 + (SZ.v n - 1) <= SZ.v (S.len tl1')));
             let n' : SZ.t = SZ.add (impl_remaining_data_items_header (S.len tl1') h1) (SZ.sub n 1sz);
             pts_to_serialized_nlist_ext

--- a/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.EverParse.fst
+++ b/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.EverParse.fst
@@ -1937,7 +1937,7 @@ let bytes_lex_compare_refl
 
 #pop-options
 
-#push-options "--z3rlimit 256 --split_queries always"
+#push-options "--z3rlimit 128 --split_queries always"
 
 let serialized_lex_compare_simple_value
   (x1 x2: simple_value)

--- a/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.EverParse.fst
+++ b/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.EverParse.fst
@@ -1937,7 +1937,7 @@ let bytes_lex_compare_refl
 
 #pop-options
 
-#push-options "--z3rlimit 128 --split_queries always"
+#push-options "--z3rlimit 256 --split_queries always"
 
 let serialized_lex_compare_simple_value
   (x1 x2: simple_value)

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma12.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma12.fst
@@ -9,7 +9,7 @@ module EqTest = CDDL.Spec.EqTest
 
 open CDDL.Spec.MapGroup
 
-#push-options "--z3rlimit 256 --fuel 1 --ifuel 1 --z3seed 42"
+#push-options "--z3rlimit 256 --fuel 1 --ifuel 1 --z3seed 42 --z3refresh"
 
 let invariant_insert_success
   #pe #minl #maxl p key tkey sp1 value tvalue inj sp2 except em out vout size count m v0 v min max vout_old gk gv min_old max_old em_old size_old count_old m_old l

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma12.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma12.fst
@@ -9,7 +9,7 @@ module EqTest = CDDL.Spec.EqTest
 
 open CDDL.Spec.MapGroup
 
-#push-options "--z3rlimit 256 --fuel 1 --ifuel 1 --z3seed 42 --z3refresh --split_queries always"
+#push-options "--z3rlimit 256 --fuel 1 --ifuel 1 --z3seed 42"
 
 let invariant_insert_success
   #pe #minl #maxl p key tkey sp1 value tvalue inj sp2 except em out vout size count m v0 v min max vout_old gk gv min_old max_old em_old size_old count_old m_old l

--- a/src/cddl/spec/CDDL.Spec.AST.Elab.Disjoint.Array.fst
+++ b/src/cddl/spec/CDDL.Spec.AST.Elab.Disjoint.Array.fst
@@ -35,6 +35,7 @@ let array_group_disjoint
     else array_group_disjoint e  close1 close2 a1r a2
   | (_, close1, (GDef n, a1r)), (a2, close2, _)
   | (a2, close2, _), (_, close1, (GDef n, a1r)) ->
+    assert (name_mem n e.e_sem_env.se_bound);
     let en = match e.e_sem_env.se_bound n with
     | Some NGroup -> (e.e_env n)
     | Some NType -> GElem false (TElem EAny) (e.e_env n)

--- a/src/cddl/spec/CDDL.Spec.AST.Elab.Disjoint.Array.fst
+++ b/src/cddl/spec/CDDL.Spec.AST.Elab.Disjoint.Array.fst
@@ -7,7 +7,7 @@ module U64 = FStar.UInt64
 module Util = CBOR.Spec.Util
 module U8 = FStar.UInt8
 
-#push-options "--z3rlimit 4096 --query_stats --split_queries always --fuel 4 --ifuel 8 --z3refresh --z3seed 42 --z3cliopt 'smt.qi.eager_threshold=30'"
+#push-options "--z3rlimit 4096 --query_stats --split_queries always --fuel 4 --ifuel 8 --z3refresh --z3seed 42"
 
 let array_group_disjoint
   (typ_disjoint: typ_disjoint_t)

--- a/src/cddl/spec/CDDL.Spec.AST.Elab.MGCC.fst
+++ b/src/cddl/spec/CDDL.Spec.AST.Elab.MGCC.fst
@@ -14,7 +14,7 @@ let squash_modus_ponens
 : Tot (squash p2)
 = ()
 
-#push-options "--z3rlimit 256 --ifuel 8 --fuel 2 --split_queries always"
+#push-options "--z3rlimit 256 --ifuel 4 --fuel 2 --split_queries always"
 
 #restart-solver
 let rec map_group_choice_compatible'

--- a/src/cddl/spec/CDDL.Spec.ArrayGroup.fst
+++ b/src/cddl/spec/CDDL.Spec.ArrayGroup.fst
@@ -313,6 +313,7 @@ let array_group_concat_unique_strong_zero_or_more_right
   ))
 = ()
 
+#push-options "--split_queries always"
 let array_group_concat_unique_strong'_zero_or_more_left
   #b (a1 a2: array_group b)
 : Lemma
@@ -373,6 +374,7 @@ let array_group_concat_unique_strong'_zero_or_more_left
 let array_group_concat_unique_strong_zero_or_more_left
   #b (a1 a2: array_group b)
 = array_group_concat_unique_strong'_zero_or_more_left a1 a2
+#pop-options
 
 let array_group_concat_unique_weak_intro
   #b (a1 a3: array_group b)

--- a/src/cddl/spec/CDDL.Spec.ArrayGroup.fst
+++ b/src/cddl/spec/CDDL.Spec.ArrayGroup.fst
@@ -313,8 +313,6 @@ let array_group_concat_unique_strong_zero_or_more_right
   ))
 = ()
 
-#push-options "--z3rlimit 16"
-
 let array_group_concat_unique_strong'_zero_or_more_left
   #b (a1 a2: array_group b)
 : Lemma
@@ -371,8 +369,6 @@ let array_group_concat_unique_strong'_zero_or_more_left
     end
   in
   Classical.forall_intro_2 prf
-
-#pop-options
 
 let array_group_concat_unique_strong_zero_or_more_left
   #b (a1 a2: array_group b)

--- a/src/cddl/spec/CDDL.Spec.MapGroup.fsti
+++ b/src/cddl/spec/CDDL.Spec.MapGroup.fsti
@@ -203,7 +203,7 @@ let map_group_footprint_concat
   (ensures (
     map_group_footprint (map_group_concat g1 g2) (map_constraint_choice f1 f2)
   ))
-  [SMTPat (map_group_footprint g1 f1); SMTPat (map_group_footprint g2 f2); SMTPat (map_group_concat g1 g2)]
+  [SMTPat (map_group_footprint (map_group_concat g1 g2) (map_constraint_choice f1 f2))]
 = bring_cbor_map_defined_alt ()
 
 #restart-solver
@@ -218,7 +218,7 @@ let map_group_footprint_choice
   (ensures (
     map_group_footprint (map_group_choice g1 g2) (map_constraint_choice f1 f2)
   ))
-  [SMTPat (map_group_footprint g1 f1); SMTPat (map_group_footprint g2 f2); SMTPat (map_group_choice g1 g2)]
+  [SMTPat (map_group_footprint (map_group_choice g1 g2) (map_constraint_choice f1 f2))]
 = bring_cbor_map_defined_alt ()
 
 #restart-solver


### PR DESCRIPTION
#272 only backported 02c6a8e6b3f9e2a86ec54d8d52f4d3e3e841837c from #270.

This PR backports the missing 94977971753b293c433f30e5ee889dac9b0f7997 and f38cf9438a2f56872813e5b91024b33693c84a6a.