### PR TITLE
Make filter patterns compatible with both relative and absolute paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,21 +51,21 @@ $(FSTAR_DEP_FILE): $(NEED_FSTAR) $(NEED_KRML)
 $(ALL_CHECKED_FILES): %.checked: $(NEED_FSTAR) $(NEED_Z3) $(NEED_KRML)
 
 ifeq (1,$(ADMIT_LOWPARSE))
-$(filter src/lowparse/%,$(ALL_CHECKED_FILES)): ADMIT := 1
+$(filter $(_EP)src/lowparse/%,$(ALL_CHECKED_FILES)): ADMIT := 1
 endif
 
 ifeq (1,$(ADMIT_CBOR_CDDL))
-$(filter src/cbor/% src/cddl/%,$(ALL_CHECKED_FILES)): ADMIT := 1
+$(filter $(_EP)src/cbor/% $(_EP)src/cddl/%,$(ALL_CHECKED_FILES)): ADMIT := 1
 endif
 
-LOWPARSE_FILES := $(filter-out src/lowparse/pulse/%,$(filter src/lowparse/%,$(ALL_CHECKED_FILES)))
-LOWPARSE_LOW_FILTER := src/lowparse/LowParse.SLow.% src/lowparse/LowParse.Low.% src/lowparse/LowParse.Repr.% src/lowparse/LowParse.Slice.% src/lowparse/LowParse.TestLib.%
+LOWPARSE_FILES := $(filter-out $(_EP)src/lowparse/pulse/%,$(filter $(_EP)src/lowparse/%,$(ALL_CHECKED_FILES)))
+LOWPARSE_LOW_FILTER := $(_EP)src/lowparse/LowParse.SLow.% $(_EP)src/lowparse/LowParse.Low.% $(_EP)src/lowparse/LowParse.Repr.% $(_EP)src/lowparse/LowParse.Slice.% $(_EP)src/lowparse/LowParse.TestLib.%
 # TODO: re-enable once Low* is gone
 # lowparse: $(LOWPARSE_FILES)
 lowparse: $(filter-out $(LOWPARSE_LOW_FILTER),$(LOWPARSE_FILES))
 
 ifeq (,$(NO_PULSE))
-lowparse: $(filter src/lowparse/pulse/%,$(ALL_CHECKED_FILES))
+lowparse: $(filter $(_EP)src/lowparse/pulse/%,$(ALL_CHECKED_FILES))
 endif
 
 # lowparse needed because of .fst behind .fsti for extraction
@@ -84,7 +84,7 @@ endif
 3d: 3d-prelude 3d-exe
 
 # filter-out comes from NOT_INCLUDED in src/ASN1/Makefile
-asn1: $(filter-out $(addprefix src/ASN1/,$(addsuffix .checked,ASN1.Tmp.fst ASN1.Test.Interpreter.fst ASN1.Low.% ASN1Test.fst ASN1.bak%)),$(filter src/ASN1/%,$(ALL_CHECKED_FILES)))
+asn1: $(filter-out $(addprefix $(_EP)src/ASN1/,$(addsuffix .checked,ASN1.Tmp.fst ASN1.Test.Interpreter.fst ASN1.Low.% ASN1Test.fst ASN1.bak%)),$(filter $(_EP)src/ASN1/%,$(ALL_CHECKED_FILES)))
 
 quackyducky: qd-exe lowparse
 
@@ -143,10 +143,10 @@ submodules:
 
 .PHONY: submodules
 
-cbor-interface: $(filter-out src/cbor/spec/raw/%,$(filter src/cbor/spec/%,$(ALL_CHECKED_FILES)))
+cbor-interface: $(filter-out $(_EP)src/cbor/spec/raw/%,$(filter $(_EP)src/cbor/spec/%,$(ALL_CHECKED_FILES)))
 
 ifeq (,$(NO_PULSE))
-cbor-interface: $(filter-out src/cbor/pulse/raw/%,$(filter src/cbor/pulse/%,$(ALL_CHECKED_FILES)))
+cbor-interface: $(filter-out $(_EP)src/cbor/pulse/raw/%,$(filter $(_EP)src/cbor/pulse/%,$(ALL_CHECKED_FILES)))
 endif
 
 .PHONY: cbor-interface
@@ -169,17 +169,17 @@ endif
 
 .PHONY: cbor-det-common-vertest
 
