### PR TITLE
`qd -pulse`: eliminate C function-pointer variables from extracted code

### DIFF
--- a/share/everparse/tests/qd/unit/unittests.rfc
+++ b/share/everparse/tests/qd/unit/unittests.rfc
@@ -259,3 +259,26 @@ struct {
 uint32_le t60[8];
 
 uint16_le t61[6];
+
+/*
+ Single-field structs are simplified to type aliases (like t10). Unlike t10
+ (which wraps the constant-size total type t3), these wrap types that require a
+ validator/jumper/leaf-reader/leaf-writer/leaf-size, exercising the low-level
+ Pulse alias definitions in the type-alias code path (which must be eta-expanded
+ to avoid C function-pointer variables under qd -pulse).
+*/
+
+/* alias of an enum: exercises validator + reader + writer + leaf_size aliases */
+struct {
+  tag w;
+} t62;
+
+/* alias of a variable-length vector: exercises validator + jumper aliases */
+struct {
+  t5 w;
+} t63;
+
+/* alias of a multi-field struct: exercises validator + jumper aliases */
+struct {
+  t8 w;
+} t64;

--- a/src/qd/rfc_fstar_compiler.ml
+++ b/src/qd/rfc_fstar_compiler.ml
@@ -3941,17 +3941,17 @@ and compile_typedef tch o i tn fn (ty:type_t) vec def al =
       end;
       (* Pulse: validator, jumper, reader for type aliases *)
       (if need_validator then
-        wp o "let %s_validator = %s\n\n" n (pulse_validator_name ty));
+        wp o "let %s_validator = fun input poffset #offset #pm #v -> (%s) input poffset #offset #pm #v\n\n" n (pulse_validator_name ty));
       (if need_jumper then
          let jumper_annot = if is_private then sprintf " : LPS.jumper %s_parser" n else "" in
-         wp o "let %s_jumper%s = %s\n\n" n jumper_annot (pulse_jumper_name ty));
+         wp o "let %s_jumper%s = fun input offset #pm #v -> (%s) input offset #pm #v\n\n" n jumper_annot (pulse_jumper_name ty));
       if li.has_lserializer then begin
         wp i "val %s_reader : PPB.leaf_reader %s_parser\n\n" n n;
-        wp o "let %s_reader = %s\n\n" n (pulse_leaf_reader_name ty);
+        wp o "let %s_reader = fun input #pm #v -> (%s) input #pm #v\n\n" n (pulse_leaf_reader_name ty);
         wp i "val %s_writer : LPS.l2r_leaf_writer %s_serializer\n\n" n n;
-        wp o "let %s_writer = %s\n\n" n (pulse_leaf_writer_name ty);
+        wp o "let %s_writer = fun x out offset #v -> (%s) x out offset #v\n\n" n (pulse_leaf_writer_name ty);
         wp i "val %s_leaf_size : LPS.leaf_size %s_serializer\n\n" n n;
-        wp o "let %s_leaf_size = %s\n\n" n (pulse_leaf_size_name ty)
+        wp o "let %s_leaf_size = fun x -> (%s) x\n\n" n (pulse_leaf_size_name ty)
       end;
       (* Pulse: copyful parser + free for type aliases *)
       wp i "let %s_lowtype = %s\n\n" n (copyful_lowtype_name ty);

--- a/src/qd/rfc_fstar_compiler.ml
+++ b/src/qd/rfc_fstar_compiler.ml
@@ -1627,7 +1627,7 @@ let emit_copyful_bounded_vldata_payload o i n ty smax =
   wp i "val free_%s : PPB.free_t %s_vmatch\n\n" n n;
   wp o "let read_%s : PPB.copyful_parse %s_vmatch %s_parser %s_conv =\n" n n n n;
   wp o "  PPVD.copyful_parse_bounded_vldata_payload 0 %d %s (PPBI.leaf_read_bounded_integer_%d ())\n\n" smax (copyful_read_name ty) (log256 smax);
-  wp o "let free_%s : PPB.free_t %s_vmatch = %s\n\n" n n (copyful_free_name ty);
+  wp o "let free_%s : PPB.free_t %s_vmatch = fun x #v -> (%s) x #v\n\n" n n (copyful_free_name ty);
   if !emit_pulse && copyful_writer_available ty then begin
     wp i "val write_%s : PPB.l2r_safe_writer %s_vmatch %s_serializer %s_conv\n\n" n n n n;
     wp o "let write_%s : PPB.l2r_safe_writer %s_vmatch %s_serializer %s_conv =\n" n n n n;
