### PR TITLE
Backport selected `fstar2`-branch changes to `master` (fstar1-compatible subset)

### DIFF
--- a/share/everparse/tests/lowparse/LowParseExample11.fst
+++ b/share/everparse/tests/lowparse/LowParseExample11.fst
@@ -34,6 +34,7 @@ type elem = U32.t
 type t = (l: list elem { let ln = L.length l in 10 <= ln /\ ln <= 1000 })
 
 inline_for_extraction
+noextract
 let parse_t_kind : parser_kind = strong_parser_kind 11 5005 None
 
 let parse_t' = parse_vclist 10 1000 parse_bcvli parse_bcvli

--- a/share/everparse/tests/lowparse/LowParseExample12.fst
+++ b/share/everparse/tests/lowparse/LowParseExample12.fst
@@ -26,9 +26,11 @@ module I32 = FStar.Int32
 module U8 = FStar.UInt8
 
 inline_for_extraction
+noextract
 type t = parse_bounded_vlbytes_t 0 512
 
 inline_for_extraction
+noextract
 let parse_t_kind : parser_kind = strong_parser_kind 3 517 None
 
 let parse_t' = parse_vlgen 0 1023 (parse_bounded_der_length32 0 1023) (serialize_bounded_vlbytes 0 512)

--- a/share/everparse/tests/lowparse/LowParseExample2.fst
+++ b/share/everparse/tests/lowparse/LowParseExample2.fst
@@ -60,7 +60,7 @@ let serialize_t_spec : serializer parse_t_spec =
     synth_t_recip
     ()
 
-let t'_l_serializable (x: list t) : GTot Type0 =
+let t'_l_serializable (x: list t) : GTot prop =
   parse_bounded_vldata_strong_pred 0 255 (serialize_list _ serialize_t_spec) x
 
 inline_for_extraction

--- a/share/everparse/tests/lowparse/LowParseExample7.Aux.fst
+++ b/share/everparse/tests/lowparse/LowParseExample7.Aux.fst
@@ -16,7 +16,7 @@ type binders = LP.parse_bounded_vlbytes_t 0 65535
 let parse_binders : LP.parser _ binders = LP.parse_bounded_vlbytes 0 65535
 let serialize_binders: LP.serializer parse_binders = LP.serialize_bounded_vlbytes 0 65535
 
-type pre_shared_key_extension = (U32.t * binders)
+type pre_shared_key_extension = (U32.t & binders)
 let parse_pre_shared_key_extension : LP.parser _ pre_shared_key_extension = LP.nondep_then LP.parse_u32 parse_binders
 let serialize_pre_shared_key_extension : LP.serializer parse_pre_shared_key_extension = LP.serialize_nondep_then LP.serialize_u32 serialize_binders
 
@@ -24,7 +24,7 @@ type extension_type = | PreSharedKeyExtension_t
 
 inline_for_extraction
 let extension_enum : LP.enum extension_type U32.t =