-cbor-verify: $(filter src/cbor/spec/%,$(ALL_CHECKED_FILES))
+cbor-verify: $(filter $(_EP)src/cbor/spec/%,$(ALL_CHECKED_FILES))
 
 ifeq (,$(NO_PULSE))
-cbor-verify: $(filter src/cbor/pulse/%,$(ALL_CHECKED_FILES))
+cbor-verify: $(filter $(_EP)src/cbor/pulse/%,$(ALL_CHECKED_FILES))
 endif
 
 .PHONY: cbor-verify
 
 # lowparse needed for extraction because of .fst files behind .fsti
 ifeq (,$(NO_PULSE))
-cbor-extract-pre: cbor-verify $(filter-out $(LOWPARSE_LOW_FILTER),$(filter src/lowparse/%,$(ALL_CHECKED_FILES)))
+cbor-extract-pre: cbor-verify $(filter-out $(LOWPARSE_LOW_FILTER),$(filter $(_EP)src/lowparse/%,$(ALL_CHECKED_FILES)))
 
 .PHONY: cbor-extract-pre
 
@@ -216,13 +216,13 @@ cbor-test-extracted: cbor-test-unverified cbor-test-verified
 
 cbor-test: cbor-test-extracted cbor-test-snapshot
 
-cddl-spec: $(filter src/cddl/spec/%,$(ALL_CHECKED_FILES))
+cddl-spec: $(filter $(_EP)src/cddl/spec/%,$(ALL_CHECKED_FILES))
 
 ifeq (,$(NO_PULSE))
-cddl-pulse: cddl-spec $(filter src/cddl/pulse/%,$(ALL_CHECKED_FILES))
+cddl-pulse: cddl-spec $(filter $(_EP)src/cddl/pulse/%,$(ALL_CHECKED_FILES))
 
 # cbor-extract-pre needed because Rust extraction extracts CBOR and COSE altogether
-cddl-tool: cddl-pulse $(filter src/cddl/tool/%,$(ALL_CHECKED_FILES)) cbor-extract-pre
+cddl-tool: cddl-pulse $(filter $(_EP)src/cddl/tool/%,$(ALL_CHECKED_FILES)) cbor-extract-pre
 	+$(MAKE) -C src/cddl/tool
 else
 cddl-tool:

--- a/src/3d/prelude/Makefile
+++ b/src/3d/prelude/Makefile
@@ -31,6 +31,9 @@ ifeq (,$(filter clean clean-buffer clean-extern,$(MAKECMDGOALS)))
 include .depend
 endif
 
+# Support both relative and absolute paths from fstar --dep full
+_EP := $(if $(filter /%,$(firstword $(ALL_CHECKED_FILES)) $(firstword $(ALL_KRML_FILES))),$(CURDIR)/,)
+
 buffer: EverParse.rsp
 	+$(MAKE) -C buffer
 
@@ -41,7 +44,7 @@ extract: EverParse.rsp
 
 verify: $(ALL_CHECKED_FILES)
 
-FILTERED_KRML_FILES=$(filter-out ResultOps.krml Actions.krml,$(ALL_KRML_FILES))
+FILTERED_KRML_FILES=$(filter-out $(_EP)ResultOps.krml $(_EP)Actions.krml,$(ALL_KRML_FILES))
 
 EverParse.rsp: $(FILTERED_KRML_FILES)
 	for f in $^ ; do echo $$f ; done > $@.tmp

--- a/src/3d/prelude/extern/Makefile
+++ b/src/3d/prelude/extern/Makefile
@@ -13,7 +13,7 @@ INCLUDE_PATHS += ..
 include $(EVERPARSE_SRC_PATH)/everparse.Makefile
 include $(EVERPARSE_SRC_PATH)/common.Makefile
 
-FILTERED_KRML_FILES=$(filter-out ResultOps.krml Actions.krml,$(ALL_KRML_FILES))
+FILTERED_KRML_FILES=$(filter-out $(_EP)ResultOps.krml $(_EP)Actions.krml,$(ALL_KRML_FILES))
 
 extract: extract-extern extract-static
 

--- a/src/common.Makefile
+++ b/src/common.Makefile
@@ -94,6 +94,11 @@ ifeq (,$(filter $(clean_rules) $(other_clean_rules),$(MAKECMDGOALS)))
 include $(FSTAR_DEP_FILE)
 endif
 
