### PR TITLE
Make PulseParse, CDDL and `make test` work on Windows

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -76,6 +76,45 @@ jobs:
           path: fstar-src.tar.gz
           name: package-src
 
+  testci:
+    needs: fstar-src
+    runs-on: windows-2025
+    steps:
+
+      - run: git config --global core.autocrlf input
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 4.14.2
+        # This will install Cygwin as well
+
+      - name: Install Cygwin packages
+        shell: C:\.opam\.cygwin\root\bin\bash.exe --login '{0}'
+        env:
+          CYGWIN_ROOT: C:\.opam\.cygwin\root
+          CYGWIN_MIRROR: https://mirrors.kernel.org/sourceware/cygwin/
+        run: >-
+          "$GITHUB_WORKSPACE"/src/package/windows/install-cygwin-packages.sh
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: package-src
+
+      - name: Expand F* source package
+        shell: C:\.opam\.cygwin\root\bin\bash.exe --login '{0}'
+        run: >-
+          cd "$GITHUB_WORKSPACE" && tar xzf fstar-src.tar.gz && mv fstar opt/FStar
+
+      - name: Run tests
+        shell: C:\.opam\.cygwin\root\bin\bash.exe --login '{0}'
+        run: >-
+          cd $GITHUB_WORKSPACE && eval $(opam env) && env V=1 MAKE=make make test -kj$(nproc)
+
   build:
     needs: fstar-src
     runs-on: windows-2025
@@ -127,7 +166,7 @@ jobs:
             EverParse*.nupkg
           name: everparse-nupkg
 
-  test:
+  testpackage:
     needs: build
     runs-on: windows-latest
     steps:
@@ -158,3 +197,9 @@ jobs:
       - name: Test EverCDDL
         run: |
           ${{ github.workspace }}\test\bin\cddl.exe ${{ github.workspace }}\everparse\src\cddl\tests\demo\test.cddl
+
+  test:
+    needs: [testpackage, testci]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Workflow succeeded!"

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -155,3 +155,6 @@ jobs:
         shell: cmd
         run: |
           ${{ github.workspace }}\test\everparse.cmd ${{ github.workspace }}\everparse\src\3d\tests\probe\src\Probe.3d --odir ${{ github.workspace }}\test-probe --z3_test Probe._primaryInPlace --z3_witnesses 10 --z3_branch_depth 5
+      - name: Test EverCDDL
+        run: |
+          ${{ github.workspace }}\test\bin\cddl.exe ${{ github.workspace }}\everparse\src\cddl\tests\demo\test.cddl

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -5,6 +5,11 @@ on:
     - _**
   pull_request:
   workflow_dispatch:
+    inputs:
+      run_full_ci:
+        description: Run full CI
+        type: boolean
+        default: false
 
 jobs:
   fstar-src:
@@ -77,6 +82,7 @@ jobs:
           name: package-src
 
   testci:
+    if: ${{ inputs.run_full_ci }}
     needs: fstar-src
     runs-on: windows-2025
     steps:

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,8 @@ include nofstar.Makefile
 
 include deps.Makefile
 
-ifneq ($(OS),Windows_NT)
 ifneq (1,$(EVERPARSE_ONLY_3D))
 package-subset: cddl
-endif
 endif
 
 # Disable COSE on MacOS because we don't know how to link with OpenSSL

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,11 @@ package-subset: cddl
 endif
 
 # Disable COSE on MacOS because we don't know how to link with OpenSSL
+# Disable COSE on Windows because we don't know how to link with OpenSSL
+ifneq ($(OS),Windows_NT)
 ifneq ($(OS),Darwin)
 all: cose
+endif
 endif
 
 ifeq (,$(NO_PULSE))
@@ -141,8 +144,11 @@ test: 3d-test
 endif
 
 # Disable COSE tests on MacOS because we don't know how to link with OpenSSL
+# Disable COSE tests on Windows because we don't know how to link with OpenSSL
+ifneq ($(OS),Windows_NT)
 ifneq ($(OS),Darwin)
 test: cose-test
+endif
 endif
 
 submodules:

--- a/deps.Makefile
+++ b/deps.Makefile
@@ -9,8 +9,6 @@ endif
 export EVERPARSE_OPT_PATH := $(realpath opt)
 ifeq ($(OS),Windows_NT)
 export EVERPARSE_OPT_PATH := $(shell cygpath -m $(EVERPARSE_OPT_PATH))
-# Pulse does not compile on Windows
-NO_PULSE := 1
 endif
 
 ifeq (1,$(EVERPARSE_ONLY_3D))

--- a/deps.Makefile
+++ b/deps.Makefile
@@ -10,6 +10,7 @@ ifeq ($(OS),Windows_NT)
   export CC:=x86_64-w64-mingw32-gcc
   export LD:=x86_64-w64-mingw32-ld
   export AR:=x86_64-w64-mingw32-ar
+  export CXX:=x86_64-w64-mingw32-g++
 endif
 
 export EVERPARSE_OPT_PATH := $(realpath opt)
@@ -182,6 +183,7 @@ ifeq ($(OS),Windows_NT)
 	@echo export CC=$(CC)
 	@echo export LD=$(LD)
 	@echo export AR=$(AR)
+	@echo export CXX=$(CXX)
 endif
 	@echo export EVERPARSE_USE_OPAMROOT=$(EVERPARSE_USE_OPAMROOT)
 	@echo export EVERPARSE_USE_FSTAR_EXE=$(EVERPARSE_USE_FSTAR_EXE)

--- a/deps.Makefile
+++ b/deps.Makefile
@@ -6,6 +6,12 @@ ifeq (,$(OS))
 export OS := $(shell uname)
 endif
 
+ifeq ($(OS),Windows_NT)
+  export CC:=x86_64-w64-mingw32-gcc
+  export LD:=x86_64-w64-mingw32-ld
+  export AR:=x86_64-w64-mingw32-ar
+endif
+
 export EVERPARSE_OPT_PATH := $(realpath opt)
 ifeq ($(OS),Windows_NT)
 export EVERPARSE_OPT_PATH := $(shell cygpath -m $(EVERPARSE_OPT_PATH))