-  let l : list (extension_type * U32.t) = [
+  let l : list (extension_type & U32.t) = [
     PreSharedKeyExtension_t, 18ul;
   ]
   in

--- a/share/everparse/tests/lowparse/LowParseExample8.Aux.fst
+++ b/share/everparse/tests/lowparse/LowParseExample8.Aux.fst
@@ -39,7 +39,7 @@ let u8 : eqtype = U8.t
 inline_for_extraction
 let k_enum : enum k_t u8 =
   [@inline_let]
-  let e : list (k_t * U8.t) = [
+  let e : list (k_t & U8.t) = [
     Ka, 18uy;
     Kb, 42uy;
   ]

--- a/src/3d/Ast.fst
+++ b/src/3d/Ast.fst
@@ -47,7 +47,7 @@ type comments_buffer_t = {
 
 #push-options "--warn_error -272" //top-level effect; ok
 let comments_buffer : comments_buffer_t =
-  let buffer : ref (list (string & pos & pos)) = FStar.ST.alloc [] in
+  let buffer : ref (list (string & pos & pos)) = alloc [] in
   let buffer_comment (c, s, p) =
     let c = String.substring c 2 (String.length c - 2) in
     buffer := (c, s, p) :: !buffer

--- a/src/3d/Ast.fst
+++ b/src/3d/Ast.fst
@@ -83,7 +83,7 @@ let string_of_pos p =
 
 /// range: A source extent
 [@@ PpxDerivingYoJson ]
-let range = pos * pos
+let range = pos & pos
 
 /// comment: A list of line comments, i.e., a list of strings
 let comments = list string
@@ -166,7 +166,7 @@ type integer_type =
 [@@ PpxDerivingYoJson ]
 let pointer_size_t = i:integer_type { i == UInt32 \/ i == UInt64 }
 
-let parse_int_suffix (i:string) : string * option integer_type =
+let parse_int_suffix (i:string) : string & option integer_type =
     let l = String.length i in
     if l >= 2
     then let suffix = String.sub i (l - 2) 2 in
@@ -767,7 +767,7 @@ let decl_with_v (d:decl) (v:decl') : decl =
 noeq
 type type_refinement = {
   includes:list string;
-  type_map:list (ident * option ident);
+  type_map:list (ident & option ident);
   auto_type_map: list (ident & option ident); //map from type to its auto-generated type
 }
 
@@ -1548,7 +1548,7 @@ let map_opt (f:'a -> ML 'b) (o:option 'a) : ML (option 'b) =
 ////////////////////////////////////////////////////////////////////////////////
 module H = Hashtable
 let subst = H.t ident' expr
-let mk_subst (s:list (ident * expr)) : ML subst =
+let mk_subst (s:list (ident & expr)) : ML subst =
   let h = H.create 10 in
   List.iter (fun (i, e) -> H.insert h i.v e) s;
   h

--- a/src/3d/Binding.fst
+++ b/src/3d/Binding.fst
@@ -1907,9 +1907,9 @@ let rec check_field (env:env) (f:field)
  *)
 let elaborate_bit_fields env (fields:list field)
   : ML (out:list field { List.length out == List.length fields })
-  = let bf_index : ref int = ST.alloc 0 in
-    let get_bf_index () = !bf_index in
-    let next_bf_index () = bf_index := !bf_index + 1 in
+  = let bf_index : ref int = alloc 0 in
+    let get_bf_index () : ML _ = !bf_index in
+    let next_bf_index () : ML _ = bf_index := !bf_index + 1 in
     let new_bit_field (sf:atomic_field') bw r : ML (atomic_field & option (int & typ & int & int)) =
         let index = get_bf_index () in
         let size = size_of_integral_typ env sf.field_type r in
@@ -1964,7 +1964,7 @@ let elaborate_bit_fields env (fields:list field)
 
          | AtomicField af ->
            let sf = af.v in
-           let check_new_bf bf =
+           let check_new_bf bf : ML _ =
              if bf.v.bitfield_from <> 0
              then error ("Bitfield must start at position 0")
                         bf.range

--- a/src/3d/Deps.fst
+++ b/src/3d/Deps.fst
@@ -361,7 +361,7 @@ let has_extern_probe g m = List.Tot.mem m g.modules_with_extern_probe
 
 
 #push-options "--warn_error -272"
-let parsed_config : ref (option (Config.config & string)) = ST.alloc None
+let parsed_config : ref (option (Config.config & string)) = alloc None
 #pop-options
 
 let parse_config () =

--- a/src/3d/Getopt.fsti
+++ b/src/3d/Getopt.fsti
@@ -14,7 +14,7 @@
    limitations under the License.
 *)
 module Getopt
-open FStar.ST
+
 open FStar.All
 open FStar.Char
 

--- a/src/3d/Getopt.fsti
+++ b/src/3d/Getopt.fsti
@@ -23,9 +23,9 @@ val nolong : string
 noeq
 type opt_variant 'a =
   | ZeroArgs of (unit -> ML 'a)
-  | OneArg of (string -> ML 'a) * string
+  | OneArg of (string -> ML 'a) & string
 
-type opt' 'a = char * string * opt_variant 'a
+type opt' 'a = char & string & opt_variant 'a
 type opt = opt' unit
 
 type parse_cmdline_res =

--- a/src/3d/Main.fst
+++ b/src/3d/Main.fst
@@ -1,10 +1,10 @@
 module Main
+
 open FStar.IO
 open FStar.All
 open Ast
 open ParserDriver
 module T = Target
-open FStar.ST
 #push-options "--z3rlimit_factor 2"
 
 let open_write_file (s:string) : ML FStar.IO.fd_write =

--- a/src/3d/Options.fst
+++ b/src/3d/Options.fst
@@ -1,7 +1,7 @@
 module Options
 open HashingOptions
 open FStar.All
-open FStar.ST
+
 module U8 = FStar.UInt8
 module OS = OS
 open Utils
@@ -515,8 +515,8 @@ let get_skip_o_rules _ =
 let get_json () =
   !json
 
-let get_input_stream_binding _ =
-  let get_include () =
+let get_input_stream_binding () : ML input_stream_binding_t =
+  let get_include () : ML string =
     match !input_stream_include with
     | None -> ""
     | Some s -> s

--- a/src/3d/StaticAssertions.fst
+++ b/src/3d/StaticAssertions.fst
@@ -64,7 +64,7 @@ let compute_static_asserts_aux
       (benv:B.global_env)
       (senv:TypeSizes.size_env)
       (includes:list string)
-      (type_map: list (ident * option ident))
+      (type_map: list (ident & option ident))
   : ML static_asserts
   = let env = B.mk_env benv, senv in
     let static_assertions =

--- a/src/3d/Target.fsti
+++ b/src/3d/Target.fsti
@@ -59,7 +59,7 @@ type expr' =
   | Constant   : c:A.constant -> expr'
   | Identifier : i:A.ident -> expr'
   | App        : hd:op -> args:list expr -> expr'
-  | Record     : type_name:A.ident -> list (A.ident * expr) -> expr'
+  | Record     : type_name:A.ident -> list (A.ident & expr) -> expr'
 
 and expr = expr' & A.range
 
@@ -340,9 +340,9 @@ type type_decl = {
   decl_is_enum : bool
 }
 
-let definition = A.ident * list param * typ * expr
+let definition = A.ident & list param & typ & expr
 
-let assumption = A.ident * typ
+let assumption = A.ident & typ
 
 type decl_attributes = {
   is_hoisted: bool;
@@ -402,7 +402,7 @@ type decl' =
   | Extern_fn : A.ident -> typ -> list param -> pure:bool -> decl'
   | Extern_probe : A.ident -> probe_qualifier -> decl'
 
-type decl = decl' * decl_attributes
+type decl = decl' & decl_attributes
 
 type decls = list decl
 val has_output_types (ds:list decl) : bool

--- a/src/3d/TranslateForInterpreter.fst
+++ b/src/3d/TranslateForInterpreter.fst
@@ -78,10 +78,9 @@ let add_parser_kind_is_constant_size (genv:global_env) (id:A.ident) (is_constant
 
 /// gensym (top-level effect, safe to ignore)
 #push-options "--warn_error -272"
-let gen_ident : option string -> St ident =
-  let open FStar.ST in
+let gen_ident : option string -> ML ident =
   let ctr : ref int = alloc 0 in
-  let next base_name_opt =
+  let next base_name_opt : ML _ =
     let v = !ctr in
     ctr := v + 1;
     let id =

--- a/src/3d/TranslateForInterpreter.fst
+++ b/src/3d/TranslateForInterpreter.fst
@@ -1049,7 +1049,7 @@ let make_tdn (i:A.ident) (attrs:list A.attribute) =
     typedef_attributes = attrs
   }
 
-let env_t = list (A.ident * T.typ)
+let env_t = list (A.ident & T.typ)
 
 let check_in_global_env (env:global_env) (i:A.ident) =
   let _ = B.lookup_expr_name (B.mk_env env.benv) i in ()
@@ -1249,7 +1249,7 @@ let hoist_field (genv:global_env) (env:env_t) (tdn:T.typedef_name) (f:T.field)
       d@[td], f
 
 let hoist_refinements (genv:global_env) (tdn:T.typedef_name) (fields:list T.field)
-  : ML (list T.decl * list T.field)
+  : ML (list T.decl & list T.field)
   = let hoist_one_field edf (f:T.field)
         : ML _ =
         let open T in

--- a/src/3d/prelude/EverParse3d.Interpreter.fst
+++ b/src/3d/prelude/EverParse3d.Interpreter.fst
@@ -1354,7 +1354,7 @@ let rec as_validator
       A.validate_with_error_handler typename fn (A.validate_eta (dtyp_as_validator td))
 
     | T_pair fn k1_const t1 k2_const t2 ->
-      assert_norm (as_type (T_pair fn k1_const t1 k2_const t2) == as_type t1 * as_type t2);
+      assert_norm (as_type (T_pair fn k1_const t1 k2_const t2) == as_type t1 & as_type t2);
       assert_norm (as_parser (T_pair fn k1_const t1 k2_const t2) == P.parse_pair (as_parser t1) (as_parser t2));
       A.validate_pair fn
           k1_const

--- a/src/3d/prelude/EverParse3d.Prelude.fsti
+++ b/src/3d/prelude/EverParse3d.Prelude.fsti
@@ -70,7 +70,7 @@ val parse_dep_pair (#nz1:_) (#k1:parser_kind nz1 WeakKindStrongPrefix) (#t1: Typ
 inline_for_extraction noextract
 val parse_pair (#nz1:_) (#k1:parser_kind nz1 WeakKindStrongPrefix) (#t1:_) (p1:parser k1 t1)
                (#nz2:_) (#wk2: _) (#k2:parser_kind nz2 wk2) (#t2:_) (p2:parser k2 t2)
-  : Tot (parser (and_then_kind k1 k2) (t1 * t2))
+  : Tot (parser (and_then_kind k1 k2) (t1 & t2))
 
 /// Parser: filter
 let refine t (f:t -> bool) = x:t{f x}

--- a/src/ASN1/ASN1.Base.fst
+++ b/src/ASN1/ASN1.Base.fst
@@ -163,7 +163,7 @@ and asn1_sequence_k_wf (li : id_decs) : Type =
 
 let my_as_set l = Set.as_set l
 
-let proj2_of_3 (#a #b : Type) (#c : a -> b -> Type) (x : dtuple3 a (fun _ -> b) c) : a * b = 
+let proj2_of_3 (#a #b : Type) (#c : a -> b -> Type) (x : dtuple3 a (fun _ -> b) c) : a & b = 
   let (| xa, xb, _ |) = x in (xa, xb)
 
 let rec asn1_any_prefix_k_wf' (ks : Set.set asn1_id_t) (li : id_decs) (s : Set.set asn1_id_t) : Type =
@@ -199,7 +199,7 @@ type asn1_content_k : Type =
              prefix:asn1_gen_items_l id_decs_prefix ->
              id : asn1_id_t ->
              key_k : asn1_terminal_k ->
-             supported : list (asn1_terminal_t key_k * asn1_gen_items_lk) -> 
+             supported : list (asn1_terminal_t key_k & asn1_gen_items_lk) -> 
              fallback : option asn1_gen_items_lk ->
              pf_wf : squash (asn1_any_prefix_k_wf (Set.singleton id) id_decs_prefix) ->
              pf_sup : squash (List.noRepeats (List.map fst supported)) -> 
@@ -342,7 +342,7 @@ let rec asn1_content_t (k : asn1_content_k) : Tot Type (decreases k) =
       | Some fb -> make_gen_choice_type_with_fallback (asn1_any_t_core (asn1_terminal_t key_k) ls) (asn1_sequence_t_core (dsnd fb))) in
     asn1_sequence_any_t_core prefix suffix_t
 
-and asn1_any_t_core (t : eqtype) (ls : list (t * asn1_gen_items_lk)) : Tot (list (t & Type)) (decreases ls) =
+and asn1_any_t_core (t : eqtype) (ls : list (t & asn1_gen_items_lk)) : Tot (list (t & Type)) (decreases ls) =
   match ls with
   | [] -> [] 
   | h :: tl -> 
@@ -414,7 +414,7 @@ let rec asn1_sequence_t_core_equiv' (items:list asn1_gen_item_k)
     | hd::tl -> asn1_sequence_t_core_equiv' tl
 
 
-let rec asn1_any_t (t : eqtype) (ls : list (t * asn1_gen_items_k)) : Tot (list (t & Type)) (decreases ls) =
+let rec asn1_any_t (t : eqtype) (ls : list (t & asn1_gen_items_k)) : Tot (list (t & Type)) (decreases ls) =
   match ls with
   | [] -> [] 
   | h :: tl -> 

--- a/src/ASN1/ASN1.Spec.Automata.fst
+++ b/src/ASN1/ASN1.Spec.Automata.fst
@@ -58,10 +58,10 @@ noeq
 type automata_data_param (cp : automata_control_param) = {
   ret_t : eqtype;
   partial_t : eqtype;
-  pre_t : cp.control_t -> partial_t -> Type0;
+  pre_t : cp.control_t -> partial_t -> prop;
   post_t : (s : cp.control_t) -> 
            (data : partial_t {pre_t s data}) ->
-           ret_t -> Type0;
+           ret_t -> prop;
   update_term : (s : cp.control_t) ->
                 (data : partial_t {pre_t s data}) ->
                 (ch : cp.ch_t {cp.fail_check s ch = false /\ cp.termination_check s ch = true}) ->
@@ -110,8 +110,8 @@ type automata_bare_parser_param (cp : automata_control_param) = {
 
 let id_cast
   (t : eqtype)
-  (p1 : t -> Type0)
-  (p2 : t -> Type0)
+  (p1 : t -> prop)
+  (p2 : t -> prop)
   (lem : (x : t -> (Lemma (requires p1 x) (ensures p2 x))))
   (x : t {p1 x})
 : (x' : t {p2 x'})
@@ -200,11 +200,11 @@ type automata_parser_param (cp : automata_control_param) (dp : automata_data_par
 let and_then_cases_injective_dep_precond
   (#t:Type)
   (#t': Type)
-  (gt : t -> t' -> Type0)
+  (gt : t -> t' -> prop)
   (p': ((x : t) -> Tot (bare_parser (y : t' {gt x y}))))
   (x1 x2: t)
   (b1 b2: bytes)
-: GTot Type0
+: GTot prop
 = Some? (parse (p' x1) b1) /\
   Some? (parse (p' x2) b2) /\ (
     let (Some (v1, _)) = parse (p' x1) b1 in
@@ -215,9 +215,9 @@ let and_then_cases_injective_dep_precond
 let and_then_cases_injective_dep
   (#t : Type)
   (#t' : Type)
-  (gt : t -> t' -> Type0)
+  (gt : t -> t' -> prop)
   (p': ((m : t) -> Tot (bare_parser (x : t' {gt m x}))))
-: GTot Type0
+: GTot prop
 = forall (x1 x2: t) (b1 b2: bytes) . {:pattern (parse (p' x1) b1); (parse (p' x2) b2)}
   and_then_cases_injective_dep_precond gt p' x1 x2 b1 b2 ==>
   x1 == x2
@@ -225,7 +225,7 @@ let and_then_cases_injective_dep
 let and_then_cases_injective_dep_intro
   (#t : Type)
   (#t': Type)
-  (gt : t -> t' -> Type0)
+  (gt : t -> t' -> prop)
   (p': ((x : t) -> Tot (bare_parser (y : t' {gt x y}))))
   (lem: (
     (x1: t) -> 

--- a/src/ASN1/ASN1.Spec.Automata.fst
+++ b/src/ASN1/ASN1.Spec.Automata.fst
@@ -125,7 +125,7 @@ let rec automata_bare_parser'
   (s : cp.control_t)
   (data : dp.partial_t {dp.pre_t s data})
   (b : bytes)
-: Tot (option ((ret : dp.ret_t {dp.post_t s data ret}) * (consumed_length b)))
+: Tot (option ((ret : dp.ret_t {dp.post_t s data ret}) & (consumed_length b)))
   (decreases (Seq.length b))
 = match (bp.ch_t_bare_parser b) with
   | None -> None

--- a/src/ASN1/ASN1.Spec.Choice.fst
+++ b/src/ASN1/ASN1.Spec.Choice.fst
@@ -92,7 +92,7 @@ let make_gen_choice_strong_parser
 = parse_tagged_union p (tag_of_gen_choice_type (extract_types lc)) (make_gen_choice_strong_payload_parser lc)
 
 let make_asn1_choice_parser
-  (lc : list (asn1_id_t * asn1_content_k))
+  (lc : list (asn1_id_t & asn1_content_k))
   (pf : squash (List.noRepeats (List.map fst lc)))
   (#s : _)
   (k : asn1_k s)
@@ -104,7 +104,7 @@ let make_asn1_choice_parser
 = weaken asn1_strong_parser_kind (make_gen_choice_strong_parser parse_asn1_identifier_U32 lp)
 
 let make_asn1_choice_parser_twin
-  (lc : list (asn1_id_t * asn1_content_k))
+  (lc : list (asn1_id_t & asn1_content_k))
   (pf : squash (List.noRepeats (List.map fst lc)))
   (#s : _)
   (k : asn1_k s)
@@ -117,7 +117,7 @@ let make_asn1_choice_parser_twin
 = parse_tagged_union_payload (project_tags lp) (make_gen_choice_strong_payload_parser lp) id'
 
 let make_asn1_choice_parser_twin_cases_injective
-  (lc : list (asn1_id_t * asn1_content_k))
+  (lc : list (asn1_id_t & asn1_content_k))
   (pf : squash (List.noRepeats (List.map fst lc)))
   (#s : _)
   (k : asn1_k s)

--- a/src/ASN1/ASN1.Spec.Content.UTF8STRING.fst
+++ b/src/ASN1/ASN1.Spec.Content.UTF8STRING.fst
@@ -83,14 +83,14 @@ let ret_t = utf8_cp_t
 
 let partial_t = U32.t
   
-let pre_t (s : utf8_cp_s) : partial_t -> Type0 =
+let pre_t (s : utf8_cp_s) : partial_t -> prop =
   match s with
   | S1 -> (fun data -> 1 < U32.v data /\ U32.v data < pow2 15)
   | S2 -> (fun data -> 0 < U32.v data /\ U32.v data < pow2 9)
   | S3 -> (fun data -> 0 < U32.v data /\ U32.v data < pow2 3)
   | S2' | S3' | Init -> (fun data -> U32.v data = 0)
 
-let post_t (s : utf8_cp_s) (data : partial_t {pre_t s data}) : ret_t -> Type0 =
+let post_t (s : utf8_cp_s) (data : partial_t {pre_t s data}) : ret_t -> prop =
   match s with
   | S1 -> (fun ret -> U32.v data * (pow2 6) <= U32.v ret /\ U32.v ret < (U32.v data + 1) * (pow2 6))
   | S2 -> (fun ret -> U32.v data * (pow2 12) <= U32.v ret /\ U32.v ret < (U32.v data + 1) * (pow2 12))

--- a/src/ASN1/ASN1.Spec.IdentifierU32.fst
+++ b/src/ASN1/ASN1.Spec.IdentifierU32.fst
@@ -270,8 +270,8 @@ let parse_asn1_identifier_loop_immediate_terminate
 
 let parse_cast
   (t : eqtype)
-  (p1 : t -> Type0)
-  (p2 : t -> Type0)
+  (p1 : t -> prop)
+  (p2 : t -> prop)
   (lem : (x : t -> (Lemma (p1 x ==> p2 x))))
   (#k : parser_kind)
   (p : parser k (x: t {p1 x}))
@@ -285,8 +285,8 @@ let parse_cast
 
 let parse_cast_inverse
   (t : eqtype)
-  (p1 : t -> Type0)
-  (p2 : t -> Type0)
+  (p1 : t -> prop)
+  (p2 : t -> prop)
   (lem : (x : t -> (Lemma (p1 x ==> p2 x))))
   (#k : parser_kind)
   (p : parser k (x : t {p1 x}))

--- a/src/ASN1/ASN1.Spec.Interpreter.fst
+++ b/src/ASN1/ASN1.Spec.Interpreter.fst
@@ -144,7 +144,7 @@ and dasn1_content_as_parser (k : asn1_content_k) : Tot (asn1_weak_parser (asn1_c
       in
       make_asn1_sequence_any_parser itemtwins suffix_p_twin) 
 
-and dasn1_ls_as_parser (t : eqtype) (ls : list (t * asn1_gen_items_lk)) : Tot (lp : list (t & (gen_parser asn1_weak_parser_kind)) {asn1_any_t_core t ls == extract_types lp}) (decreases ls) =
+and dasn1_ls_as_parser (t : eqtype) (ls : list (t & asn1_gen_items_lk)) : Tot (lp : list (t & (gen_parser asn1_weak_parser_kind)) {asn1_any_t_core t ls == extract_types lp}) (decreases ls) =
   match ls with
   | [] -> [] 
   | h :: tl -> 
@@ -259,7 +259,7 @@ and asn1_content_as_parser (k : asn1_content_k) : Tot (asn1_weak_parser (asn1_co
       in
       make_asn1_sequence_any_parser itemtwins suffix_p_twin) 
 
-and asn1_ls_as_parser (t : eqtype) (ls : list (t * asn1_gen_items_lk)) : Tot (lp : list (t & (gen_parser asn1_weak_parser_kind)) {asn1_any_t_core t ls == extract_types lp}) (decreases ls) =
+and asn1_ls_as_parser (t : eqtype) (ls : list (t & asn1_gen_items_lk)) : Tot (lp : list (t & (gen_parser asn1_weak_parser_kind)) {asn1_any_t_core t ls == extract_types lp}) (decreases ls) =
   match ls with
   | [] -> [] 
   | h :: tl -> 

--- a/src/ASN1/ASN1.Spec.Sequence.fst
+++ b/src/ASN1/ASN1.Spec.Sequence.fst
@@ -101,7 +101,7 @@ let and_then_cases_injective_some
   (#t: Type)
   (#t' : Type)
   (p': (option t -> Tot (bare_parser t')))
-: GTot Type0
+: GTot prop
 = forall (x1 x2: option t) (b1 b2: bytes) . {:pattern (parse (p' x1) b1); (parse (p' x2) b2)}
   and_then_cases_injective_precond p' x1 x2 b1 b2 /\ Some? x1 /\ Some? x2 ==>
   x1 == x2

--- a/src/ASN1/ASN1.Syntax.fst
+++ b/src/ASN1/ASN1.Syntax.fst
@@ -50,14 +50,14 @@ let mk_retagged (id : asn1_id_t) (#s) (x : asn1_k s {is_ILC x})
 let op_Star_Hat (name : string) (#t) (x : t)
 = x
 
-let op_Hat_Star (name : string) (#s) (x : asn1_k s {is_ILC x}) : (asn1_id_t * asn1_content_k)
+let op_Hat_Star (name : string) (#s) (x : asn1_k s {is_ILC x}) : (asn1_id_t & asn1_content_k)
 = match x with
   | ASN1_ILC id c -> (id, c)
 
 noextract
 let choice_tac () = T.norm [iota;zeta;delta;primops]; T.trefl () 
 
-let asn1_choice (ls : list (asn1_id_t * asn1_content_k)) (pf : squash (List.noRepeats (List.map fst ls) ))
+let asn1_choice (ls : list (asn1_id_t & asn1_content_k)) (pf : squash (List.noRepeats (List.map fst ls) ))
 = ASN1_CHOICE_ILC ls pf
 
 // for sequences
@@ -190,21 +190,21 @@ let asn1_any = ASN1_ANY_ILC
 let asn1_any_oid_prefix
   (prefix : list asn1_gen_item_k)
   (name : string)
-  (supported : list (asn1_oid_t * asn1_gen_items_lk)) 
+  (supported : list (asn1_oid_t & asn1_gen_items_lk)) 
   (pf_wf : squash (asn1_any_prefix_k_wf (Set.singleton oid_id) (List.map proj2_of_3 prefix)))
   (pf_sup : squash (List.noRepeats (List.map fst supported)))
 = ASN1_ILC sequence_id (ASN1_ANY_DEFINED_BY _ (list_as_l prefix) oid_id ASN1_OID supported None pf_wf pf_sup)
 
 let asn1_any_oid
   (name : string)
-  (supported : list (asn1_oid_t * asn1_gen_items_lk)) 
+  (supported : list (asn1_oid_t & asn1_gen_items_lk)) 
   (pf_wf : squash (asn1_any_prefix_k_wf (Set.singleton oid_id) (List.map proj2_of_3 [])))
   (pf_sup : squash (List.noRepeats (List.map fst supported)))
 = ASN1_ILC sequence_id (ASN1_ANY_DEFINED_BY _ (list_as_l []) oid_id ASN1_OID supported None pf_wf pf_sup)
 
 let asn1_any_oid_with_fallback
   (name : string)
-  (supported : list (asn1_oid_t * asn1_gen_items_lk)) 
+  (supported : list (asn1_oid_t & asn1_gen_items_lk)) 
   (fallback : asn1_gen_items_lk)
   (pf_wf : squash (asn1_any_prefix_k_wf (Set.singleton oid_id) (List.map proj2_of_3 [])))
   (pf_sup : squash (List.noRepeats (List.map fst supported)))

--- a/src/cbor/pulse/raw/CBOR.Pulse.API.Det.C.Copy.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.API.Det.C.Copy.fst
@@ -1,9 +1,9 @@
 module CBOR.Pulse.API.Det.C.Copy
-#lang-pulse
-friend CBOR.Pulse.API.Det.C
-friend CBOR.Pulse.API.Det.Common
 friend CBOR.Pulse.API.Det.Type
 friend CBOR.Spec.API.Format
+friend CBOR.Pulse.API.Det.Common
+friend CBOR.Pulse.API.Det.C
+#lang-pulse
 
 module SpecRaw = CBOR.Spec.Raw
 module Raw = CBOR.Pulse.Raw.Match

--- a/src/cbor/pulse/raw/CBOR.Pulse.API.Det.Common.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.API.Det.Common.fst
@@ -1,7 +1,7 @@
 module CBOR.Pulse.API.Det.Common
-#lang-pulse
 friend CBOR.Pulse.API.Det.Type
 friend CBOR.Spec.API.Format
+#lang-pulse
 
 module SpecRaw = CBOR.Spec.Raw
 module Raw = CBOR.Pulse.Raw.Match

--- a/src/cbor/pulse/raw/CBOR.Pulse.Raw.Nondet.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.Raw.Nondet.fst
@@ -1,7 +1,7 @@
 module CBOR.Pulse.Raw.Nondet
-#lang-pulse
 friend CBOR.Pulse.API.Nondet.Type
 friend CBOR.Spec.API.Format
+#lang-pulse
 open CBOR.Pulse.Raw.Match
 
 module Raw = CBOR.Pulse.Raw.Match

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Serialized.Base.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Serialized.Base.fst
@@ -1,6 +1,6 @@
 module CBOR.Pulse.Raw.EverParse.Serialized.Base
-#lang-pulse
 friend CBOR.Pulse.Raw.Format.Match
+#lang-pulse
 
 open CBOR.Pulse.Raw.EverParse.Format
 open LowParse.Pulse.Combinators

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.UTF8.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.UTF8.fst
@@ -1,7 +1,7 @@
 module CBOR.Pulse.Raw.EverParse.UTF8
-#lang-pulse
-friend CBOR.Spec.API.UTF8
 friend CBOR.Spec.Raw.Format.UTF8
+friend CBOR.Spec.API.UTF8
+#lang-pulse
 
 open CBOR.Spec.Raw.Format.UTF8
 

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Compare.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Compare.fst
@@ -1,7 +1,7 @@
 module CBOR.Pulse.Raw.Format.Compare
-#lang-pulse
 friend CBOR.Pulse.Raw.Format.Match
 friend CBOR.Spec.Raw.Format
+#lang-pulse
 module Bytes = CBOR.Pulse.Raw.Compare.Bytes
 module F = CBOR.Spec.Raw.EverParse
 module VCList = LowParse.Spec.VCList

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Nondet.Compare.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Nondet.Compare.fst
@@ -1,6 +1,6 @@
 module CBOR.Pulse.Raw.Format.Nondet.Compare
-#lang-pulse
 friend CBOR.Pulse.Raw.Format.Match
+#lang-pulse
 
 module EP = CBOR.Pulse.Raw.EverParse.Nondet.Basic
 module SZ = FStar.SizeT

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Nondet.Validate.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Nondet.Validate.fst
@@ -1,6 +1,6 @@
 module CBOR.Pulse.Raw.Format.Nondet.Validate
-#lang-pulse
 friend CBOR.Spec.Raw.Format
+#lang-pulse
 module EP = CBOR.Pulse.Raw.EverParse.Format
 module EPND = CBOR.Pulse.Raw.EverParse.Nondet.Basic
 

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Parse.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Parse.fst
@@ -1,7 +1,7 @@
 module CBOR.Pulse.Raw.Format.Parse
+friend CBOR.Spec.Raw.Format
 #lang-pulse
 open CBOR.Pulse.Raw.EverParse.Serialized.Base
-friend CBOR.Spec.Raw.Format
 open CBOR.Spec.Raw.EverParse
 open CBOR.Pulse.Raw.EverParse.Format
 open LowParse.Spec.Base

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialize.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialize.fst
@@ -1,8 +1,8 @@
 module CBOR.Pulse.Raw.Format.Serialize
-#lang-pulse
-open Pulse.Lib.Pervasives
 friend CBOR.Spec.Raw.Format
 friend CBOR.Pulse.Raw.Format.Match
+#lang-pulse
+open Pulse.Lib.Pervasives
 open CBOR.Spec.Raw.EverParse
 open LowParse.Spec.Base
 open LowParse.Pulse.Base

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialized.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialized.fst
@@ -1,4 +1,5 @@
 module CBOR.Pulse.Raw.Format.Serialized
+friend CBOR.Pulse.Raw.Format.Match
 #lang-pulse
 open CBOR.Spec.Raw.Base
 open CBOR.Pulse.Raw.Iterator
@@ -8,7 +9,6 @@ open CBOR.Spec.Raw.EverParse
 open CBOR.Pulse.Raw.EverParse.Format
 open LowParse.Pulse.Combinators
 open CBOR.Pulse.Raw.EverParse.Serialized.Base
-friend CBOR.Pulse.Raw.Format.Match
 
 module Trade = Pulse.Lib.Trade.Util
 

--- a/src/cbor/spec/raw/CBOR.Spec.Raw.fst
+++ b/src/cbor/spec/raw/CBOR.Spec.Raw.fst
@@ -1,6 +1,6 @@
 module CBOR.Spec.Raw
-friend CBOR.Spec.API.Type
 friend CBOR.Spec.Raw.DataModel
+friend CBOR.Spec.API.Type
 
 module DM = CBOR.Spec.Raw.DataModel
 

--- a/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.EverParse.fst
+++ b/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.EverParse.fst
@@ -776,7 +776,7 @@ let synth_raw_data_item'_from_alt
           then (| h, LeafContentSeq?.v lc |)
           else (| h, () |)
 
-#push-options "--ifuel 3 --z3rlimit_factor 2"
+#push-options "--ifuel 3 --z3rlimit_factor 4"
 #restart-solver
 
 let synth_raw_data_item'_from_alt_injective : squash (synth_injective synth_raw_data_item'_from_alt) =

--- a/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.Format.MapPair.fst
+++ b/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.Format.MapPair.fst
@@ -1,6 +1,6 @@
 module CBOR.Spec.Raw.Format.MapPair
-friend CBOR.Spec.API.Type
 friend CBOR.Spec.Raw.DataModel
+friend CBOR.Spec.API.Type
 open LowParse.Spec.Combinators
 open LowParse.Spec.VCList
 open CBOR.Spec.Raw.EverParse

--- a/src/cddl/pulse/CDDL.Pulse.AST.Tactics.fst
+++ b/src/cddl/pulse/CDDL.Pulse.AST.Tactics.fst
@@ -2,9 +2,9 @@ module CDDL.Pulse.AST.Tactics
 include CDDL.Spec.AST.Elab
 include CDDL.Pulse.AST.Bundle
 
-let as_squash (#t:Type0) (f: unit -> Lemma t) : squash t = f ()
+let as_squash (#t:prop) (f: unit -> Lemma t) : squash t = f ()
 
-let squash_bij_lemma (#a:Type) (#p:a -> Type)
+let squash_bij_lemma (#a:Type) (#p:a -> prop)
     ($f: (x:a -> Lemma (p x)))
     (x:a)
 : squash (p x)

--- a/src/cddl/pulse/CDDL.Pulse.Bundle.ArrayGroup.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Bundle.ArrayGroup.fst
@@ -127,7 +127,7 @@ let array_bundle_set_parser_and_serializer
 = {
     ab_typ = b.ab_typ;
     ab_spec_type = spect;
-    ab_spec_type_eq = b.ab_spec_type_eq;
+    ab_spec_type_eq = coerce_eq () b.ab_spec_type_eq;
     ab_spec = b.ab_spec;
     ab_impl_type = t;
     ab_rel = r;
@@ -213,7 +213,7 @@ let bundle_array_group_item
 {
   ab_typ = _;
   ab_spec_type = maybe_named nm b_spec_type;
-  ab_spec_type_eq = b_spec_type_eq;
+  ab_spec_type_eq = coerce_eq () b_spec_type_eq;
   ab_spec = ag_spec_item b_spec;
   ab_impl_type = maybe_named nm b_impl_type;
   ab_rel = _;

--- a/src/cddl/pulse/CDDL.Pulse.Bundle.Base.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Bundle.Base.fst
@@ -202,7 +202,7 @@ let bundle_set_parser_and_serializer
 = {
     b_typ = b.b_typ;
     b_spec_type = spect;
-    b_spec_type_eq = b.b_spec_type_eq;
+    b_spec_type_eq = coerce_eq () b.b_spec_type_eq;
     b_spec = b.b_spec;
     b_impl_type = t;
     b_rel = r;

--- a/src/cddl/pulse/CDDL.Pulse.Bundle.MapGroup.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Bundle.MapGroup.fst
@@ -227,7 +227,7 @@ let bundle_map_match_item_for
   mb_footprint = _;
   mb_footprint_correct = ();
   mb_spec_type = maybe_named nm b_spec_type;
-  mb_spec_type_eq = b_spec_type_eq;
+  mb_spec_type_eq = coerce_eq () b_spec_type_eq;
   mb_spec = mg_spec_match_item_for cut key b_spec;
   mb_impl_type = maybe_named nm b_impl_type;
   mb_rel = _;

--- a/src/cddl/pulse/CDDL.Pulse.Parse.MapGroup.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Parse.MapGroup.fst
@@ -70,6 +70,7 @@ let impl_zero_copy_map_group
         )
 
 module Util = CBOR.Spec.Util
+
 #push-options "--fuel 1 --ifuel 1 --z3rlimit_factor 8 --query_stats --split_queries always"
 #restart-solver
 inline_for_extraction noextract [@@noextract_to "krml"]
@@ -645,7 +646,7 @@ let mk_map_iterator_eq_postcond
     res.tex == tex /\
     res.t2 == t2 /\
     res.ser2 == ser2 /\
-    res.ps2 == ps2 /\
+    res.ps2 === ps2 /\
     True
 
 let mk_map_iterator_eq
@@ -678,7 +679,10 @@ let mk_map_iterator_eq
     mk_map_iterator_eq_postcond cddl_map_iterator_contents pm sp1 eq1 tex ps2 res
   ))
   [SMTPat (mk_map_iterator cddl_map_iterator_contents pm sp1 eq1 cddl_map_iterator_impl_validate1 cddl_map_iterator_impl_parse1 cddl_map_iterator_impl_validate_ex cddl_map_iterator_impl_validate2 cddl_map_iterator_impl_parse2)]
-= ()
+= assert_norm (
+    let res = mk_map_iterator cddl_map_iterator_contents pm sp1 eq1 cddl_map_iterator_impl_validate1 cddl_map_iterator_impl_parse1 cddl_map_iterator_impl_validate_ex cddl_map_iterator_impl_validate2 cddl_map_iterator_impl_parse2 in
+    mk_map_iterator_eq_postcond cddl_map_iterator_contents pm sp1 eq1 tex ps2 res
+  )
 
 module Map = CDDL.Spec.Map
 
@@ -894,9 +898,38 @@ let cddl_map_iterator_is_empty_t
     (map_iterator_t cbor_map_iterator_t impl_elt1 impl_elt2 vmatch vmatch2)
     (rel_map_iterator vmatch vmatch2 cbor_map_iterator_match impl_elt1 impl_elt2)
 
-#restart-solver
+let map_of_list_cons_not_equal_empty
+  (#key #value: Type0)
+  (key_eq: EqTest.eq_test key)
+  (k: key)
+  (v: value)
+  (m: Map.t key (list value))
+: Lemma
+  (map_of_list_cons key_eq k v m =!= Map.empty key (list value))
+= assert (Some? (Map.get (map_of_list_cons key_eq k v m) k));
+  Map.ext (map_of_list_cons key_eq k v m) (Map.empty key (list value))
 
-let rec rel_map_iterator_cond_is_empty
+let map_of_list_pair_nil_is_empty
+  (#key #value: Type0)
+  (key_eq: EqTest.eq_test key)
+  (l: list (key & value))
+: Lemma
+  (requires Nil? l)
+  (ensures map_of_list_pair key_eq l == Map.empty key (list value))
+= ()
+
+let rec map_of_list_pair_cons_not_empty
+  (#key #value: Type0)
+  (key_eq: EqTest.eq_test key)
+  (l: list (key & value))
+: Lemma
+  (requires Cons? l)
+  (ensures map_of_list_pair key_eq l =!= Map.empty key (list value))
+= let (k, v) :: q = l in
+  map_of_list_pair_cons key_eq k v q;
+  map_of_list_cons_not_equal_empty key_eq k v (map_of_list_pair key_eq q)
+
+let rel_map_iterator_cond_is_empty
   (#ty #ty2: Type0) (#vmatch: perm -> ty -> cbor -> slprop)
   (#vmatch2: perm -> ty2 -> (cbor & cbor) -> slprop)
   (#cbor_map_iterator_t: Type0)
@@ -913,25 +946,16 @@ let rec rel_map_iterator_cond_is_empty
   (ensures (
     s `Map.equal` Map.empty (dfst spec1) (list (dfst spec2)) <==> Nil? (parse_table_entries i.sp1.parser i.tex i.ps2 l)
   ))
-  (decreases l)
-= match l with
-  | [] ->
-    assert_norm (parse_table_entries i.sp1.parser i.tex i.ps2 [] == []);
-    assert_norm (map_of_list_pair i.eq1 [] == Map.empty (dfst spec1) (list (dfst spec2)))
-  | (k, v) :: q ->
-    rel_map_iterator_cond_is_empty i (map_of_list_pair i.eq1 (parse_table_entries i.sp1.parser i.tex i.ps2 q)) q;
-    let rq = parse_table_entries i.sp1.parser i.tex i.ps2 q in
-    assert_norm (parse_table_entries i.sp1.parser i.tex i.ps2 ((k, v) :: q) == (
-      if Ghost.reveal i.t1 k && not (Ghost.reveal i.tex (k, v)) && Ghost.reveal i.t2 v
-      then (i.sp1.parser k, Ghost.reveal i.ps2 v) :: rq
-      else rq
-    ));
-    if Ghost.reveal i.t1 k && not (Ghost.reveal i.tex (k, v)) && Ghost.reveal i.t2 v
-    then begin
-      map_of_list_pair_cons i.eq1 (i.sp1.parser k) (Ghost.reveal i.ps2 v) rq;
-      ()
-    end
-    else ()
+= let l' = parse_table_entries i.sp1.parser i.tex i.ps2 l in
+  if Nil? l'
+  then begin
+    map_of_list_pair_nil_is_empty i.eq1 l';
+    Map.ext s (Map.empty (dfst spec1) (list (dfst spec2)))
+  end
+  else begin
+    map_of_list_pair_cons_not_empty i.eq1 l';
+    Map.ext s (Map.empty (dfst spec1) (list (dfst spec2)))
+  end
 
 inline_for_extraction
 fn cddl_map_iterator_is_empty
@@ -1290,6 +1314,7 @@ let map_of_list_pair_parse_table_entries_correct
   Classical.forall_intro prf
 
 // FIXME: WHY WHY WHY is it SO tedious to prove this:
+#push-options "--z3rlimit 64"
 let impl_zero_copy_map_zero_or_more_aux
   (#ty #ty2: Type0)
   (#vmatch: perm -> ty -> cbor -> slprop)
@@ -1340,10 +1365,12 @@ let impl_zero_copy_map_zero_or_more_aux
   assert (except == i.tex);
   assert (i.t2 == value);
   assert (Ghost.reveal i.ser2 == coerce_eq (_ by (FStar.Tactics.norm [delta_only [`%dfst; `%Mkdtuple2?._1; `%Iterator.mk_spec;]; iota; primops]; FStar.Tactics.trefl ())) sp2.serializable);
+  assert (i.ps2 === Ghost.hide sp2.parser);
   assert (sp2.parser == coerce_eq () (Ghost.reveal i.ps2));
   assert (parse_table_entries sp1.parser except sp2.parser li == parse_table_entries i.sp1.parser i.tex i.ps2 li);
   assert (s == map_of_list_pair key_eq (parse_table_entries sp1.parser except sp2.parser li));
   ()
+#pop-options
 
 inline_for_extraction noextract [@@noextract_to "krml"]
 fn impl_zero_copy_map_zero_or_more'

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.Concat.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.Concat.fst
@@ -51,7 +51,8 @@ let mg_spec_concat_serializer_eq
 #pop-options
 
 
-#push-options "--z3rlimit 128 --split_queries always"
+#restart-solver
+#push-options "--z3rlimit 256 --split_queries always"
 
 let impl_serialize_map_group_concat_false_helper
   (p: bare_cbor_map_parser)

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux1.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux1.fst
@@ -46,6 +46,7 @@ let map_of_list_is_append_serializable_intro_serializable
 = ()
 
 #restart-solver
+#push-options "--z3rlimit 1024 --split_queries no --z3seed 1"
 let map_of_list_is_append_serializable_intro
   (#key #value: Type)
   (#tkey: typ)
@@ -93,6 +94,7 @@ let map_of_list_is_append_serializable_intro
     cbor_map_mem_disjoint (sp.mg_serializer m1) (sp.mg_serializer m2);
     cbor_map_mem_ext (sp.mg_serializer m) (sp.mg_serializer m1 `cbor_map_union` sp.mg_serializer m2)
   end
+#pop-options
 
 #pop-options
 
@@ -124,7 +126,70 @@ let map_of_list_is_append_cons
   )
 = ()
 
-#push-options "--z3rlimit 128 --split_queries always"
+#push-options "--z3rlimit 64 --split_queries always"
+
+#restart-solver
+let map_of_list_is_append_serializable_disjoint_at
+  (#key #value: Type)
+  (#tkey: typ)
+  (sp1: spec tkey key true)
+  (#tvalue: typ)
+  (#inj: bool)
+  (sp2: spec tvalue value inj)
+  (except: map_constraint { inj \/ map_constraint_value_injective tkey sp2.parser except })
+  (m1: Map.t key (list value))
+  (m2: Map.t key (list value))
+  (m: Map.t key (list value))
+  (k: key)
+: Lemma
+  (requires (
+    map_of_list_is_append m1 m2 m /\
+    map_of_list_maps_to_nonempty m1 /\
+    map_of_list_maps_to_nonempty m2 /\
+    (mg_zero_or_more_match_item sp1 sp2 except).mg_serializable m
+  ))
+  (ensures (~ (Map.defined k m1 /\ Map.defined k m2)))
+= match Map.get m1 k, Map.get m2 k with
+  | Some l1, Some l2 ->
+    List.Tot.append_length l1 l2;
+    let lk = List.Tot.append l1 l2 in
+    let kv : (key & list value) = (k, lk) in
+    assert (Map.get m k == Some lk);
+    assert (Map.mem kv m);
+    let _ = Map.for_all (map_entry_serializable sp1 sp2 except) m in
+    ()
+  | _ -> ()
+
+#restart-solver
+let map_of_list_is_append_serializable_member_at
+  (#key #value: Type)
+  (#tkey: typ)
+  (sp1: spec tkey key true)
+  (#tvalue: typ)
+  (#inj: bool)
+  (sp2: spec tvalue value inj)
+  (except: map_constraint { inj \/ map_constraint_value_injective tkey sp2.parser except })
+  (m1: Map.t key (list value))
+  (m2: Map.t key (list value))
+  (m: Map.t key (list value))
+  (kv: (key & list value))
+: Lemma
+  (requires (
+    map_of_list_is_append m1 m2 m /\
+    Map.disjoint m1 m2 /\
+    (mg_zero_or_more_match_item sp1 sp2 except).mg_serializable m /\
+    (Map.mem kv m1 \/ Map.mem kv m2)
+  ))
+  (ensures (map_entry_serializable sp1 sp2 except kv))
+= let k = fst kv in
+  let v = snd kv in
+  assert (Map.get m k == Some v);
+  assert (Map.mem kv m);
+  let _ = Map.for_all (map_entry_serializable sp1 sp2 except) m in
+  ()
+#pop-options
+
+#push-options "--z3rlimit 64 --split_queries always"
 
 #restart-solver
 let map_of_list_is_append_serializable_elim
@@ -156,12 +221,25 @@ let map_of_list_is_append_serializable_elim
 = let sp = mg_zero_or_more_match_item sp1 sp2 except in
   if sp.mg_serializable m
   then begin
-    assert (
-      sp.mg_serializable m1 /\
-      sp.mg_serializable m2 /\
-      Map.disjoint m1 m2
-    );
-    map_of_list_serializable_disjoint sp1 sp2 except m1 m2
+    let disjoint_aux (k: key) : Lemma (~ (Map.defined k m1 /\ Map.defined k m2)) =
+      map_of_list_is_append_serializable_disjoint_at sp1 sp2 except m1 m2 m k
+    in
+    Classical.forall_intro disjoint_aux;
+    assert (Map.disjoint m1 m2);
+    let member_m1 (kv: (key & list value)) : Lemma (Map.mem kv m1 ==> map_entry_serializable sp1 sp2 except kv) =
+      Classical.move_requires (map_of_list_is_append_serializable_member_at sp1 sp2 except m1 m2 m) kv
+    in
+    Classical.forall_intro member_m1;
+    let _ = Map.for_all (map_entry_serializable sp1 sp2 except) m1 in
+    assert (sp.mg_serializable m1);
+    let member_m2 (kv: (key & list value)) : Lemma (Map.mem kv m2 ==> map_entry_serializable sp1 sp2 except kv) =
+      Classical.move_requires (map_of_list_is_append_serializable_member_at sp1 sp2 except m1 m2 m) kv
+    in
+    Classical.forall_intro member_m2;
+    let _ = Map.for_all (map_entry_serializable sp1 sp2 except) m2 in
+    assert (sp.mg_serializable m2);
+    map_of_list_serializable_disjoint sp1 sp2 except m1 m2;
+    assert (cbor_map_disjoint (sp.mg_serializer m1) (sp.mg_serializer m2))
   end
 
 let map_of_list_is_append_serializable_elim'

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma12.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma12.fst
@@ -9,7 +9,7 @@ module EqTest = CDDL.Spec.EqTest
 
 open CDDL.Spec.MapGroup
 
-#push-options "--z3rlimit 256 --fuel 1 --ifuel 1 --z3seed 42 --z3refresh"
+#push-options "--z3rlimit 512 --fuel 1 --ifuel 1 --z3seed 42 --split_queries always"
 
 let invariant_insert_success
   #pe #minl #maxl p key tkey sp1 value tvalue inj sp2 except em out vout size count m v0 v min max vout_old gk gv min_old max_old em_old size_old count_old m_old l

--- a/src/cddl/spec/CDDL.Spec.AST.Elab.Base.fst
+++ b/src/cddl/spec/CDDL.Spec.AST.Elab.Base.fst
@@ -1068,10 +1068,12 @@ let rec array_group_concat_unique_weak
     if not (RSuccess? res3)
     then res3
     else begin
+      assert (array_group_sem env.e_sem_env (GConcat g1r g2) == Spec.array_group_concat (array_group_sem env.e_sem_env g1r) (array_group_sem env.e_sem_env g2));
       Spec.array_group_concat_unique_weak_choice_left
         (array_group_sem env.e_sem_env g1l)
         (array_group_sem env.e_sem_env g1r)
         (array_group_sem env.e_sem_env g2);
+      assert (Spec.array_group_concat_unique_weak (Spec.array_group_choice (array_group_sem env.e_sem_env g1l) (array_group_sem env.e_sem_env g1r)) (array_group_sem env.e_sem_env g2));
       RSuccess ()
     end
   | _ ->
@@ -1088,6 +1090,7 @@ let rec array_group_concat_unique_weak
           (array_group_sem env.e_sem_env g1)
           (array_group_sem env.e_sem_env g2l)
           (array_group_sem env.e_sem_env g2r);
+        assert (Spec.array_group_concat_unique_weak (array_group_sem env.e_sem_env g1) (Spec.array_group_choice (array_group_sem env.e_sem_env g2l) (array_group_sem env.e_sem_env g2r)));
         RSuccess ()
       end
     | _ ->
@@ -1101,6 +1104,10 @@ let rec array_group_concat_unique_weak
         if not (RSuccess? res2)
         then res2
         else begin
+          assert (array_group_sem env.e_sem_env g1 == Spec.array_group_concat (array_group_sem env.e_sem_env g1l) (array_group_sem env.e_sem_env g1r));
+          assert (Spec.array_group_concat_unique_weak (array_group_sem env.e_sem_env g1l) (array_group_sem env.e_sem_env g1r));
+          assert (array_group_sem env.e_sem_env (GConcat g1r g2) == Spec.array_group_concat (array_group_sem env.e_sem_env g1r) (array_group_sem env.e_sem_env g2));
+          assert (Spec.array_group_concat_unique_weak (array_group_sem env.e_sem_env g1l) (Spec.array_group_concat (array_group_sem env.e_sem_env g1r) (array_group_sem env.e_sem_env g2)));
           Spec.array_group_concat_unique_weak_concat_left
             (array_group_sem env.e_sem_env g1l)
             (array_group_sem env.e_sem_env g1r)
@@ -1130,11 +1137,13 @@ let rec array_group_concat_unique_weak
         else begin
           match g' with
           | GZeroOrMore _ ->
+            assert (array_group_sem env.e_sem_env g' == Spec.array_group_zero_or_more (array_group_sem env.e_sem_env g));
             Spec.array_group_concat_unique_weak_zero_or_more_left
               (array_group_sem env.e_sem_env g)
               (array_group_sem env.e_sem_env g2);
             RSuccess ()
           | GOneOrMore _ ->
+            assert (array_group_sem env.e_sem_env g' == Spec.array_group_one_or_more (array_group_sem env.e_sem_env g));
             Spec.array_group_concat_unique_weak_one_or_more_left
               (array_group_sem env.e_sem_env g)
               (array_group_sem env.e_sem_env g2);
@@ -1151,6 +1160,7 @@ let rec array_group_concat_unique_weak
           Spec.array_group_concat_unique_weak_zero_or_one_left
             (array_group_sem env.e_sem_env g)
             (array_group_sem env.e_sem_env g2);
+          assert (Spec.array_group_concat_unique_weak (Spec.array_group_zero_or_one (array_group_sem env.e_sem_env g)) (array_group_sem env.e_sem_env g2));
           RSuccess ()
         end
       end

--- a/src/cddl/spec/CDDL.Spec.AST.Elab.Disjoint.Array.fst
+++ b/src/cddl/spec/CDDL.Spec.AST.Elab.Disjoint.Array.fst
@@ -7,7 +7,7 @@ module U64 = FStar.UInt64
 module Util = CBOR.Spec.Util
 module U8 = FStar.UInt8
 
-#push-options "--z3rlimit 4096 --query_stats --split_queries always --fuel 4 --ifuel 8 --z3refresh --z3seed 42"
+#push-options "--z3rlimit 131072 --query_stats --split_queries always --fuel 4 --ifuel 8 --z3refresh --retry 3"
 
 let array_group_disjoint
   (typ_disjoint: typ_disjoint_t)
@@ -35,7 +35,6 @@ let array_group_disjoint
     else array_group_disjoint e  close1 close2 a1r a2
   | (_, close1, (GDef n, a1r)), (a2, close2, _)
   | (a2, close2, _), (_, close1, (GDef n, a1r)) ->
-    assert (name_mem n e.e_sem_env.se_bound);
     let en = match e.e_sem_env.se_bound n with
     | Some NGroup -> (e.e_env n)
     | Some NType -> GElem false (TElem EAny) (e.e_env n)

--- a/src/cddl/spec/CDDL.Spec.AST.Elab.Included.Array.fst
+++ b/src/cddl/spec/CDDL.Spec.AST.Elab.Included.Array.fst
@@ -6,7 +6,101 @@ module U64 = FStar.UInt64
 module Util = CBOR.Spec.Util
 module U8 = FStar.UInt8
 
-#push-options "--z3rlimit 4096 --query_stats --split_queries always --fuel 4 --ifuel 8 --z3refresh --z3seed 0"
+(* Helpers factored out of the [GDef]-on-the-second-group branch of
+   [array_group_included] below. Inlining that branch into the big
+   [--split_queries always] obligation triggers a Z3 instantiation cascade
+   (the [maybe_close_array_group_sem_destruct_group] SMTPat recursively
+   destructs the group semantics), so we prove it here in a small, clean
+   context. *)
+
+(* Spec-level congruence: replacing the right-hand side of an inclusion by an
+   equivalent array group preserves inclusion. Stated on raw [array_group]
+   values (not on [array_group_sem e g]) so that the destruct SMTPat cannot
+   fire here. *)
+#push-options "--fuel 0 --ifuel 1 --z3rlimit 20"
+let included_equiv_r
+  (close: bool)
+  (s1 s2 s3: Spec.array_group None)
+: Lemma
+  (requires
+     Spec.array_group_equiv s2 s3 /\
+     Spec.array_group_included (Spec.maybe_close_array_group s1 close) (Spec.maybe_close_array_group s2 close))
+  (ensures
+     Spec.array_group_included (Spec.maybe_close_array_group s1 close) (Spec.maybe_close_array_group s3 close))
+= ()
+#pop-options
+
+(* The def-expanded group [GConcat en a1r] is semantically equivalent to the
+   original def-headed group [a2]. *)
+#push-options "--fuel 4 --ifuel 2 --z3rlimit 64 --z3refresh"
+let gdef_snd_equiv
+  (e: ast_env)
+  (n: name e.e_sem_env.se_bound)
+  (a1r: group { group_bounded e.e_sem_env.se_bound a1r })
+  (a2: group { group_bounded e.e_sem_env.se_bound a2 })
+  (en: group { group_bounded e.e_sem_env.se_bound en })
+: Lemma
+  (requires
+     destruct_group a2 == (GDef n, a1r) /\
+     (match e.e_sem_env.se_bound n with
+      | Some NGroup -> en == e.e_env n
+      | Some NType -> en == GElem false (TElem EAny) (e.e_env n)))
+  (ensures
+     group_bounded e.e_sem_env.se_bound (GConcat en a1r) /\
+     Spec.array_group_equiv
+       (array_group_sem e.e_sem_env (GConcat en a1r))
+       (array_group_sem e.e_sem_env a2))
+= array_group_sem_destruct_group e.e_sem_env a2
+#pop-options
+
+(* Specialized handling of the case where the second group [a2] is headed by a
+   group/type definition. Expand the definition, rewrite, and recurse. *)
+#push-options "--z3rlimit 64 --fuel 4 --ifuel 2 --z3refresh"
+let array_group_included_gdef_snd
+  (array_group_included: array_group_included_t)
+  (fuel: nat)
+  (e: ast_env)
+  (close: bool)
+  (a1: group { group_bounded e.e_sem_env.se_bound a1 })
+  (a2: group { group_bounded e.e_sem_env.se_bound a2 })
+: Pure (result unit)
+  (requires GDef? (fst (destruct_group a2)))
+  (ensures fun r ->
+    match r with
+    | RSuccess _ ->
+      Spec.array_group_included
+        (Spec.maybe_close_array_group (array_group_sem e.e_sem_env a1) close)
+        (Spec.maybe_close_array_group (array_group_sem e.e_sem_env a2) close)
+    | _ -> True
+  )
+= let (g0, a1r) = destruct_group a2 in
+  array_group_sem_destruct_group e.e_sem_env a2;
+  let GDef n = g0 in
+  let en = match e.e_sem_env.se_bound n with
+    | Some NGroup -> (e.e_env n)
+    | Some NType -> GElem false (TElem EAny) (e.e_env n)
+  in
+  let a1' = GConcat en a1r in
+  gdef_snd_equiv e n a1r a2 en;
+  rewrite_group_correct e.e_sem_env fuel false a1';
+  let (a1_, res) = rewrite_group fuel false a1' in
+  if res
+  then begin
+    let r = array_group_included e close a1 (a1_) in
+    if RSuccess? r
+    then begin
+      included_equiv_r close
+        (array_group_sem e.e_sem_env a1)
+        (array_group_sem e.e_sem_env a1_)
+        (array_group_sem e.e_sem_env a2);
+      r
+    end
+    else r
+  end
+  else ROutOfFuel
+#pop-options
+
+#push-options "--z3rlimit 512 --query_stats --split_queries always --fuel 4 --ifuel 8 --z3refresh"
 
 let array_group_included
   (typ_included: typ_included_t)
@@ -87,16 +181,7 @@ let array_group_included
     then array_group_included e close (a1_) a2
     else ROutOfFuel
   | (a2, _), (_, (GDef n, a1r)) ->
-    let en = match e.e_sem_env.se_bound n with
-    | Some NGroup -> (e.e_env n)
-    | Some NType -> GElem false (TElem EAny) (e.e_env n)
-    in
-    let a1' = GConcat en a1r in
-    rewrite_group_correct e.e_sem_env fuel false a1';
-    let (a1_, res) = rewrite_group fuel false a1' in
-    if res
-    then array_group_included e close a2 (a1_)
-    else ROutOfFuel
+    array_group_included_gdef_snd array_group_included fuel e close a2 a20
   | _, (_, (GAlwaysFalse, _)) -> RFailure "array_group_included: GAlwaysFalse"
   | (GNop, _), (_, (GZeroOrOne _, a2r))
   | (GNop, _), (_, (GZeroOrMore _, a2r))
@@ -199,3 +284,5 @@ let array_group_included
   | (_, (GElem _ _ _, _)), _ ->
     RFailure "array_group_included: GArrayElem"
   end
+
+#pop-options

--- a/src/cddl/spec/CDDL.Spec.AST.Elab.fst
+++ b/src/cddl/spec/CDDL.Spec.AST.Elab.fst
@@ -1069,7 +1069,7 @@ let map_group_filtered_table_except_ext
         (Util.notp (Util.andp (Spec.matches_map_group_entry key value) (Util.notp except1)))
         (Util.notp (Util.andp (Spec.matches_map_group_entry key value) (Util.notp except2)))
 
-#push-options "--z3rlimit 64 --ifuel 6 --fuel 4 --split_queries always"
+#push-options "--z3rlimit 64 --ifuel 6 --fuel 4 --split_queries always --z3refresh"
 
 #restart-solver
 

--- a/src/cddl/spec/CDDL.Spec.ArrayGroup.fst
+++ b/src/cddl/spec/CDDL.Spec.ArrayGroup.fst
@@ -449,7 +449,36 @@ let array_group_concat_unique_weak_concat_zero_or_more_right
   (ensures (
     array_group_concat_unique_weak a1 (array_group_concat (array_group_zero_or_more a2) a3)
   ))
-= ()
+= let azm2 = array_group_zero_or_more a2 in
+  let a23 = array_group_concat azm2 a3 in
+  let prf1
+    (l: (l: list Cbor.cbor { opt_precedes_list l b }))
+  : Lemma
+    (requires (array_group_concat a1 a23 l == Some (l, [])))
+    (ensures (
+      exists (l1 l2: list Cbor.cbor) .
+        a1 l == Some (l1, l2) /\
+        a1 l1 == Some (l1, []) /\
+        a23 l2 == Some (l2, [])
+    ))
+  = let Some (la, lb) = a1 l in
+    let Some (lc, le) = a23 lb in
+    array_group_zero_or_more_eq a2 lb;
+    if Some? (a2 lb)
+    then array_group_concat_unique_strong_elim2 a1 a2
+    else begin
+      List.Tot.append_assoc la lb (le <: list Cbor.cbor);
+      array_group_concat_unique_weak_elim1 a1 a3 l
+    end
+  in
+  let prf2
+    (l1 l2: (l: list Cbor.cbor { opt_precedes_list l b }))
+  : Lemma
+    (requires (a1 l1 == Some (l1, []) /\ a23 l2 == Some (l2, [])))
+    (ensures (a1 (l1 `List.Tot.append` l2) == Some (l1, l2)))
+  = array_group_zero_or_more_eq a2 l2
+  in
+  array_group_concat_unique_weak_intro a1 a23 prf1 prf2
 
 #pop-options
 
@@ -520,6 +549,9 @@ let array_group_concat_unique_weak_zero_or_more_left
   #b (a1 a2: array_group b)
 = array_group_concat_unique_weak_zero_or_more_left' a1 (close_array_group a2)
 
+#push-options "--z3rlimit 128 --fuel 2 --ifuel 2"
+#restart-solver
+
 let array_group_concat_unique_weak_zero_or_more_right
   #b (a1 a2: array_group b)
 : Lemma
@@ -529,7 +561,9 @@ let array_group_concat_unique_weak_zero_or_more_right
   (ensures (
     array_group_concat_unique_weak a1 (array_group_zero_or_more a2)
   ))
-= ()
+= Classical.forall_intro (array_group_zero_or_more_eq a2)
+
+#pop-options
 
 #push-options "--z3rlimit 32"
 #restart-solver
@@ -698,9 +732,49 @@ let array_group_concat_unique_strong_one_or_more_left
 
 #pop-options
 
-#push-options "--z3rlimit 32 --split_queries always"
-
+#push-options "--z3rlimit 32"
 #restart-solver
+
+let array_group_concat_unique_weak_one_or_more_left_prf1
+  #b (a1 a2: array_group b)
+  (l: (l: list Cbor.cbor { opt_precedes_list l b }))
+: Lemma
+  (requires (
+    array_group_concat_unique_weak a1 (array_group_concat (array_group_zero_or_more a1) a2) /\
+    array_group_concat_unique_weak (array_group_zero_or_more a1) a2 /\
+    array_group_concat (array_group_one_or_more a1) a2 l == Some (l, [])
+  ))
+  (ensures (
+    exists (l1 l2: list Cbor.cbor) .
+      array_group_one_or_more a1 l == Some (l1, l2) /\
+      array_group_one_or_more a1 l1 == Some (l1, []) /\
+      a2 l2 == Some (l2, [])
+  ))
+= let Some (l1, lr) = a1 l in
+  assert (array_group_concat (array_group_zero_or_more a1) a2 lr == Some (lr, []));
+  let Some (l1s, l2) = array_group_zero_or_more a1 lr in
+  assert (array_group_zero_or_more a1 l1s == Some (l1s, []));
+  assert (a2 l2 == Some (l2, []))
+
+let array_group_concat_unique_weak_one_or_more_left_prf2
+  #b (a1 a2: array_group b)
+  (l1 l2: (l: list Cbor.cbor { opt_precedes_list l b }))
+: Lemma
+  (requires (
+    array_group_concat_unique_weak a1 (array_group_concat (array_group_zero_or_more a1) a2) /\
+    array_group_concat_unique_weak (array_group_zero_or_more a1) a2 /\
+    array_group_one_or_more a1 l1 == Some (l1, []) /\
+    a2 l2 == Some (l2, [])
+  ))
+  (ensures (
+    array_group_one_or_more a1 (l1 `List.Tot.append` l2) == Some (l1, l2)
+  ))
+= assert (Some? (a1 l1));
+  assert (array_group_zero_or_more a1 l1 == Some (l1, []));
+  let l = l1 `List.Tot.append` l2 in
+  assert (array_group_concat (array_group_zero_or_more a1) a2 l == Some (l, []));
+  assert (Some? (a1 l))
+
 let array_group_concat_unique_weak_one_or_more_left'
   #b (a1 a2: array_group b)
 : Lemma
@@ -715,22 +789,8 @@ let array_group_concat_unique_weak_one_or_more_left'
 = array_group_concat_unique_weak_concat_zero_or_more_right a1 a1 a2;
   array_group_concat_unique_weak_zero_or_more_left a1 a2;
   array_group_concat_unique_weak_intro (array_group_one_or_more a1) a2
-      (fun l ->
-        let Some (l1, lr) = a1 l in
-        assert (array_group_concat (array_group_zero_or_more a1) a2 lr == Some (lr, []));
-        let Some (l1s, l2) = array_group_zero_or_more a1 lr in
-        assert (array_group_zero_or_more a1 l1s == Some (l1s, []));
-        assert (a2 l2 == Some (l2, []));
-        ()
-      )
-      (fun l1 l2 ->
-        assert (Some? (a1 l1));
-        assert (array_group_zero_or_more a1 l1 == Some (l1, []));
-        let l = l1 `List.Tot.append` l2 in
-        assert (array_group_concat (array_group_zero_or_more a1) a2 l == Some (l, []));
-        assert (Some? (a1 l));
-        ()
-      )
+      (fun l -> array_group_concat_unique_weak_one_or_more_left_prf1 a1 a2 l)
+      (fun l1 l2 -> array_group_concat_unique_weak_one_or_more_left_prf2 a1 a2 l1 l2)
 
 let array_group_concat_unique_weak_one_or_more_left
   #b (a1 a2: array_group b)

--- a/src/cddl/spec/CDDL.Spec.MapGroup.fsti
+++ b/src/cddl/spec/CDDL.Spec.MapGroup.fsti
@@ -191,6 +191,7 @@ let map_constraint_choice
 : Tot bool
 = f1 x || f2 x
 
+#push-options "--z3rlimit 32"
 #restart-solver
 let map_group_footprint_concat
   (g1 g2: map_group)
@@ -204,7 +205,28 @@ let map_group_footprint_concat
     map_group_footprint (map_group_concat g1 g2) (map_constraint_choice f1 f2)
   ))
   [SMTPat (map_group_footprint (map_group_concat g1 g2) (map_constraint_choice f1 f2))]
-= bring_cbor_map_defined_alt ()
+= bring_cbor_map_defined_alt ();
+  map_group_footprint_intro
+    (map_group_concat g1 g2)
+    (map_constraint_choice f1 f2)
+    (fun m m' ->
+      apply_map_group_det_concat g1 g2 m;
+      apply_map_group_det_concat g1 g2 (m `cbor_map_union` m');
+      match apply_map_group_det g1 m, apply_map_group_det g1 (m `cbor_map_union` m') with
+      | MapGroupCutFail, _ -> ()
+      | MapGroupFail, _ -> ()
+      | MapGroupDet c1 r1, MapGroupDet _ r1' ->
+        assert (r1' == r1 `cbor_map_union` m');
+        begin match apply_map_group_det g2 r1, apply_map_group_det g2 (r1 `cbor_map_union` m') with
+        | MapGroupCutFail, _ -> ()
+        | MapGroupFail, _ -> ()
+        | MapGroupDet _ r2, MapGroupDet _ r2' ->
+          assert (r2' == r2 `cbor_map_union` m')
+        | _ -> ()
+        end
+      | _ -> ()
+    )
+#pop-options
 
 #restart-solver
 let map_group_footprint_choice
@@ -2346,6 +2368,7 @@ let map_group_zero_or_more_match_item_parser_op_comm
 = ()
 #pop-options
 
+#push-options "--z3rlimit_factor 8 --split_queries always"
 let rec list_fold_map_group_zero_or_more_match_item_parser_op_mem
   (#tkey #tvalue: Type)
   (#key #value: typ)
@@ -2381,6 +2404,7 @@ let rec list_fold_map_group_zero_or_more_match_item_parser_op_mem
     | a :: q ->
       list_fold_map_group_zero_or_more_match_item_parser_op_mem pkey pvalue except m (map_group_zero_or_more_match_item_parser_op pkey pvalue except m accu a) q k v
     end
+#pop-options
 
 let map_group_zero_or_more_match_item_parser_op_length
   (#tkey #tvalue: Type)

--- a/src/lowparse/LowParse.Bytes.fst
+++ b/src/lowparse/LowParse.Bytes.fst
@@ -3,7 +3,7 @@ module LowParse.Bytes
 module Seq = FStar.Seq
 module U8 = FStar.UInt8
 
-let bytes_equal (b1 b2: bytes) : GTot Type0 =
+let bytes_equal (b1 b2: bytes) : GTot prop =
   Seq.length b1 == Seq.length b2 /\
   (forall (i: nat { i < Seq.length b1 } ) . {:pattern (Seq.index b1 i); (Seq.index b2 i) } U8.v (Seq.index b1 i) == U8.v (Seq.index b2 i))
 

--- a/src/lowparse/LowParse.Bytes.fsti
+++ b/src/lowparse/LowParse.Bytes.fsti
@@ -6,7 +6,7 @@ module U8 = FStar.UInt8
 type byte = U8.byte
 type bytes = Seq.seq byte
 
-val bytes_equal (b1 b2: bytes) : GTot Type0
+val bytes_equal (b1 b2: bytes) : GTot prop
 
 val bytes_equal_intro (b1 b2: bytes) : Lemma
   (requires (

--- a/src/lowparse/LowParse.Bytes32.fst
+++ b/src/lowparse/LowParse.Bytes32.fst
@@ -43,7 +43,7 @@ let b32_reveal_create
   let pty = (i: nat { i < Seq.length lhs }) in
   let post
     (i: pty)
-  : GTot Type0
+  : GTot prop
   = Seq.index lhs (i <: nat) == Seq.index rhs (i <: nat)
   in
   let f

--- a/src/lowparse/LowParse.CLens.fst
+++ b/src/lowparse/LowParse.CLens.fst
@@ -28,7 +28,7 @@ let clens_snd (t1: Type) (t2: Type) : Tot (clens (t1 & t2) t2) = {
   clens_get = snd;
 }
 
-let clens_eq (#t: Type) (#t': Type) (cl1: clens t t') (cl2: clens t t') : GTot Type0 =
+let clens_eq (#t: Type) (#t': Type) (cl1: clens t t') (cl2: clens t t') : GTot prop =
   (forall (x: t) . {:pattern (cl1.clens_cond x) \/ (cl2.clens_cond x)} cl1.clens_cond x <==> cl2.clens_cond x) /\
   (forall (x: t) . {:pattern (cl1.clens_get x) \/ (cl2.clens_get x)} (cl1.clens_cond x \/ cl2.clens_cond x) ==> (cl1.clens_get x == cl2.clens_get x))
 
@@ -67,7 +67,7 @@ let clens_eq_intro'
 
 (*
 let clens_get_put'
-  (#t1: Type) (#clens_cond: t1 -> GTot Type0) (#t2: Type) (l: clens clens_cond t2)
+  (#t1: Type) (#clens_cond: t1 -> GTot prop) (#t2: Type) (l: clens clens_cond t2)
   (x1: t1) (x2: t2)
 : Lemma
   (requires (clens_cond x1))
@@ -76,7 +76,7 @@ let clens_get_put'
 = l.clens_get_put x1 x2
 
 let clens_put_put'
-  (#t1: Type) (#clens_cond: t1 -> GTot Type0) (#t2: Type) (l: clens clens_cond t2)
+  (#t1: Type) (#clens_cond: t1 -> GTot prop) (#t2: Type) (l: clens clens_cond t2)
   (x1: t1) (x2: t2) (x2' : t2)
 : Lemma
   (requires (clens_cond x1))
@@ -85,7 +85,7 @@ let clens_put_put'
 = l.clens_put_put x1 x2 x2'
 
 let clens_put_get'
-  (#t1: Type) (#clens_cond: t1 -> GTot Type0) (#t2: Type) (l: clens clens_cond t2)
+  (#t1: Type) (#clens_cond: t1 -> GTot prop) (#t2: Type) (l: clens clens_cond t2)
   (x1: t1)
 : Lemma
   (requires (clens_cond x1))
@@ -96,20 +96,20 @@ let clens_put_get'
 abstract
 let clens_disjoint_l
   (#t0: Type)
-  (#clens_cond2: t0 -> GTot Type0)
-  (#clens_cond3: t0 -> GTot Type0)
+  (#clens_cond2: t0 -> GTot prop)
+  (#clens_cond3: t0 -> GTot prop)
   (#t2 #t3: Type)
   (l2: clens clens_cond2 t2)
   (l3: clens clens_cond3 t3)
-: GTot Type0
+: GTot prop
 = (forall (x0: t0) (x2: t2) . (clens_cond2 x0 /\ clens_cond3 x0) ==> 
   (let x0' = l2.clens_put x0 x2 in clens_cond3 x0' /\ l3.clens_get x0' == l3.clens_get x0))
 
 abstract
 let clens_disjoint_l_elim
   (#t0: Type)
-  (#clens_cond2: t0 -> GTot Type0)
-  (#clens_cond3: t0 -> GTot Type0)
+  (#clens_cond2: t0 -> GTot prop)
+  (#clens_cond3: t0 -> GTot prop)
   (#t2 #t3: Type)
   (l2: clens clens_cond2 t2)
   (l3: clens clens_cond3 t3)
@@ -123,8 +123,8 @@ let clens_disjoint_l_elim
 abstract
 let clens_disjoint_l_intro
   (#t0: Type)
-  (#clens_cond2: t0 -> GTot Type0)
-  (#clens_cond3: t0 -> GTot Type0)
+  (#clens_cond2: t0 -> GTot prop)
+  (#clens_cond3: t0 -> GTot prop)
   (#t2 #t3: Type)
   (l2: clens clens_cond2 t2)
   (l3: clens clens_cond3 t3)
@@ -149,18 +149,18 @@ let clens_disjoint_l_intro
 
 let clens_disjoint
   (#t0: Type)
-  (#clens_cond2: t0 -> GTot Type0)
-  (#clens_cond3: t0 -> GTot Type0)
+  (#clens_cond2: t0 -> GTot prop)
+  (#clens_cond3: t0 -> GTot prop)
   (#t2 #t3: Type)
   (l2: clens clens_cond2 t2)
   (l3: clens clens_cond3 t3)
-: GTot Type0
+: GTot prop
 = clens_disjoint_l l2 l3 /\ clens_disjoint_l l3 l2
 
 let clens_disjoint_sym
   (#t0: Type)
-  (#clens_cond2: t0 -> GTot Type0)
-  (#clens_cond3: t0 -> GTot Type0)
+  (#clens_cond2: t0 -> GTot prop)
+  (#clens_cond3: t0 -> GTot prop)
   (#t2 #t3: Type)
   (l2: clens clens_cond2 t2)
   (l3: clens clens_cond3 t3)
@@ -208,7 +208,7 @@ let clens_compose_strong_pre
   (#t3: Type)
   (l12: clens t1 t2)
   (l23: clens t2 t3)
-: GTot Type0
+: GTot prop
 = forall (x: t1) . {:pattern (l12.clens_cond x) \/ (l23.clens_cond (l12.clens_get x))} l12.clens_cond x ==> l23.clens_cond (l12.clens_get x)
 
 let clens_compose_strong
@@ -227,12 +227,12 @@ let clens_compose_strong
 abstract
 let clens_disjoint_compose
   (#t0: Type)
-<  (#clens_cond2: t0 -> GTot Type0)
-  (#clens_cond3: t0 -> GTot Type0)
+<  (#clens_cond2: t0 -> GTot prop)
+  (#clens_cond3: t0 -> GTot prop)
   (#t2 #t3: Type)
   (l2: clens clens_cond2 t2)
   (l3: clens clens_cond3 t3)
-  (#clens_cond3': t3 -> GTot Type0)
+  (#clens_cond3': t3 -> GTot prop)
   (#t3' : Type)
   (l3' : clens clens_cond3' t3')
 : Lemma

--- a/src/lowparse/LowParse.SLow.Base.fst
+++ b/src/lowparse/LowParse.SLow.Base.fst
@@ -11,7 +11,7 @@ let parser32_correct
   (#t: Type)
   (p: parser k t)
   (input: bytes32)
-  (res: option (t * U32.t))
+  (res: option (t & U32.t))
 : GTot Type0
 = let gp = parse p (B32.reveal input) in
   match res with
@@ -30,7 +30,7 @@ let parser32
   (#t: Type)
   (p: parser k t)
 : Tot Type
-= (input: bytes32) -> Tot (res: option (t * U32.t) { parser32_correct p input res } )
+= (input: bytes32) -> Tot (res: option (t & U32.t) { parser32_correct p input res } )
 
 let parser32_consumes
   (#k: parser_kind)
@@ -59,9 +59,9 @@ let make_parser32
   (#k: parser_kind)
   (#t: Type)
   (p: parser k t)
-  (p32: (input: bytes32) -> Pure (option (t * U32.t)) (requires True) (ensures (fun res -> parser32_correct p input res)))
+  (p32: (input: bytes32) -> Pure (option (t & U32.t)) (requires True) (ensures (fun res -> parser32_correct p input res)))
 : Tot (parser32 p)
-= (fun (input: bytes32) -> (p32 input <: (res: option (t * U32.t) { parser32_correct p input res } )))
+= (fun (input: bytes32) -> (p32 input <: (res: option (t & U32.t) { parser32_correct p input res } )))
 
 inline_for_extraction
 let coerce_parser32

--- a/src/lowparse/LowParse.SLow.Base.fst
+++ b/src/lowparse/LowParse.SLow.Base.fst
@@ -12,7 +12,7 @@ let parser32_correct
   (p: parser k t)
   (input: bytes32)
   (res: option (t & U32.t))
-: GTot Type0
+: GTot prop
 = let gp = parse p (B32.reveal input) in
   match res with
   | None -> gp == None
@@ -80,7 +80,7 @@ let validator_correct
   (p: parser k t)
   (input: bytes32)
   (res: option U32.t)
-: GTot Type0
+: GTot prop
 = let gp = parse p (B32.reveal input) in
   match res with
   | None -> gp == None
@@ -104,7 +104,7 @@ let serializer32_correct
   (s: serializer p)
   (input: t)
   (res: bytes32)
-: GTot Type0
+: GTot prop
 = B32.reveal res == s input
 
 let serializer32_correct'
@@ -114,7 +114,7 @@ let serializer32_correct'
   (s: serializer p)
   (input: t)
   (res: bytes32)
-: GTot Type0
+: GTot prop
 = B32.reveal res `bytes_equal` s input
 
 [@unifier_hint_injective]
@@ -323,7 +323,7 @@ let size32_postcond
   (s: serializer p)
   (x: t)
   (y: U32.t)
-: GTot Type0
+: GTot prop
 = let sz = Seq.length (serialize s x) in
   if sz > U32.v u32_max
   then y == u32_max
@@ -348,7 +348,7 @@ let size32_constant_precond
   (#p: parser k t)
   (s: serializer p)
   (len32: U32.t)
-: GTot Type0
+: GTot prop
 = k.parser_kind_high == Some k.parser_kind_low /\
   U32.v len32 == k.parser_kind_low
 

--- a/src/lowparse/LowParse.SLow.Bytes.fst
+++ b/src/lowparse/LowParse.SLow.Bytes.fst
@@ -47,7 +47,7 @@ let parse32_all_bytes
   : parser32 parse_all_bytes
 = fun (input: B32.bytes) ->
     let res = Some (input, B32.len input) in
-    (res <: (res: option (bytes32 * U32.t) { parser32_correct parse_all_bytes input res } ))
+    (res <: (res: option (bytes32 & U32.t) { parser32_correct parse_all_bytes input res } ))
 
 inline_for_extraction
 let serialize32_all_bytes

--- a/src/lowparse/LowParse.SLow.Combinators.fst
+++ b/src/lowparse/LowParse.SLow.Combinators.fst
@@ -12,7 +12,7 @@ let parse32_ret
   (#t: Type)
   (x: t)
 : Tot (parser32 (parse_ret x))
-= (fun input -> ((Some (x, 0ul)) <: (res: option (t * U32.t) { parser32_correct (parse_ret x) input res } )))
+= (fun input -> ((Some (x, 0ul)) <: (res: option (t & U32.t) { parser32_correct (parse_ret x) input res } )))
 
 inline_for_extraction
 let parse32_empty : parser32 parse_empty = parse32_ret ()
@@ -78,7 +78,7 @@ let parse32_and_then
     | _ -> None
     end
   | _ -> None
-  ) <: (res: option (t' * U32.t) { parser32_correct (p `and_then` p') input res } ))
+  ) <: (res: option (t' & U32.t) { parser32_correct (p `and_then` p') input res } ))
 
 inline_for_extraction
 let parse32_nondep_then
@@ -103,7 +103,7 @@ let parse32_nondep_then
     | _ -> None
     end
   | _ -> None
-  ) <: (res: option ((t1 * t2) * U32.t) { parser32_correct (p1 `nondep_then` p2) input res } ))
+  ) <: (res: option ((t1 & t2) & U32.t) { parser32_correct (p1 `nondep_then` p2) input res } ))
 
 let serialize32_kind_precond
   (k1 k2: parser_kind)
@@ -127,7 +127,7 @@ let serialize32_nondep_then
     serialize32_kind_precond k1 k2
   })
 : Tot (serializer32 (serialize_nondep_then s1 s2))
-= fun (input: t1 * t2) ->
+= fun (input: t1 & t2) ->
   [@inline_let]
   let _ = serialize_nondep_then_eq s1 s2 input in
   match input with
@@ -164,7 +164,7 @@ let parse32_dtuple2
     | _ -> None
     end
   | _ -> None
-  ) <: (res: option (dtuple2 t1 t2 * U32.t) { parser32_correct (parse_dtuple2 p1 p2) input res } ))
+  ) <: (res: option (dtuple2 t1 t2 & U32.t) { parser32_correct (parse_dtuple2 p1 p2) input res } ))
 
 inline_for_extraction
 let serialize32_dtuple2
@@ -213,7 +213,7 @@ let parse32_strengthen
     let (x' : t1 { p2 x' } ) = x in
     Some (x', consumed)
   | _ -> None
-  ) <: (res: option ((x: t1 { p2 x}) * U32.t) { parser32_correct (parse_strengthen p1 p2 prf) xbytes res } ))
+  ) <: (res: option ((x: t1 { p2 x}) & U32.t) { parser32_correct (parse_strengthen p1 p2 prf) xbytes res } ))
 
 inline_for_extraction
 let parse32_synth
@@ -234,7 +234,7 @@ let parse32_synth
     match p1' input with
     | Some (v1, consumed) -> Some (f2' v1, consumed)
     | _ -> None
-   ) <: (res: option (t2 * U32.t) { parser32_correct (parse_synth p1 f2) input res } ))
+   ) <: (res: option (t2 & U32.t) { parser32_correct (parse_synth p1 f2) input res } ))
 
 inline_for_extraction
 let parse32_synth'
@@ -309,7 +309,7 @@ let parse32_filter
       else
         None
     | _ -> None
-  ) <: (res: option ((v': t { f v' == true } ) * U32.t) { parser32_correct (parse_filter p f) input res } ))
+  ) <: (res: option ((v': t { f v' == true } ) & U32.t) { parser32_correct (parse_filter p f) input res } ))
 
 inline_for_extraction
 let serialize32_filter
@@ -342,7 +342,7 @@ let make_constant_size_parser32
       | None -> None
       | Some v -> Some (v, sz')
     end
-  ) <: (res: option (t * U32.t) { parser32_correct (make_constant_size_parser sz t f) input res } ))
+  ) <: (res: option (t & U32.t) { parser32_correct (make_constant_size_parser sz t f) input res } ))
 
 inline_for_extraction
 let make_total_constant_size_parser32
@@ -361,7 +361,7 @@ let make_total_constant_size_parser32
     else
       let s' = B32.slice input 0ul sz' in
       Some (f' s', sz')
-  ) <: (res: option (t * U32.t) { parser32_correct (make_total_constant_size_parser sz t f) input res } ))
+  ) <: (res: option (t & U32.t) { parser32_correct (make_total_constant_size_parser sz t f) input res } ))
 
 inline_for_extraction
 let size32_nondep_then

--- a/src/lowparse/LowParse.SLow.Combinators.fst
+++ b/src/lowparse/LowParse.SLow.Combinators.fst
@@ -201,7 +201,7 @@ let parse32_strengthen
   (#t1: Type)
   (#p1: parser k t1)
   (p1' : parser32 p1)
-  (p2: t1 -> GTot Type0)
+  (p2: t1 -> GTot prop)
   (prf: parse_strengthen_prf p1 p2)
 : Tot (parser32 (parse_strengthen p1 p2 prf))
 = fun (xbytes: bytes32) -> ((

--- a/src/lowparse/LowParse.SLow.Enum.fst
+++ b/src/lowparse/LowParse.SLow.Enum.fst
@@ -64,7 +64,7 @@ let parse32_enum_key_gen
       | _ -> None
       end
     | _ -> None
-  ) <: (res: option (enum_key e * U32.t) { parser32_correct (parse_enum_key p e) input res } )))
+  ) <: (res: option (enum_key e & U32.t) { parser32_correct (parse_enum_key p e) input res } )))
 
 inline_for_extraction
 let parse32_enum_key

--- a/src/lowparse/LowParse.SLow.FLData.fst
+++ b/src/lowparse/LowParse.SLow.FLData.fst
@@ -26,7 +26,7 @@ let parse32_fldata
 	  Some (v, consumed)
 	end else None
       | None -> None
-  ) <: (res: option (t * U32.t) { parser32_correct (parse_fldata p sz) input res } )))
+  ) <: (res: option (t & U32.t) { parser32_correct (parse_fldata p sz) input res } )))
 
 inline_for_extraction
 let parse32_fldata_strong
@@ -48,7 +48,7 @@ let parse32_fldata_strong
       Some ((v <: parse_fldata_strong_t s sz), consumed)
     | None -> None
     )   
-    <: (res: option (parse_fldata_strong_t s sz * U32.t) { parser32_correct (parse_fldata_strong s sz) input res } )))
+    <: (res: option (parse_fldata_strong_t s sz & U32.t) { parser32_correct (parse_fldata_strong s sz) input res } )))
 
 inline_for_extraction
 let serialize32_fldata_strong

--- a/src/lowparse/LowParse.SLow.List.fst
+++ b/src/lowparse/LowParse.SLow.List.fst
@@ -94,7 +94,7 @@ let list_rev_inv
   (l: list t)
   (b: bool)
   (x: list t & list t)
-: GTot Type0
+: GTot prop
 = let (rem, acc) = x in
   L.rev l == L.rev_acc rem acc /\
   (b == false ==> rem == [])
@@ -127,7 +127,7 @@ let parse_list_tailrec_inv
   (input: bytes32)
   (b: bool)
   (x: option (bytes32 & list t))
-: GTot Type0
+: GTot prop
 = match x with
   | Some (input', accu') ->
     parse_list_tailrec' p32 input [] == parse_list_tailrec' p32 input' accu' /\
@@ -277,7 +277,7 @@ let partial_serialize32_list'_inv
   (input: list t)
   (continue: bool)
   (x: bytes32 & list t)
-: GTot Type0
+: GTot prop
 = serialize_list_precond k /\
   Seq.length (serialize (serialize_list p s) input) < 4294967296 /\ (
     let (accu, input') = x in
@@ -376,7 +376,7 @@ let size32_list_inv
   (input: list t)
   (continue: bool)
   (accu: (U32.t & list t))
-: GTot Type0
+: GTot prop
 = let (len, rem) = accu in
   let sz = Seq.length (serialize (serialize_list p s) input) in
   if continue

--- a/src/lowparse/LowParse.SLow.List.fst
+++ b/src/lowparse/LowParse.SLow.List.fst
@@ -93,7 +93,7 @@ let list_rev_inv
   (#t: Type)
   (l: list t)
   (b: bool)
-  (x: list t * list t)
+  (x: list t & list t)
 : GTot Type0
 = let (rem, acc) = x in
   L.rev l == L.rev_acc rem acc /\
@@ -126,7 +126,7 @@ let parse_list_tailrec_inv
   (p32: parser32 p)
   (input: bytes32)
   (b: bool)
-  (x: option (bytes32 * list t))
+  (x: option (bytes32 & list t))
 : GTot Type0
 = match x with
   | Some (input', accu') ->
@@ -137,7 +137,7 @@ let parse_list_tailrec_inv
 
 let parse_list_tailrec_measure
   (#t: Type)
-  (x: option (bytes32 * list t))
+  (x: option (bytes32 & list t))
 : GTot nat
 = match x with
   | None -> 0
@@ -150,14 +150,14 @@ let parse_list_tailrec_body
   (#p: parser k t)
   (p32: parser32 p)
   (input: bytes32)
-: (x: option (bytes32 * list t)) ->
-  Pure (bool * option (bytes32 * list t))
+: (x: option (bytes32 & list t)) ->
+  Pure (bool & option (bytes32 & list t))
   (requires (parse_list_tailrec_inv p32 input true x))
   (ensures (fun (continue, y) ->
     parse_list_tailrec_inv p32 input continue y /\
     (if continue then parse_list_tailrec_measure y < parse_list_tailrec_measure x else True)
   ))
-= fun (x: option (bytes32 * list t)) ->
+= fun (x: option (bytes32 & list t)) ->
   let (Some (input', accu')) = x in
   let len = B32.len input' in
   if len = 0ul
@@ -205,7 +205,7 @@ let parse32_list
     | None -> None
     | Some res ->
       Some (res, B32.len input)
-  ) <: (res: option (list t * U32.t) { parser32_correct (parse_list p) input res } ))
+  ) <: (res: option (list t & U32.t) { parser32_correct (parse_list p) input res } ))
 
 let rec partial_serialize32_list'
   (#t: Type)
@@ -276,7 +276,7 @@ let partial_serialize32_list'_inv
   (s32: partial_serializer32 s)
   (input: list t)
   (continue: bool)
-  (x: bytes32 * list t)
+  (x: bytes32 & list t)
 : GTot Type0
 = serialize_list_precond k /\
   Seq.length (serialize (serialize_list p s) input) < 4294967296 /\ (
@@ -291,7 +291,7 @@ let partial_serialize32_list'_inv
 
 let partial_serialize32_list'_measure
   (#t: Type)
-  (x: bytes32 * list t)
+  (x: bytes32 & list t)
 : GTot nat
 = L.length (snd x)
 
@@ -303,14 +303,14 @@ let partial_serialize32_list'_body
   (s: serializer p)
   (s32: partial_serializer32 s)
   (input: list t)
-: (x: (bytes32 * list t)) ->
-  Pure (bool * (bytes32 * list t))
+: (x: (bytes32 & list t)) ->
+  Pure (bool & (bytes32 & list t))
   (requires (partial_serialize32_list'_inv p s s32 input true x))
   (ensures (fun (continue, y) ->
     partial_serialize32_list'_inv p s s32 input continue y /\
     (continue == true ==> partial_serialize32_list'_measure y < partial_serialize32_list'_measure x)
   ))
-= fun (x: bytes32 * list t) ->
+= fun (x: bytes32 & list t) ->
   let (accu, input') = x in
   match input' with
   | [] -> (false, x)
@@ -375,7 +375,7 @@ let size32_list_inv
   })
   (input: list t)
   (continue: bool)
-  (accu: (U32.t * list t))
+  (accu: (U32.t & list t))
 : GTot Type0
 = let (len, rem) = accu in
   let sz = Seq.length (serialize (serialize_list p s) input) in
@@ -388,7 +388,7 @@ let size32_list_inv
 
 let size32_list_measure
   (#t: Type)
-  (accu: (U32.t * list t))
+  (accu: (U32.t & list t))
 : GTot nat
 = let (_, rem) = accu in
   L.length rem
@@ -404,8 +404,8 @@ let size32_list_body
     serialize_list_precond k
   })
   (input: list t)
-: (x: (U32.t * list t)) ->
-  Pure (bool * (U32.t * list t))
+: (x: (U32.t & list t)) ->
+  Pure (bool & (U32.t & list t))
   (requires (size32_list_inv s32 u input true x))
   (ensures (fun (continue, y) ->
     size32_list_inv s32 u input continue y /\

--- a/src/lowparse/LowParse.SLow.Option.fst
+++ b/src/lowparse/LowParse.SLow.Option.fst
@@ -9,7 +9,7 @@ inline_for_extraction
 let parse32_option (#k: parser_kind) (#t: Type) (#p: parser k t) (p32: parser32 p) : Tot (parser32 (parse_option p)) =
   fun input -> ((match p32 input with
   | Some (x, consumed) -> Some (Some x, consumed)
-  | _ -> Some (None, 0ul)) <: (y: option (option t * U32.t) { parser32_correct (parse_option p) input y } ))
+  | _ -> Some (None, 0ul)) <: (y: option (option t & U32.t) { parser32_correct (parse_option p) input y } ))
 
 inline_for_extraction
 let serialize32_option (#k: parser_kind) (#t: Type) (#p: parser k t) (#s: serializer p) (s32: serializer32 s) (u: squash (k.parser_kind_low > 0)) : Tot (serializer32 (serialize_option s u)) =

--- a/src/lowparse/LowParse.SLow.Sum.fst
+++ b/src/lowparse/LowParse.SLow.Sum.fst
@@ -19,7 +19,7 @@ let serializer32_sum_gen_precond
 
 inline_for_extraction
 let parse32_sum_t (t: sum) : Tot Type =
-  bytes32 -> Tot (option (sum_type t * U32.t))
+  bytes32 -> Tot (option (sum_type t & U32.t))
 
 let parse32_sum_eq (t: sum) : Tot (parse32_sum_t t -> parse32_sum_t t -> GTot Type0) =
   feq _ _ (eq2 #_)
@@ -60,7 +60,7 @@ let parse32_sum_aux
 = fun input ->
   parse_sum_eq' t p pc (B32.reveal input);
   [@inline_let]
-  let res : option (sum_type t * U32.t) =
+  let res : option (sum_type t & U32.t) =
     //NS: hoist nested match
     //we do not expect the case analysis to
     //on `p32 input` to reduce; hoist it for more efficient
@@ -82,7 +82,7 @@ let parse32_sum_aux
         | Some (x, consumed_x) ->
           Some ((x <: sum_type t), consumed_k `U32.add` consumed_x)
   in
-  (res <: (res: option (sum_type t * U32.t) { parser32_correct (parse_sum t p pc) input res } ))
+  (res <: (res: option (sum_type t & U32.t) { parser32_correct (parse_sum t p pc) input res } ))
 #pop-options
 
 inline_for_extraction
@@ -149,13 +149,13 @@ let parse32_sum'
   (p32: parser32 (parse_enum_key p (sum_enum t)))
   (pc: ((x: sum_key t) -> Tot (k: parser_kind & parser k (sum_type_of_tag t x))))
   (pc32: ((x: sum_key t) -> Tot (parser32 (dsnd (pc x)))))
-  (destr: enum_destr_t (option (sum_type t * U32.t)) (sum_enum t))
+  (destr: enum_destr_t (option (sum_type t & U32.t)) (sum_enum t))
   (input: B32.bytes)
-: Pure (option (sum_type t * U32.t))
+: Pure (option (sum_type t & U32.t))
   (requires True)
   (ensures (fun res -> res == parse32_sum_aux t p p32 pc pc32 input))
 = [@inline_let]
-  let res : option (sum_type t * U32.t) =
+  let res : option (sum_type t & U32.t) =
     //NS: hoist nested match
     let pi = p32 input in
     match pi with
@@ -163,7 +163,7 @@ let parse32_sum'
     | Some (k, consumed_k) ->
         let input_k = B32.b32slice input consumed_k (B32.len input) in
         destr
-          (eq2 #(option (sum_type t * U32.t))) (default_if _)
+          (eq2 #(option (sum_type t & U32.t))) (default_if _)
           (fun _ -> ()) (fun _ _ _ -> ())
           (fun k ->
             //NS: hoist nested match
@@ -186,10 +186,10 @@ let parse32_sum
   (p32: parser32 (parse_enum_key p (sum_enum t)))
   (pc: ((x: sum_key t) -> Tot (k: parser_kind & parser k (sum_type_of_tag t x))))
   (pc32: ((x: sum_key t) -> Tot (parser32 (dsnd (pc x)))))
-  (destr: enum_destr_t (option (sum_type t * U32.t)) (sum_enum t))
+  (destr: enum_destr_t (option (sum_type t & U32.t)) (sum_enum t))
 : Tot (parser32 (parse_sum t p pc))
 = fun input ->
-  (parse32_sum' t p p32 pc pc32 destr input <: (res: option (sum_type t * U32.t) { parser32_correct (parse_sum t p pc) input res } ))
+  (parse32_sum' t p p32 pc pc32 destr input <: (res: option (sum_type t & U32.t) { parser32_correct (parse_sum t p pc) input res } ))
 
 inline_for_extraction
 let parse32_sum2
@@ -199,7 +199,7 @@ let parse32_sum2
   (p32: parser32 p)
   (pc: ((x: sum_key t) -> Tot (k: parser_kind & parser k (sum_type_of_tag t x))))
   (pc32: ((x: sum_key t) -> Tot (parser32 (dsnd (pc x)))))
-  (destr: enum_destr_t (option (sum_type t * U32.t)) (sum_enum t))
+  (destr: enum_destr_t (option (sum_type t & U32.t)) (sum_enum t))
   (f: maybe_enum_key_of_repr'_t (sum_enum t))
 : Tot (parser32 (parse_sum t p pc))
 = parse32_sum t p (parse32_enum_key p32 (sum_enum t) f) pc pc32 destr
@@ -662,7 +662,7 @@ let parse32_dsum_aux
 : GTot (parser32 (parse_dsum t p f g))
 = fun input ->
   parse_dsum_eq' t p f g (B32.reveal input);
-  let res : option (dsum_type t * U32.t) =
+  let res : option (dsum_type t & U32.t) =
     //NS: hoist nested match
     let pi = p32 input in 
     match pi with
@@ -679,7 +679,7 @@ let parse32_dsum_aux
           Some ((x <: dsum_type t), consumed_k `U32.add` consumed_x)
       end
   in
-  (res <: (res: option (dsum_type t * U32.t) { parser32_correct (parse_dsum t p f g) input res } ))
+  (res <: (res: option (dsum_type t & U32.t) { parser32_correct (parse_dsum t p f g) input res } ))
 
 inline_for_extraction
 let parse32_dsum'
@@ -692,19 +692,19 @@ let parse32_dsum'
   (#k': parser_kind)
   (#g: parser k' (dsum_type_of_unknown_tag t))
   (g32: parser32 g)
-  (destr: maybe_enum_destr_t (option (dsum_type t * U32.t)) (dsum_enum t))
+  (destr: maybe_enum_destr_t (option (dsum_type t & U32.t)) (dsum_enum t))
   (input: B32.bytes)
-: Pure (option (dsum_type t * U32.t))
+: Pure (option (dsum_type t & U32.t))
   (requires True)
   (ensures (fun res -> res == parse32_dsum_aux t p32 f f32 g32 input))
 = //NS: hoist nested match
   let pi = p32 input in
   match pi with
-  | None -> None #(dsum_type t * U32.t)
+  | None -> None #(dsum_type t & U32.t)
   | Some (k', consumed_k) ->
     let input_k = B32.b32slice input consumed_k (B32.len input) in
     [@inline_let]
-    let f (k: maybe_enum_key (dsum_enum t)) : Tot (option (dsum_type t * U32.t)) =
+    let f (k: maybe_enum_key (dsum_enum t)) : Tot (option (dsum_type t & U32.t)) =
       //NS: hoist nested match
       let pcases4 = parse32_dsum_cases' t f f32 g g32 k input_k in
       match pcases4 with
@@ -726,10 +726,10 @@ let parse32_dsum
   (#k': parser_kind)
   (#g: parser k' (dsum_type_of_unknown_tag t))
   (g32: parser32 g)
-  (destr: maybe_enum_destr_t (option (dsum_type t * U32.t)) (dsum_enum t))
+  (destr: maybe_enum_destr_t (option (dsum_type t & U32.t)) (dsum_enum t))
 : Tot (parser32 (parse_dsum t p f g))
 = fun input ->
-  (parse32_dsum' t p32 f f32 g32 destr input <: (res: option (dsum_type t * U32.t) { parser32_correct (parse_dsum t p f g) input res } ))
+  (parse32_dsum' t p32 f f32 g32 destr input <: (res: option (dsum_type t & U32.t) { parser32_correct (parse_dsum t p f g) input res } ))
 
 inline_for_extraction
 let serialize32_dsum_type_of_tag

--- a/src/lowparse/LowParse.SLow.VCList.fst
+++ b/src/lowparse/LowParse.SLow.VCList.fst
@@ -86,7 +86,7 @@ let parse_nlist_tailrec_inv
   (input: bytes32)
   (b: bool)
   (x: option (bytes32 & U32.t & list t & U32.t))
-: GTot Type0
+: GTot prop
 = match x with
   | Some (input', i, accu', consumed') ->
     U32.v i <= U32.v n /\
@@ -157,7 +157,7 @@ let parse32_nlist
 let serialize32_nlist_precond
   (n: nat)
   (k: parser_kind)
-: GTot Type0
+: GTot prop
 = k.parser_kind_subkind == Some ParserStrong /\ (
     match k.parser_kind_high with
     | None -> False
@@ -314,7 +314,7 @@ let serialize32_vclist_precond
   (max: nat { min <= max } )
   (lk: parser_kind)
   (k: parser_kind)
-: GTot Type0
+: GTot prop
 = match lk.parser_kind_high, k.parser_kind_high with
   | Some lhi, Some hi ->
     lhi + (max `FStar.Mul.op_Star` hi) < 4294967296

--- a/src/lowparse/LowParse.SLow.VCList.fst
+++ b/src/lowparse/LowParse.SLow.VCList.fst
@@ -13,9 +13,9 @@ let rec parse_nlist_tailrec
   (#k: parser_kind)
   (#t: Type)
   (p: parser k t)
-  (accu: list t * nat)
+  (accu: list t & nat)
   (b: bytes)
-: GTot (option (list t * nat))
+: GTot (option (list t & nat))
 = if n = 0
   then Some accu
   else
@@ -31,7 +31,7 @@ let rec parse_nlist_tailrec_correct'
   (#k: parser_kind)
   (#t: Type)
   (p: parser k t)
-  (accu: list t * nat)
+  (accu: list t & nat)
   (b: bytes)
 : Lemma
   (match parse_nlist_tailrec n p accu b, parse (parse_nlist n p) b with
@@ -82,10 +82,10 @@ let parse_nlist_tailrec_inv
   (#k: parser_kind)
   (#t: Type)
   (p: parser k t)
-  (accu: list t * nat)
+  (accu: list t & nat)
   (input: bytes32)
   (b: bool)
-  (x: option (bytes32 * U32.t * list t * U32.t))
+  (x: option (bytes32 & U32.t & list t & U32.t))
 : GTot Type0
 = match x with
   | Some (input', i, accu', consumed') ->
@@ -99,7 +99,7 @@ let parse_nlist_tailrec_inv
 let parse_nlist_tailrec_measure
   (#t: Type)
   (n: U32.t)
-  (x: option (bytes32 * U32.t * list t * U32.t))
+  (x: option (bytes32 & U32.t & list t & U32.t))
 : GTot nat
 = match x with
   | None -> 0
@@ -113,8 +113,8 @@ let parse_nlist_body
   (#p: parser k t)
   (p32: parser32 p)
   (input: bytes32)
-  (x: option (bytes32 * U32.t * list t * U32.t))
-: Pure (bool * option (bytes32 * U32.t * list t * U32.t))
+  (x: option (bytes32 & U32.t & list t & U32.t))
+: Pure (bool & option (bytes32 & U32.t & list t & U32.t))
   (requires (parse_nlist_tailrec_inv n p ([], 0) input true x))
   (ensures (fun (continue, y) ->
     parse_nlist_tailrec_inv n p ([], 0) input continue y /\
@@ -186,12 +186,12 @@ let serialize32_nlist
       Seq.append_empty_l (serialize (serialize_nlist (n) s) input)
     in
     let x = C.Loops.total_while
-      (fun (x: (list t * bytes32)) -> L.length (fst x))
-      (fun (continue: bool) (x: (list t * bytes32)) ->
+      (fun (x: (list t & bytes32)) -> L.length (fst x))
+      (fun (continue: bool) (x: (list t & bytes32)) ->
         serialize (serialize_nlist (n) s) input == B32.reveal (snd x) `Seq.append` serialize (serialize_nlist (L.length (fst x)) s) (fst x) /\
         (continue == false ==> fst x == [])
       )
-      (fun (x: (list t * bytes32)) ->
+      (fun (x: (list t & bytes32)) ->
          match x with
          | [], res -> (false, x)
          | a :: q, res ->
@@ -238,12 +238,12 @@ let size32_nlist
       parse_nlist_kind_high (n) k
     in
     let x = C.Loops.total_while
-      (fun (x: (list t * U32.t)) -> L.length (fst x))
-      (fun (continue: bool) (x: (list t * U32.t)) ->
+      (fun (x: (list t & U32.t)) -> L.length (fst x))
+      (fun (continue: bool) (x: (list t & U32.t)) ->
         Seq.length (serialize (serialize_nlist (n) s) input) == U32.v (snd x) + Seq.length (serialize (serialize_nlist (L.length (fst x)) s) (fst x)) /\
         (continue == false ==> fst x == [])
       )
-      (fun (x: (list t * U32.t)) ->
+      (fun (x: (list t & U32.t)) ->
          match x with
          | [], res -> (false, x)
          | a :: q, res ->

--- a/src/lowparse/LowParse.SLow.VLData.fst
+++ b/src/lowparse/LowParse.SLow.VLData.fst
@@ -95,7 +95,7 @@ let parse32_bounded_vldata_strong_aux
   (s: serializer p)
   (p32: parser32 p)
   (input: bytes32)
-: Tot (option (parse_bounded_vldata_strong_t min max #k #t #p s * U32.t))
+: Tot (option (parse_bounded_vldata_strong_t min max #k #t #p s & U32.t))
 = let res =
     parse32_strengthen
       #(parse_bounded_vldata_strong_kind min max l k)
@@ -125,7 +125,7 @@ let parse32_bounded_vldata_strong_correct
   (p32: parser32 p)
   (input: bytes32)
 : Lemma
-  ( let res : option (parse_bounded_vldata_strong_t min max s * U32.t) = 
+  ( let res : option (parse_bounded_vldata_strong_t min max s & U32.t) = 
       parse32_bounded_vldata_strong_aux min min32 max max32 l s p32 input
     in
     parser32_correct (parse_bounded_vldata_strong' min max l s) input res)

--- a/src/lowparse/LowParse.Spec.Base.fsti
+++ b/src/lowparse/LowParse.Spec.Base.fsti
@@ -23,13 +23,13 @@ inline_for_extraction
 let consumed_length (b: bytes) : Tot Type = (n: nat { n <= Seq.length b } )
 
 inline_for_extraction
-let bare_parser (t:Type) : Tot Type = (b: bytes) -> GTot (option (t * consumed_length b))
+let bare_parser (t:Type) : Tot Type = (b: bytes) -> GTot (option (t & consumed_length b))
 
 let parse
   (#t: Type)
   (p: bare_parser t)
   (input: bytes)
-: GTot (option (t * consumed_length input))
+: GTot (option (t & consumed_length input))
 = p input
 
 let parse_consume
@@ -362,7 +362,7 @@ let parser
 = (f: bare_parser t { parser_kind_prop k f } )
 
 inline_for_extraction
-let tot_bare_parser (t:Type) : Tot Type = (b: bytes) -> Tot (option (t * consumed_length b))
+let tot_bare_parser (t:Type) : Tot Type = (b: bytes) -> Tot (option (t & consumed_length b))
 
 [@unifier_hint_injective]
 let tot_parser

--- a/src/lowparse/LowParse.Spec.BoundedInt.fsti
+++ b/src/lowparse/LowParse.Spec.BoundedInt.fsti
@@ -20,7 +20,7 @@ val integer_size_values (i: integer_size) : Lemma
 let bounded_integer_prop
   (i: integer_size)
   (u: U32.t)
-: GTot Type0
+: GTot prop
 = U32.v u < (match i with 1 -> 256 | 2 -> 65536 | 3 -> 16777216 | 4 -> 4294967296)
 
 val bounded_integer_prop_equiv

--- a/src/lowparse/LowParse.Spec.Bytes.fst
+++ b/src/lowparse/LowParse.Spec.Bytes.fst
@@ -156,7 +156,7 @@ let parse_bounded_vlbytes_pred
   (min: nat)
   (max: nat { min <= max /\ max > 0 /\ max < 4294967296 } )
   (x: B32.bytes)
-: GTot Type0
+: GTot prop
 = let reslen = B32.length x in
   min <= reslen /\ reslen <= max
 

--- a/src/lowparse/LowParse.Spec.Bytes.fst
+++ b/src/lowparse/LowParse.Spec.Bytes.fst
@@ -76,7 +76,7 @@ let parse_all_bytes_kind =
 
 let parse_all_bytes'
   (input: bytes)
-: Tot (option (B32.bytes * consumed_length input))
+: Tot (option (B32.bytes & consumed_length input))
 = let len = Seq.length input in
   if len >= 4294967296
   then None

--- a/src/lowparse/LowParse.Spec.Combinators.fst
+++ b/src/lowparse/LowParse.Spec.Combinators.fst
@@ -417,10 +417,12 @@ let nondep_then_eq
     end
   | _ -> None
   ))
-
-  by (T.norm [delta_only [`%nondep_then;]])
-  
-= ()
+= parse_tagged_union_eq p1 fst (fun x -> parse_synth p2 (fun y -> (x, y) <: refine_with_tag fst x)) b;
+  match parse p1 b with
+  | None -> ()
+  | Some (x1, consumed1) ->
+    let b' = Seq.slice b consumed1 (Seq.length b) in
+    parse_synth_eq p2 (fun y -> (x1, y) <: refine_with_tag fst x1) b'
 #pop-options
 
 let tot_nondep_then_bare

--- a/src/lowparse/LowParse.Spec.Combinators.fst
+++ b/src/lowparse/LowParse.Spec.Combinators.fst
@@ -389,7 +389,7 @@ let nondep_then
   (#k2: parser_kind)
   (#t2: Type)
   (p2: parser k2 t2)
-: Tot (parser (and_then_kind k1 k2) (t1 * t2))
+: Tot (parser (and_then_kind k1 k2) (t1 & t2))
 = parse_tagged_union
     p1
     fst
@@ -468,7 +468,7 @@ let serialize_nondep_then_eq
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (input: t1 * t2)
+  (input: t1 & t2)
 : Lemma
   (serialize (serialize_nondep_then s1 s2) input == bare_serialize_nondep_then p1 s1 p2 s2 input)
 = ()
@@ -497,7 +497,7 @@ let serialize_nondep_then_upd_left
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t1)
 : Lemma
   (requires (Seq.length (serialize s1 y) == Seq.length (serialize s1 (fst x))))
@@ -521,7 +521,7 @@ let serialize_nondep_then_upd_left_chain
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t1)
   (i' : nat)
   (s' : bytes)
@@ -554,7 +554,7 @@ let serialize_nondep_then_upd_bw_left
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t1)
 : Lemma
   (requires (Seq.length (serialize s1 y) == Seq.length (serialize s1 (fst x))))
@@ -577,7 +577,7 @@ let serialize_nondep_then_upd_bw_left_chain
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t1)
   (i' : nat)
   (s' : bytes)
@@ -606,7 +606,7 @@ let serialize_nondep_then_upd_right
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t2)
 : Lemma
   (requires (Seq.length (serialize s2 y) == Seq.length (serialize s2 (snd x))))
@@ -630,7 +630,7 @@ let serialize_nondep_then_upd_right_chain
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t2)
   (i' : nat)
   (s' : bytes)

--- a/src/lowparse/LowParse.Spec.Combinators.fsti
+++ b/src/lowparse/LowParse.Spec.Combinators.fsti
@@ -1040,7 +1040,7 @@ let bare_parse_tagged_union
   (k': (t: tag_t) -> Tot parser_kind)
   (p: (t: tag_t) -> Tot (parser (k' t) (refine_with_tag tag_of_data t)))
   (input: bytes)
-: GTot (option (data_t * consumed_length input))
+: GTot (option (data_t & consumed_length input))
 = match parse pt input with
   | None -> None
   | Some (tg, consumed_tg) ->
@@ -1532,7 +1532,7 @@ val nondep_then
   (#k2: parser_kind)
   (#t2: Type)
   (p2: parser k2 t2)
-: Tot (parser (and_then_kind k1 k2) (t1 * t2))
+: Tot (parser (and_then_kind k1 k2) (t1 & t2))
 
 #set-options "--z3rlimit 16"
 
@@ -1624,7 +1624,7 @@ val tot_nondep_then
   (#k2: parser_kind)
   (#t2: Type)
   (p2: tot_parser k2 t2)
-: Pure (tot_parser (and_then_kind k1 k2) (t1 * t2))
+: Pure (tot_parser (and_then_kind k1 k2) (t1 & t2))
   (requires True)
   (ensures (fun y ->
     forall x . parse y x == parse (nondep_then #k1 p1 #k2 p2) x
@@ -1639,8 +1639,8 @@ let bare_serialize_nondep_then
   (#t2: Type)
   (p2: parser k2 t2)
   (s2: serializer p2)
-: Tot (bare_serializer (t1 * t2))
-= fun (x: t1 * t2) ->
+: Tot (bare_serializer (t1 & t2))
+= fun (x: t1 & t2) ->
   let (x1, x2) = x in
   Seq.append (s1 x1) (s2 x2)
 
@@ -1664,7 +1664,7 @@ val serialize_nondep_then_eq
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (input: t1 * t2)
+  (input: t1 & t2)
 : Lemma
   (serialize (serialize_nondep_then s1 s2) input == bare_serialize_nondep_then p1 s1 p2 s2 input)
 
@@ -1691,7 +1691,7 @@ val serialize_nondep_then_upd_left
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t1)
 : Lemma
   (requires (Seq.length (serialize s1 y) == Seq.length (serialize s1 (fst x))))
@@ -1710,7 +1710,7 @@ val serialize_nondep_then_upd_left_chain
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t1)
   (i' : nat)
   (s' : bytes)
@@ -1735,7 +1735,7 @@ val serialize_nondep_then_upd_bw_left
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t1)
 : Lemma
   (requires (Seq.length (serialize s1 y) == Seq.length (serialize s1 (fst x))))
@@ -1757,7 +1757,7 @@ val serialize_nondep_then_upd_bw_left_chain
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t1)
   (i' : nat)
   (s' : bytes)
@@ -1783,7 +1783,7 @@ val serialize_nondep_then_upd_right
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t2)
 : Lemma
   (requires (Seq.length (serialize s2 y) == Seq.length (serialize s2 (snd x))))
@@ -1802,7 +1802,7 @@ val serialize_nondep_then_upd_right_chain
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t2)
   (i' : nat)
   (s' : bytes)
@@ -1829,7 +1829,7 @@ let serialize_nondep_then_upd_bw_right
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t2)
 : Lemma
   (requires (Seq.length (serialize s2 y) == Seq.length (serialize s2 (snd x))))
@@ -1849,7 +1849,7 @@ let serialize_nondep_then_upd_bw_right_chain
   (#t2: Type)
   (#p2: parser k2 t2)
   (s2: serializer p2)
-  (x: t1 * t2)
+  (x: t1 & t2)
   (y: t2)
   (i' : nat)
   (s' : bytes)
@@ -1880,8 +1880,8 @@ let tot_bare_serialize_nondep_then
   (s1: tot_bare_serializer t1)
   (#t2: Type)
   (s2: tot_bare_serializer t2)
-: Tot (tot_bare_serializer (t1 * t2))
-= fun (x: t1 * t2) ->
+: Tot (tot_bare_serializer (t1 & t2))
+= fun (x: t1 & t2) ->
   let (x1, x2) = x in
   Seq.append (s1 x1) (s2 x2)
 
@@ -1905,7 +1905,7 @@ val tot_serialize_nondep_then_eq
   (#t2: Type)
   (#p2: tot_parser k2 t2)
   (s2: tot_serializer #k2 p2)
-  (input: t1 * t2)
+  (input: t1 & t2)
 : Lemma
   (bare_serialize (tot_serialize_nondep_then s1 s2) input == tot_bare_serialize_nondep_then s1 s2 input)
 

--- a/src/lowparse/LowParse.Spec.Defaultable.fsti
+++ b/src/lowparse/LowParse.Spec.Defaultable.fsti
@@ -20,14 +20,14 @@ let parse_defaultable_kind (k : parser_kind) : Tot parser_kind = {
   parser_kind_injective = k.parser_kind_injective;
 }
 
-let parse_defaultable_injective_cond (#k : parser_kind) (#t : Type) (defaultablev : option t) (p : parser k t) (b : bytes) : GTot Type0 =
+let parse_defaultable_injective_cond (#k : parser_kind) (#t : Type) (defaultablev : option t) (p : parser k t) (b : bytes) : GTot prop =
   match defaultablev with
   | None -> True
   | Some v -> match (parse p b) with
     | None -> True
     | Some (v', _) -> ~ (v == v')
 
-let parse_defaultable_injective_cond_prop (#k : parser_kind) (#t : Type) (defaultablev : option t) (p : parser k t) : GTot Type0 =
+let parse_defaultable_injective_cond_prop (#k : parser_kind) (#t : Type) (defaultablev : option t) (p : parser k t) : GTot prop =
   forall (b : bytes) . parse_defaultable_injective_cond defaultablev p b
 
 

--- a/src/lowparse/LowParse.Spec.Defaultable.fsti
+++ b/src/lowparse/LowParse.Spec.Defaultable.fsti
@@ -6,7 +6,7 @@ let mk_option_tuple
   (#t #t' : Type)
   (a : option t)
   (b : option t')
-: option (t * t')
+: option (t & t')
 = match a, b with
   | None, _
   | _, None -> None

--- a/src/lowparse/LowParse.Spec.Enum.fst
+++ b/src/lowparse/LowParse.Spec.Enum.fst
@@ -13,7 +13,7 @@ let rec list_map
   | [] -> []
   | a :: q -> f a :: list_map f q
 
-type enum (key: eqtype) (repr: eqtype) = (l: list (key * repr) {
+type enum (key: eqtype) (repr: eqtype) = (l: list (key & repr) {
   L.noRepeats (list_map fst l) /\
   L.noRepeats (list_map snd l)
 })
@@ -40,21 +40,21 @@ let make_enum_key (#key #repr: eqtype) (e: enum key repr) (k: key) : Pure (enum_
 inline_for_extraction
 let enum_repr (#key #repr: eqtype) (e: enum key repr) : Tot eqtype = (r: repr { list_mem r (list_map snd e) } )
 
-let flip (#a #b: Type) (c: (a * b)) : Tot (b * a) = let (ca, cb) = c in (cb, ca)
+let flip (#a #b: Type) (c: (a & b)) : Tot (b & a) = let (ca, cb) = c in (cb, ca)
 
-let rec map_flip_flip (#a #b: Type) (l: list (a * b)) : Lemma
+let rec map_flip_flip (#a #b: Type) (l: list (a & b)) : Lemma
   (list_map flip (list_map flip l) == l)
 = match l with
   | [] -> ()
   | _ :: q -> map_flip_flip q
 
-let rec map_fst_flip (#a #b: Type) (l: list (a * b)) : Lemma
+let rec map_fst_flip (#a #b: Type) (l: list (a & b)) : Lemma
   (list_map fst (list_map flip l) == list_map snd l)
 = match l with
   | [] -> ()
   | _ :: q -> map_fst_flip q
 
-let rec map_snd_flip (#a #b: Type) (l: list (a * b)) : Lemma
+let rec map_snd_flip (#a #b: Type) (l: list (a & b)) : Lemma
   (list_map snd (list_map flip l) == list_map fst l)
 = match l with
   | [] -> ()
@@ -62,7 +62,7 @@ let rec map_snd_flip (#a #b: Type) (l: list (a * b)) : Lemma
 
 let rec assoc_mem_snd
   (#a #b: eqtype)
-  (l: list (a * b))
+  (l: list (a & b))
   (x: a)
   (y: b)
 : Lemma
@@ -76,7 +76,7 @@ let rec assoc_mem_snd
 
 let rec assoc_flip_elim
   (#a #b: eqtype)
-  (l: list (a * b))
+  (l: list (a & b))
   (y: b)
   (x: a)
 : Lemma
@@ -106,7 +106,7 @@ let rec assoc_flip_elim
 
 let rec assoc_flip_intro
   (#a #b: eqtype)
-  (l: list (a * b))
+  (l: list (a & b))
   (y: b)
   (x: a)
 : Lemma
@@ -131,7 +131,7 @@ let enum_key_of_repr
   (requires True)
   (ensures (fun y -> L.assoc y e == Some r))
 = map_fst_flip e;
-  let e' = list_map #(key * repr) #(repr * key) flip e in
+  let e' = list_map #(key & repr) #(repr & key) flip e in
   L.assoc_mem r e';
   let k = Some?.v (L.assoc r e') in
   assoc_flip_elim e r k;
@@ -329,7 +329,7 @@ let serialize_maybe_enum_key_eq
   (serialize (serialize_maybe_enum_key p s e) x == serialize s (repr_of_maybe_enum_key e x))
 = serialize_synth_eq p (maybe_enum_key_of_repr e) s (repr_of_maybe_enum_key e) () x 
 
-let is_total_enum (#key: eqtype) (#repr: eqtype) (l: list (key * repr)) : GTot Type0 =
+let is_total_enum (#key: eqtype) (#repr: eqtype) (l: list (key & repr)) : GTot Type0 =
   forall (k: key) . {:pattern (list_mem k (list_map fst l))} list_mem k (list_map fst l)
 
 let total_enum (key: eqtype) (repr: eqtype) : Tot eqtype =
@@ -631,7 +631,7 @@ let enum_destr_cons
   let _ = r_reflexive_t_elim _ _ eq_refl in
   [@inline_let]
   let _ = r_transitive_t_elim _ _ eq_trans in
-  (fun (e' : list (key * repr) { e' == e } ) -> match e' with
+  (fun (e' : list (key & repr) { e' == e } ) -> match e' with
      | (k, _) :: _ ->
      (fun (f: (enum_key e -> Tot t)) (x: enum_key e) -> ((
        [@inline_let]
@@ -677,7 +677,7 @@ let enum_destr_cons_nil
 = fun (eq: (t -> t -> GTot Type0)) (ift: if_combinator t eq) (eq_refl: r_reflexive_t _ eq) (eq_trans: r_transitive_t _ eq) ->
   [@inline_let]
   let _ = r_reflexive_t_elim _ _ eq_refl in
-  (fun (e' : list (key * repr) { e' == e } ) -> match e' with
+  (fun (e' : list (key & repr) { e' == e } ) -> match e' with
      | (k, _) :: _ ->
      (fun (f: (enum_key e -> Tot t)) (x: enum_key e) -> ((
        f k
@@ -794,7 +794,7 @@ let dep_enum_destr_cons_nil
 (* Destructor from the representation *)
 
 
-let maybe_enum_key_of_repr_not_in (#key #repr: eqtype) (e: enum key repr) (l: list (key * repr)) (x: repr) : GTot Type0 =
+let maybe_enum_key_of_repr_not_in (#key #repr: eqtype) (e: enum key repr) (l: list (key & repr)) (x: repr) : GTot Type0 =
   (~ (L.mem x (L.map snd l)))
 
 let list_rev_cons
@@ -813,7 +813,7 @@ let list_append_rev_cons (#t: Type) (l1: list t) (x: t) (l2: list t) : Lemma
 
 let rec assoc_append_flip_l_intro
   (#key #repr: eqtype)
-  (l1 l2: list (key * repr))
+  (l1 l2: list (key & repr))
   (y: repr)
   (x: key)
 : Lemma
@@ -833,7 +833,7 @@ let maybe_enum_destr_t'
   (t: Type)
   (#key #repr: eqtype)  
   (e: enum key repr)
-  (l1 l2: list (key * repr))
+  (l1 l2: list (key & repr))
   (u1: squash (e == L.append (L.rev l1) l2))
 : Tot Type
 = (eq: (t -> t -> GTot Type0)) ->
@@ -887,7 +887,7 @@ let maybe_enum_key_of_repr_not_in_cons
   (e: enum key repr)
   (k: key)
   (r: repr)
-  (l: list (key * repr))
+  (l: list (key & repr))
   (x: repr)
 : Lemma
   (requires (maybe_enum_key_of_repr_not_in e l x /\ x <> r))
@@ -916,8 +916,8 @@ let maybe_enum_destr_cons
   (t: Type)
   (#key #repr: eqtype)
   (e: enum key repr)
-  (l1: list (key * repr))
-  (l2: list (key * repr))
+  (l1: list (key & repr))
+  (l2: list (key & repr))
   (u1: squash (Cons? l2 /\ e == L.append (L.rev l1) l2))
   (g: (maybe_enum_destr_t' t e (list_hd l2 :: l1) (list_tl l2) (list_append_rev_cons l1 (list_hd l2) (list_tl l2))))
 : Tot (maybe_enum_destr_t' t e l1 l2 u1)
@@ -967,8 +967,8 @@ let maybe_enum_destr_nil
   (t: Type)
   (#key #repr: eqtype)
   (e: enum key repr)
-  (l1: list (key * repr))
-  (l2: list (key * repr))
+  (l1: list (key & repr))
+  (l2: list (key & repr))
   (u1: squash (Nil? l2 /\ e == L.append (L.rev l1) []))
 : Tot (maybe_enum_destr_t' t e l1 l2 u1)
 = fun (eq: (t -> t -> GTot Type0)) (ift: if_combinator t eq) (eq_refl: r_reflexive_t _ eq) (eq_trans: r_transitive_t _ eq) (f: (maybe_enum_key e -> Tot t)) ->
@@ -988,8 +988,8 @@ let rec mk_maybe_enum_destr'
   (t: Type)
   (#key #repr: eqtype)
   (e: enum key repr)
-  (l1: list (key * repr))
-  (l2: list (key * repr))
+  (l1: list (key & repr))
+  (l2: list (key & repr))
   (u: squash (e == L.rev l1 `L.append` l2))
 : Tot (maybe_enum_destr_t' t e l1 l2 u)
   (decreases l2)
@@ -1029,7 +1029,7 @@ let dep_maybe_enum_destr_t'
   (#key #repr: eqtype)
   (e: enum key repr)
   (v: (maybe_enum_key e -> Tot Type))
-  (l1 l2: list (key * repr))
+  (l1 l2: list (key & repr))
   (u1: squash (e == L.append (L.rev l1) l2))
 : Tot Type
 = (v_eq: ((k: maybe_enum_key e) -> v k -> v k -> GTot Type0)) ->
@@ -1054,8 +1054,8 @@ let dep_maybe_enum_destr_cons
   (#key #repr: eqtype)
   (e: enum key repr)
   (v: (maybe_enum_key e -> Tot Type))
-  (l1: list (key * repr))
-  (l2: list (key * repr))
+  (l1: list (key & repr))
+  (l2: list (key & repr))
   (u1: squash (Cons? l2 /\ e == L.append (L.rev l1) l2))
   (g: (dep_maybe_enum_destr_t' e v (list_hd l2 :: l1) (list_tl l2) (list_append_rev_cons l1 (list_hd l2) (list_tl l2))))
 : Tot (dep_maybe_enum_destr_t' e v l1 l2 u1)
@@ -1105,8 +1105,8 @@ let dep_maybe_enum_destr_nil
   (#key #repr: eqtype)
   (e: enum key repr)
   (v: (maybe_enum_key e -> Tot Type))
-  (l1: list (key * repr))
-  (l2: list (key * repr))
+  (l1: list (key & repr))
+  (l2: list (key & repr))
   (u1: squash (Nil? l2 /\ e == L.append (L.rev l1) []))
 : Tot (dep_maybe_enum_destr_t' e v l1 l2 u1)
 = fun
@@ -1134,8 +1134,8 @@ let rec mk_dep_maybe_enum_destr'
   (#key #repr: eqtype)
   (e: enum key repr)
   (v: (maybe_enum_key e -> Tot Type))
-  (l1: list (key * repr))
-  (l2: list (key * repr))
+  (l1: list (key & repr))
+  (l2: list (key & repr))
   (u1: squash (e == L.append (L.rev l1) l2))
 : Tot (dep_maybe_enum_destr_t' e v l1 l2 u1)
   (decreases l2)
@@ -1226,7 +1226,7 @@ let enum_repr_of_key_cons
 : Pure (enum_repr_of_key'_t e)
   (requires (Cons? e))
   (ensures (fun _ -> True))
-= (fun (e' : list (key * repr) { e' == e } ) -> match e' with
+= (fun (e' : list (key & repr) { e' == e } ) -> match e' with
      | (k, r) :: _ ->
      (fun (x: enum_key e) -> (
       if k = x
@@ -1251,7 +1251,7 @@ let enum_repr_of_key_cons_nil
 : Pure (enum_repr_of_key'_t e)
   (requires (Cons? e /\ Nil? (enum_tail' e)))
   (ensures (fun _ -> True))
-= (fun (e' : list (key * repr) { e' == e } ) -> match e' with
+= (fun (e' : list (key & repr) { e' == e } ) -> match e' with
      | [(k, r)] ->
      (fun (x: enum_key e) ->
       (r <: (r: enum_repr e { enum_repr_of_key e x == r } ))))
@@ -1299,7 +1299,7 @@ let maybe_enum_key_of_repr'_t_cons_nil
 : Pure (maybe_enum_key_of_repr'_t e)
   (requires (Cons? e /\ Nil? (enum_tail' e)))
   (ensures (fun _ -> True))
-= (fun (e' : list (key * repr) { e' == e } ) -> match e' with
+= (fun (e' : list (key & repr) { e' == e } ) -> match e' with
   | [(k, r)] ->
     (fun x -> ((
       if r = x
@@ -1325,7 +1325,7 @@ let maybe_enum_key_of_repr'_t_cons
 : Pure (maybe_enum_key_of_repr'_t e)
   (requires (Cons? e))
   (ensures (fun _ -> True))
-= (fun (e' : list (key * repr) { e' == e } ) -> match e' with
+= (fun (e' : list (key & repr) { e' == e } ) -> match e' with
      | (k, r) :: _ ->
      (fun x -> ((
         if r = x

--- a/src/lowparse/LowParse.Spec.FLData.fst
+++ b/src/lowparse/LowParse.Spec.FLData.fst
@@ -116,7 +116,7 @@ let parse_fldata_strong_pred
   (s: serializer p)
   (sz: nat)
   (x: t)
-: GTot Type0
+: GTot prop
 = Seq.length (serialize s x) == sz
 
 let parse_fldata_strong_t

--- a/src/lowparse/LowParse.Spec.List.fst
+++ b/src/lowparse/LowParse.Spec.List.fst
@@ -109,7 +109,7 @@ let rec tot_parse_list_aux
   (#t: Type)
   (p: tot_parser k t)
   (b: bytes)
-: Pure (option (list t * (consumed_length b)))
+: Pure (option (list t & (consumed_length b)))
     (requires True)
     (ensures (fun y -> y == parse_list_aux #k p b))
     (decreases (Seq.length b))

--- a/src/lowparse/LowParse.Spec.List.fsti
+++ b/src/lowparse/LowParse.Spec.List.fsti
@@ -13,7 +13,7 @@ let rec parse_list_aux
   (#t: Type)
   (p: parser k t)
   (b: bytes)
-: GTot (option (list t * (consumed_length b)))
+: GTot (option (list t & (consumed_length b)))
   (decreases (Seq.length b))
 = if Seq.length b = 0
   then 

--- a/src/lowparse/LowParse.Spec.Seq.fst
+++ b/src/lowparse/LowParse.Spec.Seq.fst
@@ -15,7 +15,7 @@ val parse_seq_aux
   (#t: Type)
   (p: bare_parser t)
   (b: bytes)
-: GTot (option (Seq.seq t * (consumed_length b)))
+: GTot (option (Seq.seq t & (consumed_length b)))
   (decreases (Seq.length b))
 
 let rec parse_seq_aux #t p b =

--- a/src/lowparse/LowParse.Spec.SeqBytes.fst
+++ b/src/lowparse/LowParse.Spec.SeqBytes.fst
@@ -23,7 +23,7 @@ let parse_seq_all_bytes_kind =
 
 let parse_seq_all_bytes'
   (input: bytes)
-: GTot (option (bytes * consumed_length input))
+: GTot (option (bytes & consumed_length input))
 = let len = Seq.length input in
     Some (input, len)
 

--- a/src/lowparse/LowParse.Spec.SeqBytes.fst
+++ b/src/lowparse/LowParse.Spec.SeqBytes.fst
@@ -87,7 +87,7 @@ let parse_bounded_seq_vlbytes_pred
   (min: nat)
   (max: nat { min <= max /\ max > 0 /\ max < 4294967296 } )
   (x: bytes)
-: GTot Type0
+: GTot prop
 = let reslen = Seq.length x in
   min <= reslen /\ reslen <= max
 

--- a/src/lowparse/LowParse.Spec.Sum.fst
+++ b/src/lowparse/LowParse.Spec.Sum.fst
@@ -435,7 +435,7 @@ let synth_case_recip_synth_case_post
   (synth_case: ((x: enum_key e) -> (y: type_of_tag x) -> Tot (refine_with_tag tag_of_data x)))
   (synth_case_recip: ((k: enum_key e) -> (x: refine_with_tag tag_of_data k) -> Tot (type_of_tag k)))
   (x: key)
-: GTot Type0
+: GTot prop
 = 
   list_mem x (list_map fst e) ==> (
     forall (y: type_of_tag x) . {:pattern (synth_case_recip' e tag_of_data type_of_tag synth_case_recip (synth_case x y))}
@@ -1028,7 +1028,7 @@ let synth_dsum_case_recip_synth_case_known_post
   (synth_case: ((x: maybe_enum_key e) -> (y: dsum_type_of_tag' e type_of_known_tag type_of_unknown_tag x) -> Tot (refine_with_tag tag_of_data x)))
   (synth_case_recip: ((k: maybe_enum_key e) -> (refine_with_tag tag_of_data k) -> Tot (dsum_type_of_tag' e type_of_known_tag type_of_unknown_tag k)))
   (x: key)
-: GTot Type0
+: GTot prop
 = 
   list_mem x (list_map fst e) ==> (
     forall (y: type_of_known_tag x) . {:pattern (synth_case_recip (Known x) (synth_case (Known x) y))}
@@ -1045,7 +1045,7 @@ let synth_dsum_case_recip_synth_case_unknown_post
   (synth_case: ((x: maybe_enum_key e) -> (y: dsum_type_of_tag' e type_of_known_tag type_of_unknown_tag x) -> Tot (refine_with_tag tag_of_data x)))
   (synth_case_recip: ((k: maybe_enum_key e) -> (refine_with_tag tag_of_data k) -> Tot (dsum_type_of_tag' e type_of_known_tag type_of_unknown_tag k)))
   (x: repr)
-: GTot Type0
+: GTot prop
 = 
   list_mem x (list_map snd e) == false ==> (
     forall (y: type_of_unknown_tag) . {:pattern (synth_case_recip (Unknown x) (synth_case (Unknown x) y))}

--- a/src/lowparse/LowParse.Spec.Tac.Enum.fst
+++ b/src/lowparse/LowParse.Spec.Tac.Enum.fst
@@ -22,7 +22,7 @@ let rec enum_tac_gen
   (t_cons_nil: T.term)
   (t_cons: T.term)
   (#key #repr: Type)
-  (e: list (key * repr))
+  (e: list (key & repr))
 : T.Tac unit
 = match e with
   | [] -> T.fail "enum_tac_gen: e must be cons"
@@ -44,14 +44,14 @@ let rec enum_tac_gen
 noextract
 let maybe_enum_key_of_repr_tac
   (#key #repr: Type)
-  (e: list (key * repr))
+  (e: list (key & repr))
 : T.Tac unit
 = enum_tac_gen (quote maybe_enum_key_of_repr'_t_cons_nil') (quote maybe_enum_key_of_repr'_t_cons') e
 
 noextract
 let enum_repr_of_key_tac
   (#key #repr: Type)
-  (e: list (key * repr))
+  (e: list (key & repr))
 : T.Tac unit
 = enum_tac_gen (quote enum_repr_of_key_cons_nil') (quote enum_repr_of_key_cons') e
 

--- a/src/lowparse/LowParse.Spec.Tac.Sum.fst
+++ b/src/lowparse/LowParse.Spec.Tac.Sum.fst
@@ -11,7 +11,7 @@ module U32 = FStar.UInt32
 noextract
 let enum_destr_tac
   (#key #repr: Type)
-  (e: list (key * repr))
+  (e: list (key & repr))
 : T.Tac unit
 = enum_tac_gen (quote enum_destr_cons_nil') (quote enum_destr_cons') e
 

--- a/src/lowparse/LowParse.Spec.VCList.fsti
+++ b/src/lowparse/LowParse.Spec.VCList.fsti
@@ -26,7 +26,7 @@ let nlist_cons (#t: Type) (#n: nat) (a: t) (q: nlist n t) : Tot (nlist (n + 1) t
 
 // abstract
 inline_for_extraction
-let nlist_destruct (#t: Type) (#n: nat) (x: nlist (n + 1) t) : Tot (t * nlist n t) =
+let nlist_destruct (#t: Type) (#n: nat) (x: nlist (n + 1) t) : Tot (t & nlist n t) =
   match x with (a :: q) -> a, q
 
 // abstract
@@ -37,12 +37,12 @@ let nlist_cons_unique (#t: Type) (#n: nat) (x: nlist (n + 1) t) : Lemma
 unfold let mul = Prims.op_Multiply
 
 inline_for_extraction
-let synth_nlist (#t: Type) (n: nat) (xy: t * nlist n t) : Tot (nlist (n + 1) t) =
+let synth_nlist (#t: Type) (n: nat) (xy: t & nlist n t) : Tot (nlist (n + 1) t) =
   match xy with (x, y) ->
   nlist_cons x y
 
 inline_for_extraction
-let synth_nlist_recip (#t: Type) (n: nat) (xy: nlist (n + 1) t) : Tot (t * nlist n t) =
+let synth_nlist_recip (#t: Type) (n: nat) (xy: nlist (n + 1) t) : Tot (t & nlist n t) =
   nlist_destruct xy
 
 // abstract

--- a/src/lowparse/LowParse.Spec.VLData.fsti
+++ b/src/lowparse/LowParse.Spec.VLData.fsti
@@ -421,7 +421,7 @@ let parse_bounded_vldata_strong_pred
   (#p: parser k t)
   (s: serializer p)
   (x: t)
-: GTot Type0
+: GTot prop
 = let reslen = Seq.length (s x) in
   min <= reslen /\ reslen <= max
 

--- a/src/lowparse/LowParse.TacLib.fst
+++ b/src/lowparse/LowParse.TacLib.fst
@@ -27,7 +27,7 @@ let solve_vc ()
 
 [@@ noextract_to "krml"]
 let app_head_tail (t: term) :
-    Tac (term * list argv)
+    Tac (term & list argv)
 = collect_app t
 
 [@@ noextract_to "krml"]

--- a/src/lowparse/LowParse.TestLib.SLow.fst
+++ b/src/lowparse/LowParse.TestLib.SLow.fst
@@ -13,7 +13,7 @@ module U32 = FStar.UInt32
 (** The type of a unit test.  It takes an input Bytes, parses it,
     and returns a newly formatted Bytes.  Or it returns None if
     there is a fail to parse. *)
-type test_t = (input:FStar.Bytes.bytes) -> Stack (option (FStar.Bytes.bytes * U32.t)) (fun _ -> true) (fun _ _ _ -> true)
+type test_t = (input:FStar.Bytes.bytes) -> Stack (option (FStar.Bytes.bytes & U32.t)) (fun _ -> true) (fun _ _ _ -> true)
 
 assume val load_file: (filename:string) -> Tot FStar.Bytes.bytes
 

--- a/src/lowparse/LowParse.Tot.Combinators.fst
+++ b/src/lowparse/LowParse.Tot.Combinators.fst
@@ -181,7 +181,7 @@ val nondep_then
   (#k2: parser_kind)
   (#t2: Type)
   (p2: parser k2 t2)
-: Tot (parser (and_then_kind k1 k2) (t1 * t2))
+: Tot (parser (and_then_kind k1 k2) (t1 & t2))
 
 let nondep_then #k1 = tot_nondep_then #k1
 

--- a/src/lowparse/LowParse.Tot.DER.fst
+++ b/src/lowparse/LowParse.Tot.DER.fst
@@ -8,7 +8,7 @@ module U8 = FStar.UInt8
 let parse_der_length_payload32_bare
   (x: U8.t { der_length_payload_size_of_tag x <= 4 } )
   (input: bytes)
-: Pure (option ((refine_with_tag tag_of_der_length32 x) * consumed_length input))
+: Pure (option ((refine_with_tag tag_of_der_length32 x) & consumed_length input))
     (requires True)
     (ensures (fun y ->
       y == parse (parse_der_length_payload32 x) input

--- a/src/lowparse/LowParse.Tot.Defaultable.fst
+++ b/src/lowparse/LowParse.Tot.Defaultable.fst
@@ -2,10 +2,10 @@ module LowParse.Tot.Defaultable
 include LowParse.Spec.Defaultable
 include LowParse.Tot.Combinators
 
-let parse_defaultable_injective_cond (#k : parser_kind) (#t : Type) (defaultablev : option t) (p : parser k t) (b : bytes) : GTot Type0 =
+let parse_defaultable_injective_cond (#k : parser_kind) (#t : Type) (defaultablev : option t) (p : parser k t) (b : bytes) : GTot prop =
   parse_defaultable_injective_cond #k defaultablev p b
 
-let parse_defaultable_injective_cond_prop (#k : parser_kind) (#t : Type) (defaultablev : option t) (p : parser k t) : GTot Type0 =
+let parse_defaultable_injective_cond_prop (#k : parser_kind) (#t : Type) (defaultablev : option t) (p : parser k t) : GTot prop =
   parse_defaultable_injective_cond_prop #k defaultablev p
 
 val parse_defaultable (#k: parser_kind) (#t : Type) (defaultablev : option t) (p : parser k t) : Pure (parser (parse_defaultable_kind k) t) 

--- a/src/lowparse/pulse/LowParse.Pulse.Sum.Aux.fst
+++ b/src/lowparse/pulse/LowParse.Pulse.Sum.Aux.fst
@@ -64,7 +64,7 @@ let l2r_leaf_write_sum_cases_t_eq
   (sc: ((x: sum_key t) -> Tot (serializer (dsnd (pc x)))))
   (k: sum_key t)
   (x y: l2r_leaf_write_sum_cases_t t sc k)
-: GTot Type0
+: GTot prop
 = True
 
 inline_for_extraction

--- a/src/qd/rfc_fstar_compiler.ml
+++ b/src/qd/rfc_fstar_compiler.ml
@@ -2601,7 +2601,7 @@ and compile_typedef tch o i tn fn (ty:type_t) vec def al =
 
     (* Fixed length list *)
     | VectorFixed k when elem_li.min_len = elem_li.max_len ->
-      w i "unfold let %s_pred (l:list %s) (n:nat) : GTot Type0 = L.length l == n\n" n (compile_type ty);
+      w i "unfold let %s_pred (l:list %s) (n:nat) : GTot prop = L.length l == n\n" n (compile_type ty);
       w i "type %s = l:list %s{%s_pred l %d}\n\n" n (compile_type ty) n li.min_count;
       write_api o i false is_private li.meta n li.min_len li.max_len;
       w o "type %s' = LP.array %s %d\n\n" n (compile_type ty) li.min_count;

--- a/tests/lowparse/LowParseExample.Aux.fst
+++ b/tests/lowparse/LowParseExample.Aux.fst
@@ -17,7 +17,7 @@ let case_B = (x: U16.t { parse_case_B_filter x } )
 
 noeq
 type t =
-  | A of (U8.t * U8.t)
+  | A of (U8.t & U8.t)
   | B of case_B
   | V2 of U16.t
   | V3 of U16.t
@@ -62,7 +62,7 @@ let u8 : eqtype = U8.t
 inline_for_extraction
 let case_enum : LP.enum cases u8 =
   [@inline_let]
-  let e : list (cases * U8.t) = [
+  let e : list (cases & U8.t) = [
     Case_A, 18uy;
     Case_B, 42uy;
     Case_V2, 71uy;
@@ -134,7 +134,7 @@ let type_of_case
   (x: cases)
 : Tot Type0
 = match x with
-  | Case_A -> U8.t * U8.t
+  | Case_A -> U8.t & U8.t
   | Case_B -> case_B
   | Case_V2 -> U16.t
   | Case_V3 -> U16.t
@@ -324,7 +324,7 @@ let parse32_cases
 
 inline_for_extraction
 let parse32_case_destr
-: (LP.enum_destr_t (option (t * FStar.UInt32.t)) case_enum)
+: (LP.enum_destr_t (option (t & FStar.UInt32.t)) case_enum)
 = _ by (LP.enum_destr_tac case_enum)
 
 let parse32_case_enum

--- a/tests/lowparse/LowParseExample.fst
+++ b/tests/lowparse/LowParseExample.fst
@@ -11,7 +11,7 @@ open LowParse.TestLib.SLow
 module Aux = LowParseExample.Aux
 
 (*
-let f (input: FStar.Bytes.bytes) : Pure (option (LowParseExample.Aux.t * FStar.UInt32.t))
+let f (input: FStar.Bytes.bytes) : Pure (option (LowParseExample.Aux.t & FStar.UInt32.t))
   (requires True)
   (ensures (fun res ->
     match res with
@@ -24,10 +24,10 @@ let f (input: FStar.Bytes.bytes) : Pure (option (LowParseExample.Aux.t * FStar.U
   let _ = LowParse.SLow.Base.parser32_consumes LowParseExample.Aux.parse32_t input in
   res
 
-let g (input: FStar.Bytes.bytes) : Tot (option (LowParse.SLow.array LowParseExample.Aux.t 18 * FStar.UInt32.t)) =
+let g (input: FStar.Bytes.bytes) : Tot (option (LowParse.SLow.array LowParseExample.Aux.t 18 & FStar.UInt32.t)) =
   LowParseExample.Aux.parse32_t_array input
 
-let j (input: FStar.Bytes.bytes) : Tot (option (LowParse.SLow.vlarray LowParseExample.Aux.t 5 7 * FStar.UInt32.t)) =
+let j (input: FStar.Bytes.bytes) : Tot (option (LowParse.SLow.vlarray LowParseExample.Aux.t 5 7 & FStar.UInt32.t)) =
   LowParseExample.Aux.parse32_t_vlarray input
 *)
 
@@ -56,7 +56,7 @@ let s (x: LowParse.SLow.array LowParseExample.Aux.t 18) : Tot FStar.Bytes.bytes 
 #reset-options "--using_facts_from '* -LowParse'"
 
 (** Test parser 'f' and formatter 'm' *)
-let test_f_m (input:FStar.Bytes.bytes): Stack (option (FStar.Bytes.bytes * FStar.UInt32.t)) (fun _ -> true) (fun _ _ _ -> true) =
+let test_f_m (input:FStar.Bytes.bytes): Stack (option (FStar.Bytes.bytes & FStar.UInt32.t)) (fun _ -> true) (fun _ _ _ -> true) =
   let result = f input in
   match result with
   | Some (v, offset) -> (

--- a/tests/lowparse/LowParseExample2.fsti
+++ b/tests/lowparse/LowParseExample2.fsti
@@ -7,7 +7,7 @@ type t = {
   b: (b: B32.bytes { B32.length b <= 65535 } );
 }
 
-val t'_l_serializable (x: list t) : GTot Type0
+val t'_l_serializable (x: list t) : GTot prop
 
 val check_t'_l_serializable (x: list t) : Tot (b: bool { b == true <==> t'_l_serializable x } )
 

--- a/tests/lowparse/LowParseExample2.fsti
+++ b/tests/lowparse/LowParseExample2.fsti
@@ -22,7 +22,7 @@ let make_t' (x: list t) : Tot (option t') =
 
 module U32 = FStar.UInt32
 
-val parse_t' : B32.bytes -> Tot (option (t' * U32.t))
+val parse_t' : B32.bytes -> Tot (option (t' & U32.t))
 
 val serialize_t' : t' -> Tot B32.bytes
 

--- a/tests/lowparse/LowParseExample5.Aux.fst
+++ b/tests/lowparse/LowParseExample5.Aux.fst
@@ -13,7 +13,7 @@ module B = LowStar.Buffer
 let parse_inner_raw =
   LPI.parse_u16 `LPC.nondep_then` LPI.parse_u16
 
-let synth_inner (x: (U16.t * U16.t)) : Tot inner =
+let synth_inner (x: (U16.t & U16.t)) : Tot inner =
   let (left, right) = x in
   {left = left; right = right;}
 
@@ -22,7 +22,7 @@ let parse_inner' : LP.parser _ inner =
 
 let parse_inner = parse_inner'
 
-let synth_inner_recip (x: inner) : Tot (U16.t * U16.t) =
+let synth_inner_recip (x: inner) : Tot (U16.t & U16.t) =
   (x.left, x.right)
 
 let serialize_inner_raw : LP.serializer parse_inner_raw =
@@ -43,7 +43,7 @@ let serialize_inner_intro h b lo =
 let parse_t_raw =
   parse_inner ` LPC.nondep_then` LPI.parse_u32
 
-let synth_t (x: (inner * U32.t)) : Tot t =
+let synth_t (x: (inner & U32.t)) : Tot t =
   let (inner, last) = x in
   {inner = inner; last = last;}
 
@@ -53,7 +53,7 @@ let parse_t_kind = LP.get_parser_kind parse_t'
 
 let parse_t = parse_t'
 
-let synth_t_recip (x: t) : Tot (inner * U32.t) =
+let synth_t_recip (x: t) : Tot (inner & U32.t) =
   (x.inner, x.last)
 
 let serialize_t_raw : LP.serializer parse_t_raw =

--- a/tests/lowparse/LowParseExample6.Aux.fst
+++ b/tests/lowparse/LowParseExample6.Aux.fst
@@ -25,7 +25,7 @@ let u8 : eqtype = U8.t
 inline_for_extraction
 let case_enum : LP.enum cases u8 =
   [@inline_let]
-  let e : list (cases * U8.t) = [
+  let e : list (cases & U8.t) = [
     Case_A, 18uy;
     Case_B, 42uy;
     Case_V2, 71uy;
@@ -50,7 +50,7 @@ let case_B = (x: U16.t { U16.v x > 0 } )
 
 noeq
 type t =
-  | A of (U8.t * U8.t)
+  | A of (U8.t & U8.t)
   | B of case_B
   | C : LP.unknown_enum_repr case_enum -> U16.t -> t
   | V2 of U16.t
@@ -93,7 +93,7 @@ let type_of_known_case
   (x: cases)
 : Tot Type0
 = match x with
-  | Case_A -> U8.t * U8.t
+  | Case_A -> U8.t & U8.t
   | Case_B -> case_B
   | Case_V2 -> U16.t
   | Case_V3 -> U16.t
@@ -486,7 +486,7 @@ let cases_of_t_A (x: t) : Lemma
 = ()
 
 inline_for_extraction
-let synth_case_A_inv (z: LP.dsum_cases t_sum (LP.Known Case_A)) : Tot (z: (U8.t * U8.t)) =
+let synth_case_A_inv (z: LP.dsum_cases t_sum (LP.Known Case_A)) : Tot (z: (U8.t & U8.t)) =
   [@inline_let]
   let z' : t = z in
   let _ = cases_of_t_A z' in

--- a/tests/lowparse/LowParseExample6.fst
+++ b/tests/lowparse/LowParseExample6.fst
@@ -9,7 +9,7 @@ module AUX = LowParseExample6.Aux
 
 #reset-options "--using_facts_from '* -LowParse +LowParse.Spec.Base +LowParse.SLow.Base'"
 
-let f (input: FStar.Bytes.bytes) : Pure (option (AUX.t * FStar.UInt32.t))
+let f (input: FStar.Bytes.bytes) : Pure (option (AUX.t & FStar.UInt32.t))
   (requires True)
   (ensures (fun res ->
     match res with

--- a/tests/lowparse/LowParseExample7.Aux.fst
+++ b/tests/lowparse/LowParseExample7.Aux.fst
@@ -38,7 +38,7 @@ type binders = LP.parse_bounded_vlbytes_t 0 65535
 let parse_binders : LP.parser _ binders = LP.parse_bounded_vlbytes 0 65535
 let serialize_binders: LP.serializer parse_binders = LP.serialize_bounded_vlbytes 0 65535
 
-type pre_shared_key_extension = (U32.t * binders)
+type pre_shared_key_extension = (U32.t & binders)
 let parse_pre_shared_key_extension : LP.parser _ pre_shared_key_extension = LP.nondep_then LP.parse_u32 parse_binders
 let serialize_pre_shared_key_extension : LP.serializer parse_pre_shared_key_extension = LP.serialize_nondep_then _ LP.serialize_u32 () _ serialize_binders
 
@@ -46,7 +46,7 @@ type extension_type = | PreSharedKeyExtension_t
 
 inline_for_extraction
 let extension_enum : LP.enum extension_type U32.t =
-  let l : list (extension_type * U32.t) = [
+  let l : list (extension_type & U32.t) = [
     PreSharedKeyExtension_t, 18ul;
   ]
   in
@@ -56,7 +56,7 @@ let extension_enum : LP.enum extension_type U32.t =
 noeq
 type extension =
 | PreSharedKeyExtension of LP.parse_bounded_vldata_strong_t 2 65535 serialize_pre_shared_key_extension
-| UnknownExtension of (LP.unknown_enum_repr extension_enum * LP.parse_bounded_vlbytes_t 2 65535)
+| UnknownExtension of (LP.unknown_enum_repr extension_enum & LP.parse_bounded_vlbytes_t 2 65535)
 
 let type_of_extension (e: extension) : GTot (LP.maybe_enum_key extension_enum) =
   match e with

--- a/tests/lowparse/LowParseExample7.Aux.fst
+++ b/tests/lowparse/LowParseExample7.Aux.fst
@@ -197,7 +197,7 @@ let serialize_client_hello : LP.serializer parse_client_hello =
 
 let with_psk
   (ch: client_hello)
-: GTot Type0
+: GTot prop
 = let (_, exts) = ch in
   Cons? exts /\
   PreSharedKeyExtension? (L.last exts)

--- a/tests/lowparse/LowParseExample8.fst
+++ b/tests/lowparse/LowParseExample8.fst
@@ -14,7 +14,7 @@ let u8 : eqtype = U8.t
 inline_for_extraction
 let k_enum : LP.enum k_t u8 =
   [@inline_let]
-  let e : list (k_t * U8.t) = [
+  let e : list (k_t & U8.t) = [
     Ka, 18uy;
     Kb, 42uy;
   ]

--- a/tests/lowparse/LowParseExampleMono.fst
+++ b/tests/lowparse/LowParseExampleMono.fst
@@ -14,7 +14,7 @@ let compl
   (v: t)
   (pos' : U32.t)
   (x: Seq.seq byte)
-: GTot Type0
+: GTot prop
 = U32.v pos >= 4 /\
   Seq.length x >= 4 /\ (
   let len = frozen_until x in

--- a/tests/lowparse/TestPair.fst
+++ b/tests/lowparse/TestPair.fst
@@ -17,7 +17,7 @@ open FStar.HyperStack.ST
 assume val havoc : unit -> Stack unit (fun h -> True) (fun _ _ _ -> True)
 
 let read_components (i:irepr P.pair_parser)
-  : Stack (UInt32.t * UInt32.t)
+  : Stack (UInt32.t & UInt32.t)
     (requires fun h ->
       True)
     (ensures fun h0 x h1 ->


### PR DESCRIPTION
## Summary

This PR backports a set of source changes from the `fstar2` branch (which
targets the `master` branch of F\*) onto `master` (which targets the `fstar1`
branch of F\*), restricted to the subset that is **semantically neutral and
still typechecks/verifies under fstar1**.

The goal is to shrink the diff between the two branches by pulling over the
changes that are *not* tied to fstar2-only features, so that the eventual
`master` → `fstar2` migration is smaller and clearer. Every change here is a
faithful replica of the corresponding `fstar2` change; nothing new was
invented.

**Scope:** 100 files changed, +673 / −383 (vs `origin/master`).

Each backport commit was validated by building/verifying the affected tree
(`make -j16 test`, or `make -j16 3d` for the 3d-tool-only commit) **before**
committing. All changes verify with the fstar1 toolchain vendored under
`opt/`.

## What is included

| Category | What | Files | Notes |
|---|---|---|---|
| A. Pair type notation | `*` → `&` in tuple/pair types | 50 | Pure syntactic; `&` already accepted by fstar1 |
| B. `Type0`/`Type` → `prop` | Predicate result types | 27 | **fstar1-compatible subset only** (see exclusions) |
| C. 3d effects | `St`/`ST` → `ML`, drop `open FStar.ST`, add `ML` annotations | 7 | `FStar.All` re-exports `FStar.ST` in fstar1 |
| D. CBOR header order | `friend` decls moved before `#lang-pulse` | 13 | Pure header re-ordering (line permutation) |
| E. Proof engineering | Proof restructuring, helper lemmas, `assert`/`Classical` hints, solver-option tuning | 12 | rlimit/fuel **reductions** adapted (see exclusions) |
| F. Coercions | `coerce_eq ()` on bundle spec-type-eq fields | 3 | CDDL Pulse bundle constructors |
| — | `noextract` on new LowParse example tests | 2 | Matches fstar2 |

### A. Pair type notation `*` → `&` (50 files)
Replaces the product/tuple type notation `*` with `&` in type positions across
`lowparse`, `ASN1`, `3d`, and the lowparse example tests. Only genuine F\* pair
types were converted; C-pointer `*` inside embedded C-code string literals
(e.g. `src/3d/Z3TestGen.fst`) was intentionally left untouched.

### B. `Type0`/`Type` → `prop` (27 files, partial)
Converts the result type of logical predicates from `Type0`/`Type` to `prop`,
restricted to definitions whose bodies are pure logical formulas and therefore
still typecheck under fstar1's standard library. See the exclusions section for
the foundational modules that could **not** be converted.

### C. 3d tool effect migration (7 files)
`St`/`ST` → `ML` on `gen_ident` and `get_input_stream_binding`/`get_include`,
plus explicit `: ML _` annotations on local stateful helpers, and removal of
`open FStar.ST` / `let open FStar.ST in` in favour of the unqualified `alloc`.
Verifies because fstar1's `FStar.All` `include`s `FStar.ST`. Effect labels are
erased at extraction, so the produced OCaml and `3d.exe` are unchanged.

### D. CBOR `#lang-pulse` / `friend` re-ordering (13 files)
Re-orders module-header declarations so that all `friend` declarations precede
the `#lang-pulse` pragma (and, in a few modules, re-orders the friends among
themselves). Each change is a pure permutation of existing header lines — no
line content is added or removed.

### E. Proof engineering (12 files)
Backports the genuine proof-engineering work: explicit proofs replacing
`= ()`/tactic proofs, extracted helper lemmas, `assert` / `assert_norm` /
`Classical` hints, and solver-option additions (`#restart-solver`,
`--z3refresh`, `--split_queries`, rlimit/rlimit_factor **increases**).
Affected: `CDDL.Spec.AST.Elab.Included.Array`, `CDDL.Spec.AST.Elab.Base`,
`CDDL.Spec.AST.Elab`, `CDDL.Spec.AST.Elab.Disjoint.Array`, `CDDL.Spec.ArrayGroup`,
`CDDL.Spec.MapGroup`, `CDDL.Pulse.Parse.MapGroup`,
`CDDL.Pulse.Serialize.Gen.MapGroup.{Concat,ZeroOrMore.Aux1,ZeroOrMore.Aux2.Lemma12}`,
`CBOR.Spec.Raw.EverParse`, and `LowParse.Spec.Combinators`.

### F. Coercions (3 files)
Wraps the spec-type-equality proof fields of the CDDL Pulse bundle constructors
with `coerce_eq ()` (`Bundle.Base`, `Bundle.ArrayGroup`, `Bundle.MapGroup`).

## What is deliberately excluded (and why)

These fstar2 changes are **not** in this PR because they are tied to fstar2-only
features and do not build/verify under fstar1:

- **`FStar.Mul` removal and `op_Multiply` → `op_Star`.** In fstar1, integer `*`
  still requires `FStar.Mul` in scope, and `Prims.op_Multiply` still exists.
  These were explicitly kept as-is.
- **`FStar.StrongExcludedMiddle` → `FStar.IndefiniteDescription`** (stdlib
  relocation). Kept as `FStar.StrongExcludedMiddle`, which is what fstar1 has.
- **`Type0`/`Type` → `prop` in foundational modules.** 7 modules
  (`LowParse.Spec.Enum`, `LowParse.Spec.Base`, `LowParse.Spec.Combinators.fsti`,
  `LowParse.SLow.Sum`, `LowParse.Spec.Array`, `LowParse.Slice`, `ASN1.Base`)
  are excluded: fstar1's `eq2` / `Set.disjoint` / `LowStar.Buffer.live` return
  `Type0` (not `prop`), and converting the foundational `parser_kind_prop` /
  `if_combinator` predicates cascades type errors into their consumers.
- **fstar2 solver-limit *reductions*.** New tuned some proofs down to lower
  `--z3rlimit` / `--fuel` / `--ifuel` after restructuring; these do not close
  under fstar1's Z3. The proof restructuring is kept, but the limits are left
  at fstar1's original (higher) values in `CBOR.Spec.Raw.EverParse`,
  `CDDL.Spec.AST.Elab.Base`, and `CDDL.Spec.ArrayGroup`.
- **`LowParse.Spec.BoundedInt` named-coercion refactor** (`parse_bounded_int32_coerce`).
  It changes how `parse_bounded_int32` definitionally unfolds, which breaks
  `LowParse.SLow.BoundedInt` / `LowParse.Low.BoundedInt`. fstar2 drops those
  Low\*/SLow modules from its build, so it never had to fix them; `master`
  still builds them.
- **Low\* / Karamel `C` → `Pulse.Lib.Pervasives`, and the build-system /
  toolchain-layout changes** (KaRaMeL/Pulse relocation, `z3-version.Makefile`,
  etc.). Out of scope for this backport.

## Validation

- `make -j16 test` passes on the branch tip.
- Each backport commit was validated independently before landing.
- Verified invariants across the diff: no `FStar.Mul` / `op_Multiply` /
  `op_Star` changes leaked in, and no `FStar.IndefiniteDescription` was
  introduced.