+# Support both relative and absolute paths from fstar --dep full.
+# If paths are absolute, _EP is set to $(CURDIR)/ so that filter
+# patterns like $(_EP)src/lowparse/% match both relative and absolute.
+_EP := $(if $(filter /%,$(firstword $(ALL_CHECKED_FILES)) $(firstword $(ALL_KRML_FILES))),$(CURDIR)/,)
+
 $(ALL_CHECKED_FILES): %.checked:
 	$(call msg, "CHECK", $(basename $(notdir $@)))
 	$(Q)$(RUNLIM) $(FSTAR) $(SIL) $(COMPAT_INDEXED_EFFECTS) $(if $(filter 1,$(ADMIT)),--admit_smt_queries true,) $<

--- a/src/lowparse/Makefile
+++ b/src/lowparse/Makefile
@@ -16,13 +16,13 @@ clean_rules += clean-pulse
 
 include $(EVERPARSE_SRC_PATH)/common.Makefile
 
-tot: $(filter LowParse.Tot.%,$(ALL_CHECKED_FILES))
+tot: $(filter $(_EP)LowParse.Tot.%,$(ALL_CHECKED_FILES))
 
-spec: $(filter LowParse.Spec.%,$(ALL_CHECKED_FILES))
+spec: $(filter $(_EP)LowParse.Spec.%,$(ALL_CHECKED_FILES))
 
-slow: $(filter LowParse.SLow.%,$(ALL_CHECKED_FILES))
+slow: $(filter $(_EP)LowParse.SLow.%,$(ALL_CHECKED_FILES))
 
-low: $(filter LowParse.Low.%,$(ALL_CHECKED_FILES))
+low: $(filter $(_EP)LowParse.Low.%,$(ALL_CHECKED_FILES))
 
 .PHONY: tot spec slow low
 

--- a/tests/bitfields/Makefile
+++ b/tests/bitfields/Makefile
@@ -12,6 +12,9 @@ krml/%.krml:
 
 -include .depend
 
+# Support both relative and absolute paths from fstar --dep full
+_EP := $(if $(filter /%,$(firstword $(ALL_CHECKED_FILES)) $(firstword $(ALL_KRML_FILES))),$(CURDIR)/,)
+
 .qd_files: $(QD_FILES)
 	+$(MAKE) -f Makefile.qd_files
 
@@ -25,7 +28,7 @@ depend: .depend
 verify: $(patsubst %,cache/%.checked,$(QD_FILES))
 	echo $*
 
-ALL_KRML_FILES := $(filter-out krml/prims.krml,$(ALL_KRML_FILES))
+ALL_KRML_FILES := $(filter-out $(_EP)krml/prims.krml,$(ALL_KRML_FILES))
 
 extract: $(ALL_KRML_FILES) # from .depend
 	mkdir -p out

--- a/tests/lowparse/Makefile
+++ b/tests/lowparse/Makefile
@@ -41,7 +41,7 @@ EXAMPLES=Example Example2 Example3 Example5 Example6 Example7 Example8 Example9 
 NOEXTRACT_EXAMPLES=ExamplePair
 ROOT_FILES=$(addprefix LowParse, $(addsuffix .fst, $(EXAMPLES)))
 
-EXCLUDE_KRML_FILES=$(FSTAR_OUT_DIR)/prims.krml
+EXCLUDE_KRML_FILES=$(_EP)$(FSTAR_OUT_DIR)/prims.krml
 
 EXAMPLE_DEPEND_FILES=$(addsuffix .depend,$(EXAMPLES))
 
@@ -64,6 +64,9 @@ clean:
 ifeq (,$(filter clean,$(MAKECMDGOALS)))
 include .depend
 endif
+
+# Support both relative and absolute paths from fstar --dep full
+_EP := $(if $(filter /%,$(firstword $(ALL_CHECKED_FILES)) $(firstword $(ALL_KRML_FILES))),$(CURDIR)/,)
 
 verify-all: $(ALL_CHECKED_FILES)
 

--- a/tests/sample/Makefile
+++ b/tests/sample/Makefile
@@ -16,6 +16,9 @@ krml/%.krml:
 
 -include .depend
 