@@ -172,6 +178,11 @@ $(EVERPARSE_OPT_PATH)/pulse.done: $(EVERPARSE_OPT_PATH)/pulse/Makefile $(NEED_FS
 	touch $@
 
 env:
+ifeq ($(OS),Windows_NT)
+	@echo export CC=$(CC)
+	@echo export LD=$(LD)
+	@echo export AR=$(AR)
+endif
 	@echo export EVERPARSE_USE_OPAMROOT=$(EVERPARSE_USE_OPAMROOT)
 	@echo export EVERPARSE_USE_FSTAR_EXE=$(EVERPARSE_USE_FSTAR_EXE)
 	@echo export EVERPARSE_USE_KRML_EXE=$(EVERPARSE_USE_KRML_EXE)

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,7 +3,7 @@
 
 all: html 3d
 
-export EVERPARSE_HOME?=$(realpath ..)
+EVERPARSE_HOME?=$(realpath ..)
 
 FSTAR_EXE ?= fstar.exe
 
@@ -22,16 +22,26 @@ AUX_HEADERS=GetFieldPtrBase.h arch_flags.h
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -W
+ifeq ($(OS),Windows_NT)
+SPHINXBUILD   = .venv/Scripts/sphinx-build.exe
+else
 SPHINXBUILD   = .venv/bin/sphinx-build
+endif
 SPHINXPROJ    = EverParseDoc
 SOURCEDIR     = .
 BUILDDIR      = _build
+
+ifeq ($(OS),Windows_NT)
+python := .venv/Scripts/python.exe
+else
+python := .venv/bin/python3
+endif
 
 .venv:
 	rm -rf $@ $@.tmp
 	python3 -m venv $@.tmp
 	mv $@.tmp $@
-	if ! $@/bin/python3 -m pip install "sphinx-rtd-theme>=3.0.0" ; then mv $@ $@.tmp ; exit 1 ; fi
+	if ! $(python) -m pip install "sphinx-rtd-theme>=3.0.0" ; then mv $@ $@.tmp ; exit 1 ; fi
 
 # Put it first so that "make" without argument is like "make help".
 help: .venv

--- a/opt/hashes.Makefile
+++ b/opt/hashes.Makefile
@@ -1,3 +1,3 @@
 FStar_hash := de9d045cbfa5d0dc456fbeae04389c3d98a59347
 karamel_hash := 6c5e3d20ddcb78ac089f624dca8c94df333c53bb
-pulse_hash := 47722f87c09164e838deb1487db98b7a38ec76e3
+pulse_hash := 65b037b8edd5dc8582c5e10dec7a511e0f4df37f

--- a/opt/opam-env.sh
+++ b/opt/opam-env.sh
@@ -11,15 +11,15 @@ if [[ "$OS" = Windows_NT ]] ; then
     OPAMROOT="$(cygpath -m "$OPAMROOT")"
 fi
 root_opam="--root=$OPAMROOT"
-opam env "$root_opam" --set-root --shell=sh | grep -v '^PATH=' |
+opam env "$root_opam" --set-root --shell=sh |
     if [[ "$1" = --shell ]] ; then
-	cat
+        $SED 's!^PATH=\(.*\); export PATH;$!PATH=\1:"$PATH"; export PATH;!'
     else
-	$SED 's!^\([^=]*\)='"'"'\(.*\)'"'"'; export [^;]*;$!export \1 := \2!'
+	$SED 's!^\([^=]*\)='"'"'\(.*\)'"'"'; export [^;]*;$!export \1 := \2!' |
+	$SED 's!^export PATH := \(.*\)$!export PATH := \1:$(PATH)!'
     fi
 if [[ "$1" = --shell ]] ; then
     equal="="
-    epath=':"$PATH"'
     if [[ "$OS" = Windows_NT ]] ; then
 	eocamlpath="';'"'"$OCAMLPATH"'
 	eopamswitchprefixunix='"$(cygpath -u "$OPAM_SWITCH_PREFIX")"'
@@ -30,7 +30,6 @@ if [[ "$1" = --shell ]] ; then
     fi
 else
     equal=':='
-    epath=':$(PATH)'
     if [[ "$OS" = Windows_NT ]] ; then
 	eopamswitchprefixunix='$(shell cygpath -u "$(OPAM_SWITCH_PREFIX)")'
 	eopamswitchprefixwindows='$(shell cygpath -m "$(OPAM_SWITCH_PREFIX)")'
@@ -44,4 +43,3 @@ if [[ "$OS" = Windows_NT ]] ; then
     # Work around an opam bug about `opam var lib`
     echo 'export OCAMLPATH'"$equal$eopamswitchprefixwindows/lib$eocamlpath"
 fi
-echo 'export PATH'"$equal$eopamswitchprefixunix/bin$epath"

--- a/share/everparse/tests/cbor/Makefile
+++ b/share/everparse/tests/cbor/Makefile
@@ -22,9 +22,15 @@
 # The snapshot directory must contain the corresponding header(s) and
 # pre-built object file (CBORNondet.o or CBORDet.o, plus its dependencies).
 
+ifeq ($(OS),Windows_NT)
+  local_curdir := $(shell cygpath -m $(CURDIR))
+else
+  local_curdir := $(CURDIR)
+endif
+
 # Default snapshot locations: the in-tree C extractions.
-EVERCBOR_NONDET_PATH ?= $(realpath $(CURDIR)/../../../../src/cbor/pulse/nondet/c)
-EVERCBOR_DET_PATH    ?= $(realpath $(CURDIR)/../../../../src/cbor/pulse/det/c)
+EVERCBOR_NONDET_PATH ?= $(local_curdir)/../../../../src/cbor/pulse/nondet/c
+EVERCBOR_DET_PATH    ?= $(local_curdir)/../../../../src/cbor/pulse/det/c
 
 # Number of iterations for benchmarking. Override on the command line to make
 # timing measurements more reliable, e.g. BENCH_ITERATIONS=1000.
@@ -44,28 +50,24 @@ NONDET_OBJS = $(EVERCBOR_NONDET_PATH)/CBORNondet.o
 # The deterministic snapshot ships only CBORDet.o
 DET_OBJS    = $(EVERCBOR_DET_PATH)/CBORDet.o
 
-SRC = $(CURDIR)/cbor_tests.c
+SRC = $(local_curdir)/cbor_tests.c
 
 NONDET_BIN = cbor_tests_nondet.exe
 DET_BIN    = cbor_tests_det.exe
 
 # Directory into which the C binaries write artefact files for the
 # Python harness to consume.
-OUT_DIR = $(CURDIR)/out
+OUT_DIR = $(local_curdir)/out
 
 # Python virtual environment used to run the cross-language tests.
 PYTHON       ?= python3
+VENV_DIR      := $(local_curdir)/.venv
 ifeq ($(OS),Windows_NT)
-VENV_DIR      := $(shell cygpath -m $(CURDIR))/.venv
 VENV_PYTHON   := $(VENV_DIR)/Scripts/python.exe
 else
-VENV_DIR      := $(CURDIR)/.venv
 VENV_PYTHON   := $(VENV_DIR)/bin/python
 endif
-PY_SRC        := $(CURDIR)/cbor_tests.py
-ifeq ($(OS),Windows_NT)
-  PY_SRC := $(shell cygpath -m $(PY_SRC))
-endif
+PY_SRC        := $(local_curdir)/cbor_tests.py
 # Pin a cbor2 floor that includes the Rust rewrite (immutable / allow_indefinite
 # decoder flags). 6.0.x is the first family with that codebase.
 CBOR2_REQ    ?= cbor2>=6.0,<7
@@ -121,7 +123,7 @@ run-python: run-nondet run-det $(VENV_PYTHON) $(PY_SRC)
 
 # Run the Rust conformance suite against the C-emitted artefacts. Depends
 # on the C runs so that the artefacts exist on disk first.
-RUST_DIR = $(CURDIR)/cbor_tests_rust
+RUST_DIR = $(local_curdir)/cbor_tests_rust
 CARGO   ?= cargo
 run-rust: run-nondet run-det
 	cd $(RUST_DIR) && CBOR_TEST_OUT_DIR=$(OUT_DIR) $(CARGO) test --release

--- a/share/everparse/tests/cbor/Makefile
+++ b/share/everparse/tests/cbor/Makefile
@@ -55,9 +55,17 @@ OUT_DIR = $(CURDIR)/out
 
 # Python virtual environment used to run the cross-language tests.
 PYTHON       ?= python3
-VENV_DIR      = $(CURDIR)/.venv
-VENV_PYTHON   = $(VENV_DIR)/bin/python
-PY_SRC        = $(CURDIR)/cbor_tests.py
+ifeq ($(OS),Windows_NT)
+VENV_DIR      := $(shell cygpath -m $(CURDIR))/.venv
+VENV_PYTHON   := $(VENV_DIR)/Scripts/python.exe
+else
+VENV_DIR      := $(CURDIR)/.venv
+VENV_PYTHON   := $(VENV_DIR)/bin/python
+endif
+PY_SRC        := $(CURDIR)/cbor_tests.py
+ifeq ($(OS),Windows_NT)
+  PY_SRC := $(shell cygpath -m $(PY_SRC))
+endif
 # Pin a cbor2 floor that includes the Rust rewrite (immutable / allow_indefinite
 # decoder flags). 6.0.x is the first family with that codebase.
 CBOR2_REQ    ?= cbor2>=6.0,<7

--- a/share/everparse/tests/cbor/cbor_tests.c
+++ b/share/everparse/tests/cbor/cbor_tests.c
@@ -19,6 +19,12 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#if defined(__MINGW64__)
+#  define MKDIR(name, perm) mkdir(name)
+#else
+#  define MKDIR(name, perm) mkdir(name, perm)
+#endif
+
 #if defined(EVERCBOR_DET) && defined(EVERCBOR_NONDET)
 #  error "Define exactly one of EVERCBOR_DET or EVERCBOR_NONDET"
 #endif
@@ -357,7 +363,7 @@ static const char *g_current_test  = "(unset)";
 static int         g_write_files   = 0;
 
 static int ensure_out_dir(void) {
-  if (mkdir(g_out_dir, 0755) != 0 && errno != EEXIST) {
+  if (MKDIR(g_out_dir, 0755) != 0 && errno != EEXIST) {
     fprintf(stderr, "FATAL: cannot create output dir '%s': %s\n",
             g_out_dir, strerror(errno));
     return 1;

--- a/share/everparse/tests/cbor/cbor_tests.py
+++ b/share/everparse/tests/cbor/cbor_tests.py
@@ -34,6 +34,15 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
+import threading
+
+# Set stack size to 8 MB (must be a multiple of 4096 on Windows)
+try:
+    threading.stack_size(8 * 1024 * 1024)
+except (ValueError, threading.ThreadError) as e:
+    print(f"Error setting stack size: {e}")
+    sys.exit(1)
+
 try:
     import cbor2
     from cbor2 import CBORDecodeError, CBORTag, CBORSimpleValue
@@ -929,6 +938,12 @@ def main() -> int:
           f"{overall_skipped} skipped; total {overall_seconds:.6f}s")
     return 0 if overall_failed == 0 else 1
 
+def main0(shared_data) -> None:
+    shared_data["result"] = main()
 
 if __name__ == "__main__":
-    sys.exit(main())
+    res = {"result": 0}
+    t = threading.Thread(target=main0, args=(res,))
+    t.start()
+    t.join()
+    sys.exit(res["result"])

--- a/src/3d/tests/Makefile
+++ b/src/3d/tests/Makefile
@@ -19,12 +19,17 @@ INCLUDES=$(EVERPARSE_HOME)/src/3d/prelude $(EVERPARSE_HOME)/src/3d/prelude/buffe
 
 FSTAR_OPTIONS += $(addprefix --include , $(INCLUDES))
 
-positive_tests=$(filter-out $(wildcard FAIL*.3d) FieldDependence0.3d ActAndCheck.3d,$(wildcard *.3d))
+positive_tests:=$(filter-out $(wildcard FAIL*.3d) FieldDependence0.3d ActAndCheck.3d,$(wildcard *.3d))
+ifeq ($(OS),Windows_NT)
+  # UlongToPtr is defined in Windows DLLs, conflicts with those examples
+  exclude_modules := FineGrainedProbe FineGrainedProbeSpecialize Specialize2 Specialize3 Specialize5 Specialize6
+  positive_tests:=$(filter-out $(addsuffix .3d,$(exclude_modules)),$(positive_tests))
+endif
 positive_tests_nosuffix=$(basename $(positive_tests))
 modules_or_wrappers=$(positive_tests_nosuffix) $(addsuffix Wrapper,$(positive_tests_nosuffix))
 modules_static_assertions=$(addsuffix StaticAssertions.c, TestFieldPtr Align)
-modules_auto_static_assertions=$(addsuffix AutoStaticAssertions.c, Align Specialize2 Specialize3 Specialize5 Specialize6 FineGrainedProbe FineGrainedProbeSpecialize)
-module_extern_apis=$(addsuffix _ExternalAPI.h, Specialize2 Specialize3 Specialize5 Specialize6 FineGrainedProbe FineGrainedProbeSpecialize)
+modules_auto_static_assertions=$(addsuffix AutoStaticAssertions.c, $(filter-out $(exclude_modules),Align Specialize2 Specialize3 Specialize5 Specialize6 FineGrainedProbe FineGrainedProbeSpecialize))
+module_extern_apis=$(addsuffix _ExternalAPI.h, $(filter-out $(exclude_modules),Specialize2 Specialize3 Specialize5 Specialize6 FineGrainedProbe FineGrainedProbeSpecialize))
 clean_out_files=\
 	$(addsuffix .c,$(modules_or_wrappers)) \
 	$(modules_static_assertions) \
@@ -36,9 +41,15 @@ OTHER_HEADERS=TestFieldPtrBase.h AlignC.h
 
 all: batch-test batch-test-negative batch-cleanup-test inplace-hash-test modules \
 	 tcpip extern output-types batch-interpret-test elf-test static funptr ifdefs \
-	 probe iter z3-testgen-test exttype z3-testgen-probe-test specialize_test specialize_test2 \
-	 use_error_handler_macro specialize_test_error_handler_macro probe_error_handler_macro \
-	 specialize_tagged_union_array save_hashes
+	 probe iter z3-testgen-test exttype z3-testgen-probe-test \
+	 use_error_handler_macro \
+	 save_hashes
+
+ifneq ($(OS),Windows_NT)
+# Tests disabled on Windows because of UlongToPtr conflict
+# probe_error_handler_macro disabled on Windows because sys/mman.h is not available
+all: specialize_test specialize_test2 specialize_test_error_handler_macro specialize_tagged_union_array probe_error_handler_macro
+endif
 
 .PHONY: exttype
 

--- a/src/cbor/pulse/krml/c.Makefile
+++ b/src/cbor/pulse/krml/c.Makefile
@@ -2,8 +2,12 @@ CBOR_SLICE_BACKEND := c
 
 include extract.Makefile
 
-NONDET_C_DIRECTORY:=$(realpath ..)/nondet/c-extracted
-DET_C_DIRECTORY:=$(realpath ../det/c)/extracted
+parent_dir := $(realpath ..)
+ifeq ($(OS),Windows_NT)
+  parent_dir := $(shell cygpath -m $(parent_dir))
+endif
+NONDET_C_DIRECTORY:=$(parent_dir)/nondet/c-extracted
+DET_C_DIRECTORY:=$(parent_dir)/det/c/extracted
 
 $(NONDET_C_DIRECTORY)/CBORNondet.c: $(filter-out %CBOR_Pulse_API_Det_Rust.krml %CBOR_Pulse_API_Det_C.krml,$(ALL_KRML_FILES))
 	mkdir -p $(dir $@)

--- a/src/cbor/pulse/krml/extract.Makefile
+++ b/src/cbor/pulse/krml/extract.Makefile
@@ -1,6 +1,8 @@
 all: extract
 
-EVERPARSE_SRC_PATH = $(realpath ../../..)
+EVERPARSE_SRC_PATH := $(realpath ../../..)
+include $(EVERPARSE_SRC_PATH)/windows.Makefile
+
 SRC_DIRS += $(EVERPARSE_SRC_PATH)/cbor/pulse
 INCLUDE_PATHS += $(EVERPARSE_SRC_PATH)/cbor/spec $(EVERPARSE_SRC_PATH)/cbor/spec/raw $(EVERPARSE_SRC_PATH)/cbor/spec/raw/everparse $(EVERPARSE_SRC_PATH)/cbor/pulse/raw $(EVERPARSE_SRC_PATH)/cbor/pulse/raw/everparse $(EVERPARSE_SRC_PATH)/lowparse $(EVERPARSE_SRC_PATH)/lowparse/pulse
 

--- a/src/cbor/pulse/krml/rust.Makefile
+++ b/src/cbor/pulse/krml/rust.Makefile
@@ -1,8 +1,12 @@
 CBOR_SLICE_BACKEND := rust
 include extract.Makefile
 
-DET_RUST_DIRECTORY:=$(realpath ../det)/rust-extracted
-NONDET_RUST_DIRECTORY:=$(realpath ..)/nondet/rust-extracted
+parent_dir := $(realpath ..)
+ifeq ($(OS),Windows_NT)
+  parent_dir := $(shell cygpath -m $(parent_dir))
+endif
+DET_RUST_DIRECTORY:=$(parent_dir)/det/rust-extracted
+NONDET_RUST_DIRECTORY:=$(parent_dir)/nondet/rust-extracted
 
 $(DET_RUST_DIRECTORY)/cbordetver.rs: $(filter-out %CBOR_Pulse_API_Det_C.krml,$(ALL_KRML_FILES))
 	$(KRML_EXE) $(KRML_OPTS) -backend rust -fno-box -fkeep-tuples -fcontained-type cbor_raw_iterator -warn-error @1..27 -skip-linking -bundle 'CBOR.Pulse.API.Det.Rust=[rename=CBORDetVer]' -bundle 'CBOR.Spec.Constants+CBOR.Pulse.Raw.Type+CBOR.Pulse.Raw.Slice+CBOR.Pulse.API.Det.Type+CBOR.Pulse.API.Det.Dummy=\*[rename=CBORDetVerAux]' -tmpdir $(DET_RUST_DIRECTORY) -skip-compilation $^

--- a/src/cddl/tests/roundtrip/Makefile
+++ b/src/cddl/tests/roundtrip/Makefile
@@ -8,7 +8,7 @@
 all: test
 
 EVERPARSE_SRC_PATH := $(realpath ../../..)
-EVERPARSE_HOME     := $(realpath $(EVERPARSE_SRC_PATH)/..)
+include $(EVERPARSE_SRC_PATH)/windows.Makefile
 ODIR := _output
 
 FSTAR_EXE ?= fstar.exe
@@ -16,7 +16,11 @@ FSTAR_EXE ?= fstar.exe
 # evercddl.lib (handwritten + extracted) lives under $EVERPARSE_HOME/lib;
 # fstar.lib lives under the F* installation. `fstar.exe --ocamlenv` prepends
 # the latter to OCAMLPATH for us.
-export OCAMLPATH := $(EVERPARSE_HOME)/lib:$(OCAMLPATH)
+ifeq ($(OS),Windows_NT)
+export OCAMLPATH := $(EVERPARSE_SRC_PATH)/../lib;$(OCAMLPATH)
+else
+export OCAMLPATH := $(EVERPARSE_SRC_PATH)/../lib:$(OCAMLPATH)
+endif
 
 GEN := ocaml/_build/default/gen_fst/Main.exe
 

--- a/src/cddl/tests/rust/Makefile
+++ b/src/cddl/tests/rust/Makefile
@@ -13,8 +13,11 @@ endif
 $(OUTPUT): test.cddl
 	$(EVERPARSE_SRC_PATH)/../bin/cddl.exe $^ --odir $(dir $(OUTPUT)) --rust --fstar_only $(CDDL_ADMIT)
 
+RUST_MODULES := cbordetver cbordetveraux cddlextractiontest
+
 extract-all: $(OUTPUT)
 	+$(MAKE) -f extract.Makefile extract
+	for f in $(RUST_MODULES) ; do cp _output/$$f.rs src/ ; done
 
 build-rust: extract-all
 	cargo build
@@ -24,6 +27,7 @@ build-rust: extract-all
 clean:
 	cargo clean
 	+$(MAKE) -f extract.Makefile clean
+	for f in $(RUST_MODULES) ; do rm -f src/$$f.rs ; done
 
 .PHONY: clean
 

--- a/src/cddl/tests/rust/Makefile
+++ b/src/cddl/tests/rust/Makefile
@@ -1,6 +1,7 @@
 all: build-rust
 
-EVERPARSE_SRC_PATH = $(realpath ../../..)
+EVERPARSE_SRC_PATH := $(realpath ../../..)
+include $(EVERPARSE_SRC_PATH)/windows.Makefile
 
 OUTPUT=_output/CDDLTest.Test.fst
 

--- a/src/cddl/tests/rust/src/.gitignore
+++ b/src/cddl/tests/rust/src/.gitignore
@@ -1,0 +1,3 @@
+cbordetver.rs
+cbordetveraux.rs
+cddlextractiontest.rs

--- a/src/cddl/tests/rust/src/cbordetver.rs
+++ b/src/cddl/tests/rust/src/cbordetver.rs
@@ -1,1 +1,0 @@
-../_output/cbordetver.rs

--- a/src/cddl/tests/rust/src/cbordetveraux.rs
+++ b/src/cddl/tests/rust/src/cbordetveraux.rs
@@ -1,1 +1,0 @@
-../_output/cbordetveraux.rs

--- a/src/cddl/tests/rust/src/cddlextractiontest.rs
+++ b/src/cddl/tests/rust/src/cddlextractiontest.rs
@@ -1,1 +1,0 @@
-../_output/cddlextractiontest.rs

--- a/src/cddl/tests/unit/Makefile
+++ b/src/cddl/tests/unit/Makefile
@@ -18,6 +18,11 @@ ALL_C_FILES = $(patsubst %.cddl,$(ODIR)/%.c,$(ALL_CDDLS))
 RUN += $(patsubst Test_%.c,%,$(wildcard Test_*.c))
 RUN += $(patsubst Test_%.cpp,%,$(wildcard Test_*.cpp))
 
+# QCBOR does not compile with mingw64, because it hardcodes GNU `ar` instead of $(AR)
+ifeq ($(OS),Windows_NT)
+  RUN := $(filter-out BenchArray__Interop1 BenchArray__Interop2 BenchFlat BenchMap,$(RUN))
+endif
+
 ifeq (1,$(ADMIT))
 CDDL_ADMIT := --admit
 else
@@ -133,8 +138,12 @@ tinycbor-build/libtinycbor.a: tinycbor-build
 
 # Some tests require libqcbor, we just add it to this invocation for all tests.
 # And libqcbor requires -lm (though we could disable that)
-$(ODIR)/Test_%.exe: $(ODIR)/Test_%.o $(ODIR)/$$(call remove__,%).o QCBOR/libqcbor.a tinycbor-build/libtinycbor.a
-	$(CC) -O3 -o $@ $^ $(EVERPARSE_SRC_PATH)/cbor/pulse/det/c/CBORDet.o QCBOR/libqcbor.a tinycbor-build/libtinycbor.a -lm
+# Disable qcbor on Cygwin with mingw64
+ifneq ($(OS),Windows_NT)
+with_qcbor := QCBOR/libqcbor.a
+endif
+$(ODIR)/Test_%.exe: $(ODIR)/Test_%.o $(ODIR)/$$(call remove__,%).o $(with_qcbor) tinycbor-build/libtinycbor.a
+	$(CC) -O3 -o $@ $^ $(EVERPARSE_SRC_PATH)/cbor/pulse/det/c/CBORDet.o -lm
 
 $(ODIR)/Test_%.o: Test_%.c $(ODIR)/$$(call remove__,%).c
 	$(CC) -O3 -I $(EVERPARSE_SRC_PATH)/cbor/pulse/det/c -I _output --std=gnu2x $(CFLAGS) -c $< -o $@
@@ -145,11 +154,15 @@ $(ODIR)/Test_%.o: Test_%.cpp $(ODIR)/$$(call remove__,%).c tinycbor-build
 %.run: $(ODIR)/Test_%.exe
 	./$<
 
+ifeq ($(OS),Windows_NT)
+run-qcbor_bench:
+else
 qcbor_bench: qcbor_bench.c QCBOR/libqcbor.a
 	$(CC) $(CFLAGS) -O3 -o $@ $< QCBOR/libqcbor.a -lm
 
 run-qcbor_bench: qcbor_bench
 	./$<
+endif
 
 # all: run
 

--- a/src/cddl/tests/unit/Makefile
+++ b/src/cddl/tests/unit/Makefile
@@ -3,6 +3,7 @@
 all: all-c
 all: all-build
 all: all-run
+all: run-qcbor_bench
 
 .NOTINTERMEDIATE:
 .DELETE_ON_ERROR:
@@ -151,6 +152,8 @@ run-qcbor_bench: qcbor_bench
 	./$<
 
 # all: run
+
+.PHONY: run-qcbor_bench
 
 .PHONY: all-build
 all-build: $(patsubst %,$(ODIR)/Test_%.exe,$(RUN))

--- a/src/cddl/tool/Makefile
+++ b/src/cddl/tool/Makefile
@@ -1,6 +1,8 @@
 all: build extraction-all
 
-EVERPARSE_SRC_PATH = $(realpath ../..)
+EVERPARSE_SRC_PATH := $(realpath ../..)
+include $(EVERPARSE_SRC_PATH)/windows.Makefile
+
 INCLUDE_PATHS += $(EVERPARSE_SRC_PATH)/cbor/spec $(EVERPARSE_SRC_PATH)/cddl/spec $(EVERPARSE_SRC_PATH)/cddl/pulse $(EVERPARSE_SRC_PATH)/cbor/pulse
 
 ALREADY_CACHED := *,-CDDL.Tool,
@@ -24,7 +26,7 @@ build: $(EVERPARSE_CDDL)
 
 $(EVERPARSE_CDDL): ocaml.done $(wildcard ocaml/*/*.ml*)
 	cd ocaml && $(FSTAR_EXE) --ocamlenv dune build
-	cd ocaml && dune install --prefix=$(realpath $(EVERPARSE_SRC_PATH)/..)
+	cd ocaml && dune install --prefix=$(EVERPARSE_SRC_PATH)/..
 
 .PHONY: all
 

--- a/src/cddl/tool/ocaml.Makefile
+++ b/src/cddl/tool/ocaml.Makefile
@@ -1,6 +1,8 @@
 all: build
 
-EVERPARSE_SRC_PATH = $(realpath ../..)
+EVERPARSE_SRC_PATH := $(realpath ../..)
+include $(EVERPARSE_SRC_PATH)/windows.Makefile
+
 INCLUDE_PATHS += $(EVERPARSE_SRC_PATH)/cbor/spec $(EVERPARSE_SRC_PATH)/cddl/spec $(EVERPARSE_SRC_PATH)/cddl/pulse
 FSTAR_FILES := $(EVERPARSE_SRC_PATH)/cddl/spec/CDDL.Spec.AST.Base.fst $(EVERPARSE_SRC_PATH)/cddl/spec/CDDL.Spec.AST.Print.fst $(EVERPARSE_SRC_PATH)/cddl/spec/CDDL.Spec.AST.Elab.fst $(EVERPARSE_SRC_PATH)/cddl/spec/CDDL.Spec.AST.Driver.fst CDDL.Tool.Gen.fst $(EVERPARSE_SRC_PATH)/cbor/spec/CBOR.Spec.Constants.fst
 ALREADY_CACHED := *,

--- a/src/cddl/tool/ocaml/evercddl-gen/Main.ml
+++ b/src/cddl/tool/ocaml/evercddl-gen/Main.ml
@@ -372,11 +372,16 @@ let _ =
       ] @
         c_krml_list
   in
+  let krml_tmpfile = Filename.temp_file ~temp_dir:tmpdir "krml_options" ".rsp" in
+  let krml_tmpfile_out = open_out krml_tmpfile in
+  let _ = List.iter (fun s -> output_string krml_tmpfile_out s; output_char krml_tmpfile_out '\n') krml_options in
+  let _ = close_out krml_tmpfile_out in
   let res =
     run_cmd
       krml_exe
-      krml_options
+      ["@" ^ krml_tmpfile]
   in
+  let _ = Sys.remove krml_tmpfile in
   (* In the C case, krml only emitted the sources (-skip-compilation). Drive the
      C compiler ourselves unless compilation was explicitly skipped. The byte
      slice that cbor_raw embeds is homed by the CBOR library as the nominal

--- a/src/common.Makefile
+++ b/src/common.Makefile
@@ -27,7 +27,7 @@ endif
 # source file.
 ifneq (,$(CACHE_DIRECTORY))
 ifeq ($(OS),Windows_NT)
-  CACHE_DIRECTORY := $(shell cygpath -m $(CACHE_DIRECTORY)
+  CACHE_DIRECTORY := $(shell cygpath -m $(CACHE_DIRECTORY))
 endif
   FSTAR_OPTIONS += --cache_dir $(CACHE_DIRECTORY)
   INCLUDE_PATHS+=$(CACHE_DIRECTORY)

--- a/src/package/package.sh
+++ b/src/package/package.sh
@@ -203,7 +203,7 @@ make_everparse() {
     $EVERPARSE_HOME/bin/3d.exe --version >> everparse/README
 
     # Copy Pulse, evercbor and evercddl
-    if ! $is_windows && [[ -z "$EVERPARSE_ONLY_3D" ]]; then
+    if [[ -z "$EVERPARSE_ONLY_3D" ]]; then
     $cp -r $EVERPARSE_HOME/src/cbor everparse/src/cbor
     $cp -r $EVERPARSE_HOME/src/cddl everparse/src/cddl
 	$cp -r $PULSE_HOME/lib/pulse everparse/lib/

--- a/src/package/windows/cygwin-packages
+++ b/src/package/windows/cygwin-packages
@@ -9,3 +9,4 @@ mingw64-x86_64-libffi
 zip
 unzip
 make
+cmake

--- a/src/package/windows/cygwin-packages
+++ b/src/package/windows/cygwin-packages
@@ -8,3 +8,4 @@ mingw64-x86_64-gmp
 mingw64-x86_64-libffi
 zip
 unzip
+make

--- a/src/package/windows/cygwin-packages
+++ b/src/package/windows/cygwin-packages
@@ -1,7 +1,8 @@
 git
 wget
 time
-pkg-config
+pkg-config=2.5.1-1
+pkgconf=2.5.1-1
 mingw64-i686-gmp
 mingw64-i686-libffi
 mingw64-x86_64-gmp

--- a/tests/bitfields/Makefile.common
+++ b/tests/bitfields/Makefile.common
@@ -1,14 +1,14 @@
 EVERPARSE_HOME ?= $(realpath ../..)
 EVERPARSE_SRC_PATH ?= $(EVERPARSE_HOME)/src
+include $(EVERPARSE_SRC_PATH)/windows.Makefile
 
 FSTAR_EXE ?= fstar.exe
-LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
+LOWPARSE_HOME ?= $(EVERPARSE_SRC_PATH)/lowparse
 
 include $(EVERPARSE_SRC_PATH)/karamel.Makefile
 include $(EVERPARSE_SRC_PATH)/fstar.Makefile
 
 export LOWPARSE_HOME
-export EVERPARSE_HOME
 
 FSTAR_OPTIONS += --odir krml --cache_dir cache --cache_checked_modules \
 		--already_cached +Prims,+FStar,+LowStar,+C,+Spec.Loops,+LowParse \

--- a/tests/sample/Makefile.common
+++ b/tests/sample/Makefile.common
@@ -1,14 +1,14 @@
 EVERPARSE_HOME ?= $(realpath ../..)
 EVERPARSE_SRC_PATH ?= $(EVERPARSE_HOME)/src
+include $(EVERPARSE_SRC_PATH)/windows.Makefile
 
 FSTAR_EXE ?= fstar.exe
-LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
+LOWPARSE_HOME ?= $(EVERPARSE_SRC_PATH)/lowparse
 
 include $(EVERPARSE_SRC_PATH)/karamel.Makefile
 include $(EVERPARSE_SRC_PATH)/fstar.Makefile
 
 export LOWPARSE_HOME
-export EVERPARSE_HOME
 
 FSTAR_OPTIONS += --odir krml --cache_dir cache --cache_checked_modules \
 		--already_cached +Prims,+FStar,+LowStar,+C,+Spec.Loops,+LowParse \
@@ -28,5 +28,5 @@ KRML = $(KRML_EXE) \
 	 $(HEADERS) \
 	 -warn-error -9
 
-QD = $(EVERPARSE_HOME)/bin/qd.exe
+QD = $(EVERPARSE_SRC_PATH)/../bin/qd.exe
 RFC = Test.rfc

--- a/tests/sample0/Makefile.common
+++ b/tests/sample0/Makefile.common
@@ -1,14 +1,14 @@
 EVERPARSE_HOME ?= $(realpath ../..)
 EVERPARSE_SRC_PATH ?= $(EVERPARSE_HOME)/src
+include $(EVERPARSE_SRC_PATH)/windows.Makefile
 
 FSTAR_EXE ?= fstar.exe
-LOWPARSE_HOME ?= $(EVERPARSE_HOME)/src/lowparse
+LOWPARSE_HOME ?= $(EVERPARSE_SRC_PATH)/lowparse
 
 include $(EVERPARSE_SRC_PATH)/karamel.Makefile
 include $(EVERPARSE_SRC_PATH)/fstar.Makefile
 
 export LOWPARSE_HOME
-export EVERPARSE_HOME
 
 FSTAR_OPTIONS += --odir krml --cache_dir cache --cache_checked_modules \
 		--already_cached +Prims,+FStar,+LowStar,+C,+Spec.Loops,+LowParse \
@@ -28,5 +28,5 @@ KRML = $(KRML_EXE) \
 	 $(HEADERS) \
 	 -warn-error -9
 
-QD = $(EVERPARSE_HOME)/bin/qd.exe
+QD = $(EVERPARSE_SRC_PATH)/../bin/qd.exe
 RFC = Test.rfc


### PR DESCRIPTION
## Summary

This PR brings the Pulse-based part of EverParse — the Pulse parsing stack
(PulseParse), EverCBOR and EverCDDL — to Windows, and makes the full `make test`
suite build and run on Windows under a Cygwin shell with the MinGW-w64
toolchain. Previously Pulse was disabled outright on Windows
(`NO_PULSE := 1`), so `cddl`, the CBOR/CDDL libraries and their tests were
excluded from Windows builds and packages.

The work is a mix of build-system plumbing (Windows path normalization,
compiler selection, environment setup), a handful of source-level portability
fixes (POSIX-isms, thread stack size, command-line length limits), disabling a
few components that genuinely do not build on the MinGW toolchain, and CI
changes that actually exercise `make test` on a Windows runner.

Nothing outside the Windows code paths changes behavior: every switch is guarded
by `ifeq ($(OS),Windows_NT)` (or the equivalent), so Linux and macOS builds are
unaffected.

## Motivation

* Pulse `fstar1` now builds on Windows (cf. FStarLang/pulse#594), so there is no longer a reason to force
  `NO_PULSE` and ship a crippled Windows package.
* The Pulse-based libraries (EverCBOR, EverCDDL) and their C/Rust/Python test
  harnesses assumed a POSIX-ish `realpath`/path layout and a POSIX C/Python
  runtime, none of which hold under Cygwin + MinGW-w64.
* Windows CI only packaged and smoke-tested the binaries; it never ran the
  `make test` suite, so regressions on Windows went unnoticed.

## Changes

### 1. Re-enable Pulse / CDDL / CBOR on Windows

* **`opt/hashes.Makefile`** — advance `pulse_hash` to a revision that compiles
  on Windows.
* **`deps.Makefile`** — remove the `NO_PULSE := 1` override for Windows so the
  Pulse-based components are built again.
* **`Makefile`** — include `cddl` in `package-subset` on Windows (dropped the
  `ifneq ($(OS),Windows_NT)` guard).
* **`src/package/package.sh`** — copy the Pulse / EverCBOR / EverCDDL sources
  into the package on Windows too (previously guarded by `! $is_windows`).

### 2. Windows toolchain and environment

* **`deps.Makefile`** — on Windows, set `CC`/`LD`/`AR`/`CXX` to the
  `x86_64-w64-mingw32-*` MinGW cross tools and surface them through `make env`.
* **`opt/opam-env.sh`** — fix `PATH` handling: keep the `PATH` line produced by
  `opam env` (which contains the switch and toolchain directories) and *extend*
  the existing `PATH` instead of discarding it and re-appending only the switch
  `bin`. Applies to both the shell and the Makefile output flavors.
* **`src/package/windows/cygwin-packages`** — add `make` and `cmake` (the latter
  is needed to build tinycbor), and pin `pkg-config`/`pkgconf` to `2.5.1-1`.

### 3. Windows path normalization (`cygpath -m`)

MinGW tools expect Windows-style paths, whereas Cygwin `make`/`realpath`
produce `/cygdrive/...` paths. The fix is to normalize paths through
`cygpath -m` and derive everything from the (normalized) `EVERPARSE_SRC_PATH`
rather than `EVERPARSE_HOME`.

* Include the existing **`src/windows.Makefile`** helper (which rewrites
  `EVERPARSE_SRC_PATH` via `cygpath -m` on Windows) from the Makefiles that
  build/test Pulse components:
  `src/cbor/pulse/krml/extract.Makefile`, `src/cddl/tests/roundtrip/Makefile`,
  `src/cddl/tests/rust/Makefile`, `src/cddl/tool/Makefile`,
  `src/cddl/tool/ocaml.Makefile`, `tests/bitfields/Makefile.common`,
  `tests/sample/Makefile.common`, `tests/sample0/Makefile.common`.
* Replace `realpath`-derived paths with `cygpath -m`-normalized ones in
  `share/everparse/tests/cbor/Makefile`, `src/cbor/pulse/krml/c.Makefile` and
  `src/cbor/pulse/krml/rust.Makefile`.
* In `tests/*/Makefile.common`, derive `LOWPARSE_HOME` and `QD` from
  `EVERPARSE_SRC_PATH` and stop exporting `EVERPARSE_HOME`.
* Use `;` as the `OCAMLPATH` separator on Windows
  (`src/cddl/tests/roundtrip/Makefile`).
* Switch several recursively-expanded assignments (`=`) to immediate (`:=`) so
  the `cygpath` normalization is applied once, deterministically.
* **`src/common.Makefile`** — fix a missing closing parenthesis in the
  `cygpath -m $(CACHE_DIRECTORY)` invocation (latent bug on the Windows path).
* **`doc/Makefile`** — use the `.venv/Scripts/...` layout for the Python venv on
  Windows, introduce a `$(python)` variable, and stop exporting
  `EVERPARSE_HOME`.

### 4. Source-level portability fixes

* **`share/everparse/tests/cbor/cbor_tests.c`** — `mkdir(2)` is POSIX and takes a
  mode argument, but MinGW's `mkdir` is single-argument. Add an `MKDIR` macro
  that drops the mode under `__MINGW64__`.
* **`share/everparse/tests/cbor/cbor_tests.py`** — run `main()` on a worker
  thread with an explicit 8 MB stack. The default thread stack on Windows is too
  small for the recursive CBOR test workload and overflows.
* **`src/cddl/tool/ocaml/evercddl-gen/Main.ml`** — write the KaRaMeL options to a
  temporary `.rsp` response file and invoke `krml @file` instead of passing the
  (very long) option list on the command line, avoiding the Windows
  command-line length limit. The response file is removed afterwards.

### 5. Disable components that don't build/run on MinGW

* **COSE** (`Makefile`) — disable the `cose` build and `cose-test` on Windows
  (same reason as macOS: we don't know how to link against OpenSSL there).
* **3d tests** (`src/3d/tests/Makefile`) — exclude tests that clash with the
  MinGW/Windows environment: `FineGrainedProbe*` and `Specialize2/3/5/6` (their
  `UlongToPtr` conflicts with Windows DLL symbols) and
  `probe_error_handler_macro` (needs `sys/mman.h`, unavailable on MinGW).
* **QCBOR** (`src/cddl/tests/unit/Makefile`) — QCBOR hardcodes GNU `ar` instead
  of `$(AR)` and does not build with MinGW, so the QCBOR-linked benchmark tests
  (`BenchArray__Interop*`, `BenchFlat`, `BenchMap`, `qcbor_bench`) are disabled
  on Windows; `run-qcbor_bench` becomes a no-op there.

### 6. CDDL Rust test: copies instead of symlinks

Git symlinks don't survive a Windows checkout. The Rust test's
`src/cbordetver.rs`, `src/cbordetveraux.rs` and `src/cddlextractiontest.rs` are
changed from symlinks into `_output/` to files that are **copied** from
`_output/` during `extract-all` (and removed on `clean`), with a `.gitignore`
added so the copies are not tracked (`src/cddl/tests/rust/Makefile`,
`src/cddl/tests/rust/src/.gitignore`).

### 7. CI: actually run `make test` on Windows

**`.github/workflows/package-windows.yml`**

* Add a `testci` job (Windows 2025, Cygwin + OCaml 4.14.2) that expands the F*
  source package and runs `env V=1 MAKE=make make test -kj$(nproc)`.
* Gate `testci` behind a `run_full_ci` `workflow_dispatch` boolean input so the
  expensive full test run is opt-in.
* Rename the existing package smoke-test job `test` → `testpackage` and add an
  "Test EverCDDL" step that runs the packaged `cddl.exe` on
  `src/cddl/tests/demo/test.cddl`.
* Add an aggregate `test` job that depends on `testpackage` and `testci` so the
  workflow's overall status reflects both.

## Testing

* Full `make test` runs on the new Windows CI job (`testci`, opt-in via the
  **Run full CI** checkbox on manual dispatch).
* The packaged binaries, including `cddl.exe`, are smoke-tested by the
  `testpackage` job.
* Linux/macOS are unaffected: all changes are behind `Windows_NT` guards or are
  no-ops elsewhere (e.g. `:=` vs `=`, the response-file indirection, the
  copy-instead-of-symlink test setup).

## Notes / limitations on Windows

* COSE is not built or tested (OpenSSL linking).
* QCBOR-based benchmarks are not built (QCBOR/MinGW `ar` incompatibility).
* A few `3d` tests are excluded (`sys/mman.h` / `UlongToPtr` conflicts).