@@ -3960,11 +3960,11 @@ and compile_typedef tch o i tn fn (ty:type_t) vec def al =
       wp i "noextract let %s_conv = %s\n\n" n (copyful_conv_name ty);
       wp i "val read_%s : PPB.copyful_parse %s_vmatch %s_parser %s_conv\n\n" n n n n;
       wp i "val free_%s : PPB.free_t %s_vmatch\n\n" n n;
-      wp o "let read_%s : PPB.copyful_parse %s_vmatch %s_parser %s_conv = %s\n\n" n n n n (copyful_read_name ty);
-      wp o "let free_%s : PPB.free_t %s_vmatch = %s\n\n" n n (copyful_free_name ty);
+      wp o "let read_%s : PPB.copyful_parse %s_vmatch %s_parser %s_conv = fun input #pm #v -> (%s) input #pm #v\n\n" n n n n (copyful_read_name ty);
+      wp o "let free_%s : PPB.free_t %s_vmatch = fun x #v -> (%s) x #v\n\n" n n (copyful_free_name ty);
       if !emit_pulse && copyful_writer_available ty then begin
         wp i "val write_%s : PPB.l2r_safe_writer %s_vmatch %s_serializer %s_conv\n\n" n n n n;
-        wp o "let write_%s : PPB.l2r_safe_writer %s_vmatch %s_serializer %s_conv = %s\n\n" n n n n (copyful_writer_name ty);
+        wp o "let write_%s : PPB.l2r_safe_writer %s_vmatch %s_serializer %s_conv = fun x #y out #v perr -> (%s) x #y out #v perr\n\n" n n n n (copyful_writer_name ty);
         register_writer n
       end;
       w i "val %s_bytesize_eqn (x: %s) : Lemma (%s_bytesize x == %s) [SMTPat (%s_bytesize x)]\n\n" n n n (bytesize_call ty "x") n;
@@ -5112,7 +5112,7 @@ and compile_struct tch o i n (fl: struct_field_t list) (al:attr list) =
   wp o "  synth_%s_injective ();\n" n;
   wp o "  assert_norm (%s_parser_kind == %s'_parser_kind);\n" n n;
   wp o "  PPC.copyful_parse_synth %s synth_%s synth_%s_recip\n\n" pulse_creader n n;