+# Support both relative and absolute paths from fstar --dep full
+_EP := $(if $(filter /%,$(firstword $(ALL_CHECKED_FILES)) $(firstword $(ALL_KRML_FILES))),$(CURDIR)/,)
+
 ifeq (,$(filter clean,$(MAKECMDGOALS)))
 .depend: $(QD_FILES) .qd_files
 	+$(MAKE) -f Makefile.depend
@@ -26,7 +29,7 @@ depend: .depend
 verify: $(patsubst %,cache/%.checked,$(QD_FILES))
 	echo $*
 
-ALL_KRML_FILES := $(filter-out krml/prims.krml,$(ALL_KRML_FILES))
+ALL_KRML_FILES := $(filter-out $(_EP)krml/prims.krml,$(ALL_KRML_FILES))
 
 extract: $(ALL_KRML_FILES) # from .depend
 	mkdir -p out

--- a/tests/sample0/Makefile
+++ b/tests/sample0/Makefile
@@ -14,6 +14,9 @@ ifeq (,$(filter clean,$(MAKECMDGOALS)))
 -include .depend
 endif
 
+# Support both relative and absolute paths from fstar --dep full
+_EP := $(if $(filter /%,$(firstword $(ALL_CHECKED_FILES)) $(firstword $(ALL_KRML_FILES))),$(CURDIR)/,)
+
 .depend: $(QD_FILES) .qd_files
 	+$(MAKE) -f Makefile.depend
 
@@ -22,7 +25,7 @@ depend: .depend
 verify: $(patsubst %,cache/%.checked,$(QD_FILES))
 	echo $*
 
-ALL_KRML_FILES := $(filter-out krml/prims.krml,$(ALL_KRML_FILES))
+ALL_KRML_FILES := $(filter-out $(_EP)krml/prims.krml,$(ALL_KRML_FILES))
 
 extract: $(ALL_KRML_FILES) # from .depend
 	mkdir -p out

--- a/tests/sample_low/Makefile
+++ b/tests/sample_low/Makefile
@@ -16,6 +16,9 @@ krml/%.krml:
 
 -include .depend
 
+# Support both relative and absolute paths from fstar --dep full
+_EP := $(if $(filter /%,$(firstword $(ALL_CHECKED_FILES)) $(firstword $(ALL_KRML_FILES))),$(CURDIR)/,)
+
 ifeq (,$(filter clean,$(MAKECMDGOALS)))
 .depend: $(QD_FILES) .qd_files
 	+$(MAKE) -f Makefile.depend
@@ -26,7 +29,7 @@ depend: .depend
 verify: $(patsubst %,cache/%.checked,$(QD_FILES))
 	echo $*
 
-ALL_KRML_FILES := $(filter-out krml/prims.krml,$(ALL_KRML_FILES))
+ALL_KRML_FILES := $(filter-out $(_EP)krml/prims.krml,$(ALL_KRML_FILES))
 
 extract: $(ALL_KRML_FILES) # from .depend
 	mkdir -p out

--- a/tests/unit.Makefile
+++ b/tests/unit.Makefile
@@ -69,6 +69,9 @@ depend: $(DEPEND_FILE)
 
 -include $(DEPEND_FILE)
 
+# Support both relative and absolute paths from fstar --dep full
+_EP := $(if $(filter /%,$(firstword $(ALL_CHECKED_FILES)) $(firstword $(ALL_KRML_FILES))),$(CURDIR)/,)
+
 ifdef NO_QD_VERIFY
 verify:
 else
@@ -76,7 +79,7 @@ verify: $(patsubst %,$(CACHE_DIR)/%$(CHECKED_EXT),$(QD_FILES))
 	echo $*
 endif
 
-ALL_KRML_FILES := $(filter-out krml/prims.krml,$(ALL_KRML_FILES))
+ALL_KRML_FILES := $(filter-out $(_EP)krml/prims.krml,$(ALL_KRML_FILES))
 
 extract: $(ALL_KRML_FILES) # from .depend
 	-@mkdir out


### PR DESCRIPTION
fstar --dep full now generates absolute paths in .depend files. This breaks `$(filter src/X/%,...)` patterns in EverParse Makefiles since they assume relative paths.

Fix: introduce `_EP` (EverParse Path prefix) variable that auto-detects whether `.depend` uses absolute or relative paths. If absolute, `_EP` is set to `$(CURDIR)/` so that patterns like `$(_EP)src/lowparse/%` match both formats. If relative, `_EP` is empty (backward compatible).

Updated 11 Makefiles across the build system.