### PR TITLE
COSE tests: pin cbor2<6 to fix pycose message decoding

### DIFF
--- a/src/cose/Makefile
+++ b/src/cose/Makefile
@@ -54,7 +54,7 @@ test-extract-rust: extract-krml-rust
 .venv:
 	rm -rf $@ $@.tmp
 	python3 -m venv $@.tmp
-	$@.tmp/bin/python3 -m pip install pycose
+	$@.tmp/bin/python3 -m pip install pycose 'cbor2<6'
 	mv $@.tmp $@
 
 .PHONY: test-interop


### PR DESCRIPTION
cbor2 6.0 decodes CBOR arrays as tuples instead of lists, which breaks pycose's isinstance(value, list) check in Sign1Message.decode().

See full error report at TimothyClaeys/pycose#141