### PR TITLE
Carry validated length in size_t not uint8_t in CBOR c example (documentation)

### DIFF
--- a/src/cbor/pulse/det/c/example/main.c
+++ b/src/cbor/pulse/det/c/example/main.c
@@ -227,7 +227,7 @@ int main(void) {
      space.
   */
   // success
-  uint8_t validated_size = cbor_det_validate(output, output_size);
+  size_t validated_size = cbor_det_validate(output, output_size);
   assert (validated_size == cbor5_size);
   // failure: see RFC 8949, Section 3.3
   output_fail[0] = 0xf8u;


### PR DESCRIPTION
Classified as a documentation issue in prior correspondence with Everparse team.

The [CBOR c example](https://github.com/project-everest/everparse/blob/6b04a113db180e703d19f77ff1235500e6336c71/src/cbor/pulse/det/c/example/main.c) stores the `size_t` result of `cbor_det_validate` in `uint8_t validated_size` (ln. 230). For objects with an encoded length of 256 or more this truncates the value, so the length passed to `cbor_det_parse` is no longer the validated length.