-  wp o "let free_%s : PPB.free_t %s_vmatch = %s\n\n" n n pulse_cfree;
+  wp o "let free_%s : PPB.free_t %s_vmatch = fun x #v -> (%s) x #v\n\n" n n pulse_cfree;
 
   (* Pulse: copyful safe writer. A struct's writer is a pair-tree of its fields'
      safe writers wrapped with l2r_safe_writer_synth to (de)serialize the record.


### PR DESCRIPTION
## Summary

Under `qd -pulse`, QuackyDucky emitted some generated definitions as **bare
aliases** of the form `let f = g`, where `g` is another top-level function. When
KaRaMeL extracts such a top-level *function-valued* alias, it produces a C
**function-pointer global variable**

```c
ret (*f)(args) = g;
```

rather than a real function. This PR fixes the QuackyDucky code generator
(`src/qd/rfc_fstar_compiler.ml`) to emit **fully eta-expanded** definitions
instead, so every generated top-level function extracts to an ordinary C
function and no function-pointer globals remain.

All changes are confined to the Pulse-only output channel, so `qd` **without**
`-pulse` (i.e. the Low\*/High\* backends) is byte-for-byte unchanged.

This PR applies on top of `upstream/master` (which already contains the
`qd -pulse` copyful parsing/serialization work merged in PR #300).

## Background: what produced the function pointers

QuackyDucky simplifies a single-field struct to a **type alias**, and a few
copyful payload combinators are likewise pure aliases of an already-generated
function. In these cases the generator emitted a bare binding, e.g.

```fstar
let read_t10  = read_t3            (* copyful reader alias           *)
let free_t10  = free_t3            (* copyful free alias             *)
let write_t10 = write_t3           (* copyful writer alias           *)

let t62_validator = tag_validator  (* low-level validator alias      *)
let t63_jumper    = t5_jumper      (* low-level jumper alias          *)
```

Because the right-hand side is a bare identifier naming another top-level
function, KaRaMeL turns each of these into a C function-pointer global.

Combinator *applications* (e.g. `write_t13 = PPC.l2r_safe_writer_pair …`) were
never a problem: the applied combinators are `inline_for_extraction` and inline
into a real function body. Only the bare-identifier aliases were affected.

## The fix

Fully eta-expand the affected definitions, **binding and re-passing every
argument, including the ghost/implicit binders** dictated by each type. Two
categories of alias were fixed (both on the Pulse-only channel):

**1. Copyful reader / free / writer aliases** (and the copyful `free` in the
bounded-vldata payload and single-field-struct paths):

```fstar
let read_t10  = fun input #pm #v      -> read_t3  input #pm #v
let free_t10  = fun x #v              -> free_t3  x #v
let write_t10 = fun x #y out #v perr  -> write_t3 x #y out #v perr
```

**2. Low-level Pulse aliases** in the type-alias code path
(`validator` / `jumper` / `leaf_reader` / `l2r_leaf_writer` / `leaf_size`):

```fstar
let t62_validator  = fun input poffset #offset #pm #v -> tag_validator  input poffset #offset #pm #v
let t63_jumper     = fun input offset #pm #v          -> t5_jumper      input offset #pm #v
let t62_reader     = fun input #pm #v                 -> tag_reader     input #pm #v
let t62_writer     = fun x out offset #v              -> tag_writer     x out offset #v
let t62_leaf_size  = fun x                            -> tag_leaf_size  x   (* pure *)
```

### Why *full* eta-expansion (including implicits) is required

A naive expansion of only the explicit arguments (`fun x -> free_t3 x`) leaves
the callee **under-applied** — the copyful/low-level types carry ghost implicits
(`#pm`, `#v`, `#y`, `#offset`) — which KaRaMeL reports as

```
Warning 16: Cannot enforce arity at call-site for … (… is this a partial application?)
```

and then mis-extracts the surrounding code (in one case dropping a needed
`free_*_sum` and producing an undefined C reference). Re-passing the ghost
implicits as well makes each definition a full application, which KaRaMeL
extracts as an ordinary function.

## Tests added

The prior test corpus never exercised the low-level alias case: the only alias
(`t10`) wraps the constant-size *total* type `t3`, whose validator/jumper are
transparent `.fsti` combinator applications and which emits no leaf
reader/writer/size — so no bare low-level alias was ever generated.

Three single-field-struct aliases are added to
`share/everparse/tests/qd/unit/unittests.rfc`, each wrapping a type that *does*
require the low-level machinery (verified to produce function pointers before
the fix, and real functions after):

| Test  | Wraps            | Low-level aliases exercised                    |
|-------|------------------|------------------------------------------------|
| `t62` | enum `tag`       | `validator`, `reader`, `writer`, `leaf_size`   |
| `t63` | vector `t5`      | `validator`, `jumper`                          |
| `t64` | struct `t8`      | `validator`, `jumper`                          |

## Scope and safety

* **Pulse-only.** Every edited emission is on the generator's `wp` (Pulse)
  channel. The non-Pulse (`wl`/`w`/`wh`) emissions are untouched.
* **Non-Pulse output is byte-identical.** Verified by regenerating the full
  `unittests.rfc` + `bitcoin.rfc` corpus with both the old and new generator in
  non-Pulse mode (`qd` and `qd -low`): the outputs are identical (154 files,
  empty `diff`).

## Verification

* `make -j16 -k quackyducky-pulse-test` passes end-to-end: F\* verification,
  KaRaMeL extraction, C compilation, linking, and the test executable all
  succeed.
* The extracted C (`share/everparse/tests/qd/unit/extracted/out/*.c`, `*.h`)
  contains **zero** function-pointer variables (grep for the `(*ident)(`
  declarator pattern returns nothing). The former offenders — `T10` read/free/write,
  `T9_b` free, `T17_x_b` free, and `T62`/`T63`/`T64` validator/jumper/reader/writer/leaf_size —
  are now ordinary C functions.

## Files changed

* `src/qd/rfc_fstar_compiler.ml` — eta-expand the copyful and low-level alias
  emissions (Pulse-only).
* `share/everparse/tests/qd/unit/unittests.rfc` — add `t62`/`t63`/`t64` to cover
  the low-level alias paths.
