### PR TITLE
Apply some proof fixes necessary for FStarLang/FStar@316df75b1306199193b3d454b938b8f39b09bc96

### DIFF
--- a/src/ASN1/ASN1.Spec.Any.fst
+++ b/src/ASN1/ASN1.Spec.Any.fst
@@ -26,7 +26,11 @@ let rec make_gen_choice_weak_payload_parser
     if (id = id') then
       let p = (Mkgenparser?.p gp) in 
       parse_synth p (attach_tag lc id)
-    else      
+    else
+      let _ = assert (extract_types lc ==
+        (fst hd, Mkgenparser?.t (snd hd)) :: extract_types tl) in
+      let _ = assert_norm (project_tags lc ==
+        tag_of_gen_choice_type (extract_types lc)) in
       parse_synth (make_gen_choice_weak_payload_parser tl id) (fun x -> lemma_choice_cast (fst hd, Mkgenparser?.t (snd hd)) (extract_types tl) id x)
 
 let make_gen_choice_weak_parser
@@ -47,6 +51,23 @@ let make_gen_choice_weak_parser_twin
 : asn1_id_t -> parser (and_then_kind k asn1_weak_parser_kind) (make_gen_choice_type (extract_types lc))
 = fun id -> parse_tagged_union (fp id) (tag_of_gen_choice_type (extract_types lc)) (make_gen_choice_weak_payload_parser lc)
 
+let make_gen_choice_weak_parser_twin_precond
+  (#t : eqtype)
+  (#k : parser_kind)
+  (fp : asn1_id_t -> parser k t {and_then_cases_injective fp})
+  (lc : list (t & (gen_parser asn1_weak_parser_kind)))
+  (x1 x2 : asn1_id_t)
+  (b1 b2 : LowParse.Bytes.bytes)
+: Lemma
+  (requires (and_then_cases_injective_precond
+    (make_gen_choice_weak_parser_twin fp lc) x1 x2 b1 b2))
+  (ensures (and_then_cases_injective_precond fp x1 x2 b1 b2))
+=
+  parse_tagged_union_eq (fp x1) (tag_of_gen_choice_type (extract_types lc))
+    (make_gen_choice_weak_payload_parser lc) b1;
+  parse_tagged_union_eq (fp x2) (tag_of_gen_choice_type (extract_types lc))
+    (make_gen_choice_weak_payload_parser lc) b2
+
 let make_gen_choice_weak_parser_twin_and_then_cases_injective
   (#t : eqtype)
   (#k : parser_kind)
@@ -55,8 +76,7 @@ let make_gen_choice_weak_parser_twin_and_then_cases_injective
 : Lemma (ensures (and_then_cases_injective (make_gen_choice_weak_parser_twin fp lc)))
 = let p = make_gen_choice_weak_parser_twin fp lc in
   and_then_cases_injective_intro p (fun x1 x2 b1 b2 ->
-    parse_tagged_union_eq (fp x1) (tag_of_gen_choice_type (extract_types lc)) (make_gen_choice_weak_payload_parser lc) b1;
-    parse_tagged_union_eq (fp x2) (tag_of_gen_choice_type (extract_types lc)) (make_gen_choice_weak_payload_parser lc) b2;
+    make_gen_choice_weak_parser_twin_precond fp lc x1 x2 b1 b2;
     and_then_cases_injective_elim fp x1 x2 b1 b2
   )
 
@@ -101,7 +121,12 @@ let rec make_gen_choice_with_fallback_weak_payload_parser
     if (id = id') then
       let p = (Mkgenparser?.p gp) in 
       parse_synth p (attach_tag_with_fallback lc fb id)
-    else      
+    else
+      let _ = assert (extract_types lc ==
+        (fst hd, Mkgenparser?.t (snd hd)) :: extract_types tl) in
+      let _ = assert_norm (project_tags_with_fallback lc fb ==
+        tag_of_gen_choice_type_with_fallback (extract_types lc)
+          (Mkgenparser?.t fb)) in
       parse_synth (make_gen_choice_with_fallback_weak_payload_parser tl fb id) (fun x -> lemma_choice_with_fallback_cast (fst hd, Mkgenparser?.t (snd hd)) (extract_types tl) (Mkgenparser?.t fb) id x)
 
 let make_gen_choice_with_fallback_weak_parser
@@ -296,4 +321,3 @@ let make_asn1_sequence_any_parser
 //  (pf : (asn1_sequence_k_wf (List.map project_set_decorator itemtwins)))
 : Tot (asn1_sequence_any_parser_type itemtwins suffix_t)
 = make_asn1_sequence_any_parser' itemtwins suffix_p_twin None
-

--- a/src/ASN1/ASN1.Spec.Choice.fst
+++ b/src/ASN1/ASN1.Spec.Choice.fst
@@ -79,7 +79,11 @@ let rec make_gen_choice_strong_payload_parser
     if (id = id') then
       let p = (Mkgenparser?.p gp) in 
       parse_synth p (attach_tag lc id)
-    else 
+    else
+      let _ = assert (extract_types lc ==
+        (fst hd, Mkgenparser?.t (snd hd)) :: extract_types tl) in
+      let _ = assert_norm (project_tags lc ==
+        tag_of_gen_choice_type (extract_types lc)) in
       parse_synth (make_gen_choice_strong_payload_parser tl id) (fun x -> lemma_choice_cast (fst hd, Mkgenparser?.t (snd hd)) (extract_types tl) id x)
 
 let make_gen_choice_strong_parser

--- a/src/cbor/pulse/det/rust/src/cbordetveraux.rs
+++ b/src/cbor/pulse/det/rust/src/cbordetveraux.rs
@@ -2452,8 +2452,8 @@ pub(crate) fn cbor_array_iterator_next <'b, 'a>(
     cbor_raw
     <'a>
 {
-    let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = pi[0];
-    match i0
+    let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = pi[0];
+    match iter
     {
         cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw::CBOR_Raw_Iterator_Slice { _0: i1 } =>
           {
@@ -2558,8 +2558,8 @@ pub(crate) fn cbor_map_iterator_next <'b, 'a>(
     cbor_map_entry
     <'a>
 {
-    let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry = pi[0];
-    match i0
+    let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry = pi[0];
+    match iter
     {
         cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry::CBOR_Raw_Iterator_Slice { _0: i1 } =>
           {
@@ -4357,9 +4357,9 @@ pub(crate) fn cbor_compare_with_depth(x1: cbor_raw, x2: cbor_raw) -> i16
                         while
                         cond
                         {
-                            let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = (&pi1)[0];
+                            let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = (&pi1)[0];
                             let elt1: cbor_raw =
-                                match i0
+                                match iter
                                 {
                                     cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw::CBOR_Raw_Iterator_Slice
                                     { _0: i }
@@ -4386,9 +4386,9 @@ pub(crate) fn cbor_compare_with_depth(x1: cbor_raw, x2: cbor_raw) -> i16
                                     => cbor_serialized_array_iterator_next_with_depth(&mut pi1, i),
                                     _ => panic!("Incomplete pattern matching")
                                 };
-                            let i00: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = (&pi2)[0];
+                            let iter0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = (&pi2)[0];
                             let elt2: cbor_raw =
-                                match i00
+                                match iter0
                                 {
                                     cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw::CBOR_Raw_Iterator_Slice
                                     { _0: i }
@@ -4551,10 +4551,10 @@ pub(crate) fn cbor_compare_with_depth(x1: cbor_raw, x2: cbor_raw) -> i16
                         while
                         cond
                         {
-                            let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry =
+                            let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry =
                                 (&pi1)[0];
                             let elt1: cbor_map_entry =
-                                match i0
+                                match iter
                                 {
                                     cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry::CBOR_Raw_Iterator_Slice
                                     { _0: i }
@@ -4581,10 +4581,10 @@ pub(crate) fn cbor_compare_with_depth(x1: cbor_raw, x2: cbor_raw) -> i16
                                     => cbor_serialized_map_iterator_next_with_depth(&mut pi1, i),
                                     _ => panic!("Incomplete pattern matching")
                                 };
-                            let i00: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry =
+                            let iter0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry =
                                 (&pi2)[0];
                             let elt2: cbor_map_entry =
-                                match i00
+                                match iter0
                                 {
                                     cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry::CBOR_Raw_Iterator_Slice
                                     { _0: i }

--- a/src/cbor/pulse/nondet/rust/src/cbornondetveraux.rs
+++ b/src/cbor/pulse/nondet/rust/src/cbornondetveraux.rs
@@ -1817,8 +1817,8 @@ fn cbor_array_iterator_next <'b, 'a>(
     cbor_raw
     <'a>
 {
-    let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = pi[0];
-    match i0
+    let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = pi[0];
+    match iter
     {
         cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw::CBOR_Raw_Iterator_Slice { _0: i1 } =>
           {
@@ -1920,8 +1920,8 @@ fn cbor_map_iterator_next <'b, 'a>(
     cbor_map_entry
     <'a>
 {
-    let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry = pi[0];
-    match i0
+    let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry = pi[0];
+    match iter
     {
         cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry::CBOR_Raw_Iterator_Slice { _0: i1 } =>
           {
@@ -1987,8 +1987,8 @@ fn cbor_array_iterator_next_with_depth <'b, 'a>(
     cbor_raw
     <'a>
 {
-    let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = pi[0];
-    match i0
+    let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = pi[0];
+    match iter
     {
         cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw::CBOR_Raw_Iterator_Slice { _0: i1 } =>
           {
@@ -2058,8 +2058,8 @@ fn cbor_map_iterator_next_with_depth <'b, 'a>(
     cbor_map_entry
     <'a>
 {
-    let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry = pi[0];
-    match i0
+    let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry = pi[0];
+    match iter
     {
         cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry::CBOR_Raw_Iterator_Slice { _0: i1 } =>
           {

--- a/src/cbor/pulse/raw/CBOR.Pulse.API.Det.Common.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.API.Det.Common.fst
@@ -791,6 +791,61 @@ let rec list_map_mk_det_raw_cbor_map_entry_mk_cbor_map_entry
     SpecRaw.mk_det_raw_cbor_mk_cbor v;
     list_map_mk_det_raw_cbor_map_entry_mk_cbor_map_entry q
 
+let list_memP_map_mk_cbor_map_entry_equiv
+  (vv: list (Spec.cbor & Spec.cbor))
+  (vv': list (SpecRaw.raw_data_item & SpecRaw.raw_data_item))
+: Lemma
+  (requires (
+    List.Tot.map SpecRaw.mk_det_raw_cbor_map_entry
+      (List.Tot.map SpecRaw.mk_cbor_map_entry vv') == vv' /\
+    (forall y .
+      List.Tot.memP y vv' <==>
+      List.Tot.memP y (List.Tot.map SpecRaw.mk_det_raw_cbor_map_entry vv))
+  ))
+  (ensures (
+    forall x .
+      List.Tot.memP x (List.Tot.map SpecRaw.mk_cbor_map_entry vv') <==>
+      List.Tot.memP x vv
+  ))
+= let prf
+    (x: Spec.cbor & Spec.cbor)
+  : Lemma
+    (List.Tot.memP x (List.Tot.map SpecRaw.mk_cbor_map_entry vv') <==>
+      List.Tot.memP x vv)
+  = let raw_x = SpecRaw.mk_det_raw_cbor_map_entry x in
+    if FStar.IndefiniteDescription.strong_excluded_middle
+      (List.Tot.memP x (List.Tot.map SpecRaw.mk_cbor_map_entry vv'))
+    then begin
+      List.Tot.memP_map_intro
+        SpecRaw.mk_det_raw_cbor_map_entry
+        x
+        (List.Tot.map SpecRaw.mk_cbor_map_entry vv');
+      assert (List.Tot.memP raw_x vv');
+      assert (
+        List.Tot.memP raw_x vv' <==>
+        List.Tot.memP raw_x (List.Tot.map SpecRaw.mk_det_raw_cbor_map_entry vv)
+      );
+      let y = CBOR.Spec.Util.list_memP_map_elim
+        SpecRaw.mk_det_raw_cbor_map_entry raw_x vv in
+      SpecRaw.mk_det_raw_cbor_inj (fst y) (fst x);
+      SpecRaw.mk_det_raw_cbor_inj (snd y) (snd x)
+    end
+    else if FStar.IndefiniteDescription.strong_excluded_middle
+      (List.Tot.memP x vv)
+    then begin
+      List.Tot.memP_map_intro SpecRaw.mk_det_raw_cbor_map_entry x vv;
+      assert (
+        List.Tot.memP raw_x vv' <==>
+        List.Tot.memP raw_x (List.Tot.map SpecRaw.mk_det_raw_cbor_map_entry vv)
+      );
+      assert (List.Tot.memP raw_x vv');
+      assert (SpecRaw.mk_cbor_map_entry raw_x == x);
+      List.Tot.memP_map_intro SpecRaw.mk_cbor_map_entry raw_x vv'
+    end
+    else ()
+  in
+  Classical.forall_intro prf
+
 let list_no_repeats_map_fst_intro_mk_det_raw_cbor1
   (vv: list (Spec.cbor & Spec.cbor))
   (l1 l2: list (SpecRaw.raw_data_item & SpecRaw.raw_data_item))
@@ -962,7 +1017,8 @@ fn cbor_det_mk_map_gen (_: unit)
       seq_list_map_mk_cbor_map_entry_intro pv va' vv';
       Trade.trans _ _ (SM.seq_list_match va vv (cbor_det_map_entry_match pv));
       let vv2 = Ghost.hide (List.Tot.map SpecRaw.mk_cbor_map_entry vv');
-      assert (pure (forall x . List.Tot.memP x vv2 <==> List.Tot.memP x vv));
+      list_map_mk_det_raw_cbor_map_entry_mk_cbor_map_entry vv';
+      list_memP_map_mk_cbor_map_entry_equiv vv vv';
       assert (pure (List.Tot.length vv2 == List.Tot.length vv));
       assert (pure (~ (List.Tot.no_repeats_p (List.Tot.map fst vv))));
       assert (pure (List.Tot.length vv <= pow2 64 - 1));

--- a/src/cbor/pulse/raw/CBOR.Pulse.Raw.Iterator.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.Raw.Iterator.fst
@@ -392,6 +392,36 @@ let cbor_raw_iterator_match
   | CBOR_Raw_Iterator_Slice c' -> cbor_raw_slice_iterator_match elt_match pm c' l
   | CBOR_Raw_Iterator_Serialized c' -> ser_match pm c' l
 
+let cbor_raw_iterator_match_slice_from_eq
+  (#elt_low #elt_high: Type0)
+  (elt_match: perm -> elt_low -> elt_high -> slprop)
+  (ser_match: perm -> cbor_raw_serialized_iterator -> list elt_high -> slprop)
+  (pm: perm)
+  (c: cbor_raw_iterator elt_low)
+  (i: cbor_raw_slice_iterator elt_low)
+  (l: list elt_high)
+: Lemma
+  (requires c == CBOR_Raw_Iterator_Slice i)
+  (ensures
+    cbor_raw_iterator_match elt_match ser_match pm c l ==
+    cbor_raw_slice_iterator_match elt_match pm i l)
+= ()
+
+let cbor_raw_iterator_match_serialized_from_eq
+  (#elt_low #elt_high: Type0)
+  (elt_match: perm -> elt_low -> elt_high -> slprop)
+  (ser_match: perm -> cbor_raw_serialized_iterator -> list elt_high -> slprop)
+  (pm: perm)
+  (c: cbor_raw_iterator elt_low)
+  (i: cbor_raw_serialized_iterator)
+  (l: list elt_high)
+: Lemma
+  (requires c == CBOR_Raw_Iterator_Serialized i)
+  (ensures
+    cbor_raw_iterator_match elt_match ser_match pm c l ==
+    ser_match pm i l)
+= ()
+
 inline_for_extraction
 fn cbor_raw_iterator_init_from_slice
   (#elt_low #elt_high: Type0)
@@ -592,9 +622,12 @@ ensures
       (cbor_raw_iterator_match elt_match ser_match pm i0 l) **
     pure (Ghost.reveal l == a :: q)
 {
-  let i0 = !pi;
-  match i0 {
+  let iter = !pi;
+  assert (pure (iter == i0));
+  match iter {
     CBOR_Raw_Iterator_Slice i -> {
+      assert (pure (i0 == CBOR_Raw_Iterator_Slice i));
+      cbor_raw_iterator_match_slice_from_eq elt_match ser_match pm i0 i l;
       Trade.rewrite_with_trade // FIXME: PLEASE automate this step away!
         (cbor_raw_iterator_match elt_match ser_match pm i0 l)
         (cbor_raw_slice_iterator_match elt_match pm i l);
@@ -603,6 +636,13 @@ ensures
       Trade.trans _ _ (cbor_raw_iterator_match elt_match ser_match pm i0 l);
       with p a . assert (elt_match p res a);
       with i' q . assert (cbor_raw_slice_iterator_match elt_match pm i' q);
+      cbor_raw_iterator_match_slice_from_eq
+        elt_match
+        ser_match
+        pm
+        (CBOR_Raw_Iterator_Slice i')
+        i'
+        q;
       Trade.rewrite_with_trade
         (cbor_raw_slice_iterator_match elt_match pm i' q)
         (cbor_raw_iterator_match elt_match ser_match pm (CBOR_Raw_Iterator_Slice i') q);
@@ -615,6 +655,8 @@ ensures
       res
     }
     CBOR_Raw_Iterator_Serialized i -> {
+      assert (pure (i0 == CBOR_Raw_Iterator_Serialized i));
+      cbor_raw_iterator_match_serialized_from_eq elt_match ser_match pm i0 i l;
       Trade.rewrite_with_trade // FIXME: PLEASE automate this step away!
         (cbor_raw_iterator_match elt_match ser_match pm i0 l)
         (ser_match pm i l);
@@ -623,6 +665,13 @@ ensures
       Trade.trans _ _ (cbor_raw_iterator_match elt_match ser_match pm i0 l);
       with p a . assert (elt_match p res a);
       with i' q . assert (ser_match pm i' q);
+      cbor_raw_iterator_match_serialized_from_eq
+        elt_match
+        ser_match
+        pm
+        (CBOR_Raw_Iterator_Serialized i')
+        i'
+        q;
       Trade.rewrite_with_trade
         (ser_match pm i' q)
         (cbor_raw_iterator_match elt_match ser_match pm (CBOR_Raw_Iterator_Serialized i') q);

--- a/src/cbor/pulse/raw/CBOR.Pulse.Raw.Match.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.Raw.Match.fst
@@ -1787,9 +1787,31 @@ let depth_cb (n: nat) (r: raw_data_item)
    then (fun (_: perm) (_: cbor_raw) (_: raw_data_item) -> pure False)
    else cbor_match_with_depth (n - 1))
 
+let depth_cb_eq
+  (n: nat)
+  (r: raw_data_item)
+: Lemma
+  (ensures
+    depth_cb n r ==
+      ((if n = 0
+        then (fun (_: perm) (_: cbor_raw) (_: raw_data_item) -> pure False)
+        else cbor_match_with_depth (n - 1))
+       <: (perm -> cbor_raw -> (v': raw_data_item { v' << r }) -> slprop)))
+= assert (
+    depth_cb n r ==
+      ((if n = 0
+         then (fun (_: perm) (_: cbor_raw) (_: raw_data_item) -> pure False)
+         else cbor_match_with_depth (n - 1))
+        <: (perm -> cbor_raw -> (v': raw_data_item { v' << r }) -> slprop))
+  ) by (
+      FStar.Tactics.norm [delta_only [`%depth_cb]];
+      FStar.Tactics.trefl ()
+    )
+
 let cbor_match_with_depth_eq0 (n: nat) (p: perm) (c: cbor_raw) (r: raw_data_item)
 : Lemma (ensures cbor_match_with_depth n p c r == cbor_match0 p c r (depth_cb n r))
-= assert_norm (cbor_match_with_depth n p c r == cbor_match0 p c r (depth_cb n r))
+= depth_cb_eq n r;
+  assert_norm (cbor_match_with_depth n p c r == cbor_match0 p c r (depth_cb n r))
 
 let cbor_match_eq0 (p: perm) (c: cbor_raw) (r: raw_data_item)
 : Lemma (ensures cbor_match p c r == cbor_match0 p c r cbor_match)
@@ -1983,6 +2005,7 @@ fn cbor_match_with_depth_tagged_elim (depth: nat) (p: perm) (a: cbor_tagged) (r:
     pure (a.cbor_tagged_tag == Tagged?.tag r /\ depth >= 1)
 {
   cbor_match_with_depth_eq_tagged depth p a r;
+  depth_cb_eq depth r;
   rewrite (cbor_match_with_depth depth p (CBOR_Case_Tagged a) r) as (cbor_match_tagged a p r (depth_cb depth r));
   unfold (cbor_match_tagged a p r (depth_cb depth r));
   with c'. assert (depth_cb depth r (p `perm_mul` a.cbor_tagged_payload_perm) c' (Tagged?.v r));
@@ -2005,6 +2028,7 @@ fn cbor_match_with_depth_tagged_elim (depth: nat) (p: perm) (a: cbor_tagged) (r:
       as (depth_cb depth r (p `perm_mul` a.cbor_tagged_payload_perm) c' (Tagged?.v r));
     fold (cbor_match_tagged a p r (depth_cb depth r));
     cbor_match_with_depth_eq_tagged depth p a r;
+    depth_cb_eq depth r;
     rewrite (cbor_match_tagged a p r (depth_cb depth r)) as (cbor_match_with_depth depth p (CBOR_Case_Tagged a) r);
   };
 }
@@ -2027,6 +2051,7 @@ fn cbor_match_with_depth_array_elim (depth: nat) (p: perm) (a: cbor_array) (r: r
       SZ.v (S.len a.cbor_array_ptr) == U64.v (Array?.len r).value)
 {
   cbor_match_with_depth_eq_array depth p a r;
+  depth_cb_eq depth r;
   rewrite (cbor_match_with_depth depth p (CBOR_Case_Array a) r) as (cbor_match_array a p r (depth_cb depth r));
   unfold (cbor_match_array a p r (depth_cb depth r));
   with s. assert (pts_to a.cbor_array_ptr #(p `perm_mul` a.cbor_array_array_perm) s **
@@ -2041,6 +2066,7 @@ fn cbor_match_with_depth_array_elim (depth: nat) (p: perm) (a: cbor_array) (r: r
   {
     fold (cbor_match_array a p r (depth_cb depth r));
     cbor_match_with_depth_eq_array depth p a r;
+    depth_cb_eq depth r;
     rewrite (cbor_match_array a p r (depth_cb depth r)) as (cbor_match_with_depth depth p (CBOR_Case_Array a) r);
   };
 }
@@ -2060,6 +2086,7 @@ fn cbor_match_with_depth_map_elim (depth: nat) (p: perm) (a: cbor_map) (r: raw_d
       SZ.v (S.len a.cbor_map_ptr) == U64.v (Map?.len r).value)
 {
   cbor_match_with_depth_eq_map0 depth p a r;
+  depth_cb_eq depth r;
   rewrite (cbor_match_with_depth depth p (CBOR_Case_Map a) r) as (cbor_match_map0 a p r (depth_cb depth r));
   unfold (cbor_match_map0 a p r (depth_cb depth r));
   with s. assert (pts_to a.cbor_map_ptr #(p `perm_mul` a.cbor_map_array_perm) s **
@@ -2074,6 +2101,7 @@ fn cbor_match_with_depth_map_elim (depth: nat) (p: perm) (a: cbor_map) (r: raw_d
   {
     fold (cbor_match_map0 a p r (depth_cb depth r));
     cbor_match_with_depth_eq_map0 depth p a r;
+    depth_cb_eq depth r;
     rewrite (cbor_match_map0 a p r (depth_cb depth r)) as (cbor_match_with_depth depth p (CBOR_Case_Map a) r);
   };
 }

--- a/src/cbor/pulse/raw/CBOR.Pulse.Raw.Nondet.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.Raw.Nondet.fst
@@ -1369,9 +1369,8 @@ fn cbor_nondet_mk_map_gen_by_ref (_: unit)
       SM.seq_list_match_length (Raw.cbor_match_map_entry pv) va v';
       let raw_len = SpecRaw.mk_raw_uint64 (SZ.sizet_to_uint64 (S.len a));
       fits_mod (SZ.v (S.len a)) U64.n;
-      let sq : squash (List.Tot.length v' == U64.v raw_len.value) = ();
       let v'' : Ghost.erased (SpecRaw.nlist (SpecRaw.raw_data_item & SpecRaw.raw_data_item) (U64.v raw_len.value)) =
-        nlist_intro v' (U64.v raw_len.value) sq
+        nlist_intro v' (U64.v raw_len.value) ()
       ;
       let cr : Ghost.erased SpecRaw.raw_data_item = SpecRaw.Map raw_len v'';
       SpecRaw.valid_eq SpecRaw.basic_data_model cr;

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialize.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialize.fst
@@ -1338,16 +1338,11 @@ ensures
     (cbor_match_with_depth n xl.p xl.v xh');
   Trade.trans (cbor_match_with_depth n xl.p xl.v xh') (cbor_match_with_perm_d n xl xh') _;
   cbor_match_with_depth_cases n xl.p xl.v xh';
-  let _ : squash (cbor_major_type_byte_string == 2uy) =
-    assert_norm (cbor_major_type_byte_string == 2uy);
-  let _ : squash (cbor_major_type_text_string == 3uy) =
-    assert_norm (cbor_major_type_text_string == 3uy);
-  let _ : squash (cbor_major_type_array == 4uy) =
-    assert_norm (cbor_major_type_array == 4uy);
-  let _ : squash (cbor_major_type_map == 5uy) =
-    assert_norm (cbor_major_type_map == 5uy);
-  let _ : squash (cbor_major_type_tagged == 6uy) =
-    assert_norm (cbor_major_type_tagged == 6uy);
+  assert_norm ((cbor_major_type_byte_string <: FStar.UInt8.t) == 2uy);
+  assert_norm ((cbor_major_type_text_string <: FStar.UInt8.t) == 3uy);
+  assert_norm ((cbor_major_type_array <: FStar.UInt8.t) == 4uy);
+  assert_norm ((cbor_major_type_map <: FStar.UInt8.t) == 5uy);
+  assert_norm ((cbor_major_type_tagged <: FStar.UInt8.t) == 6uy);
   get_major_type_synth_raw_data_item_recip (Ghost.reveal xh');
   cbor_match_with_depth_to_match n xl.v;
   Trade.trans (cbor_match xl.p xl.v xh') (cbor_match_with_depth n xl.p xl.v xh') _;

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialize.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialize.fst
@@ -1225,7 +1225,7 @@ vmatch_lens #_ #_ #_
       (lseq_utf8_correct (get_header_initial_byte xh1).major_type
           (U64.v (argument_as_uint64 (get_header_initial_byte xh1) (get_header_long_argument xh1)))
       )
-      res z
+      res (Ghost.reveal z)
     );
   Trade.trans _ 
     (LowParse.Pulse.SeqBytes.pts_to_seqbytes
@@ -1280,6 +1280,8 @@ let size_payload_string
 // cbor_match via cbor_match_with_depth_to_match, then the rest reuses the exact
 // non-depth seqbytes extraction. No recursion / no `f`.
 // ============================================================================
+
+#push-options "--z3rlimit 10 --split_queries always"
 
 ghost
 fn ser_payload_string_lens_aux_d
@@ -1336,6 +1338,17 @@ ensures
     (cbor_match_with_depth n xl.p xl.v xh');
   Trade.trans (cbor_match_with_depth n xl.p xl.v xh') (cbor_match_with_perm_d n xl xh') _;
   cbor_match_with_depth_cases n xl.p xl.v xh';
+  let _ : squash (cbor_major_type_byte_string == 2uy) =
+    assert_norm (cbor_major_type_byte_string == 2uy);
+  let _ : squash (cbor_major_type_text_string == 3uy) =
+    assert_norm (cbor_major_type_text_string == 3uy);
+  let _ : squash (cbor_major_type_array == 4uy) =
+    assert_norm (cbor_major_type_array == 4uy);
+  let _ : squash (cbor_major_type_map == 5uy) =
+    assert_norm (cbor_major_type_map == 5uy);
+  let _ : squash (cbor_major_type_tagged == 6uy) =
+    assert_norm (cbor_major_type_tagged == 6uy);
+  get_major_type_synth_raw_data_item_recip (Ghost.reveal xh');
   cbor_match_with_depth_to_match n xl.v;
   Trade.trans (cbor_match xl.p xl.v xh') (cbor_match_with_depth n xl.p xl.v xh') _;
   Trade.rewrite_with_trade
@@ -1344,6 +1357,8 @@ ensures
   Trade.trans (cbor_match_with_perm xl xh') (cbor_match xl.p xl.v xh') _;
   xh'
 }
+
+#pop-options
 
 #push-options "--z3rlimit 32"
 
@@ -1414,7 +1429,7 @@ vmatch_lens #_ #_ #_
       (lseq_utf8_correct (get_header_initial_byte xh1).major_type
           (U64.v (argument_as_uint64 (get_header_initial_byte xh1) (get_header_long_argument xh1)))
       )
-      res z
+      res (Ghost.reveal z)
     );
   Trade.trans _ 
     (LowParse.Pulse.SeqBytes.pts_to_seqbytes
@@ -1489,6 +1504,19 @@ let cbor_with_perm_case_array_match_elem
 = cbor_match
     (perm_mul c.p (match c.v with CBOR_Case_Array a -> a.cbor_array_payload_perm | _ -> 1.0R (* dummy *) ))
 
+let cbor_with_perm_case_array_match_elem_eq
+  (c: with_perm cbor_raw)
+  (a: cbor_array)
+  (sq: squash (c.v == CBOR_Case_Array a))
+: Lemma (
+    (match c.v with
+      | CBOR_Case_Array a' -> a'.cbor_array_payload_perm
+      | _ -> 1.0R) == a.cbor_array_payload_perm
+  )
+= match c.v with
+  | CBOR_Case_Array a' -> assert (a' == a)
+  | _ -> assert False
+
 inline_for_extraction
 let ser_payload_array_array_elem
   (f: l2r_writer cbor_match_with_perm serialize_raw_data_item)
@@ -1550,9 +1578,10 @@ ensures
                           xh1)
                       (get_header_long_argument xh1)))
           raw_data_item) (vmatch_with_cond (match_cbor_payload xh1) cbor_with_perm_case_array) _ _;
-  vmatch_with_cond_elim_trade (match_cbor_payload xh1) _ _ _;
-  Trade.trans (match_cbor_payload xh1 _ _) _ _;
-  let xh0 = match_cbor_payload_elim_trade xh1 _ _;
+  assert (pure (Ghost.reveal xh2 == xh));
+  vmatch_with_cond_elim_trade (match_cbor_payload xh1) _ xl (Ghost.reveal xh2);
+  Trade.trans (match_cbor_payload xh1 xl (Ghost.reveal xh2)) _ _;
+  let xh0 = match_cbor_payload_elim_trade xh1 xl (Ghost.reveal xh2);
   Trade.trans (cbor_match_with_perm xl xh0) _ _;
   Trade.rewrite_with_trade
     (cbor_match_with_perm xl xh0)
@@ -1560,12 +1589,33 @@ ensures
   Trade.trans (cbor_match _ _ _) (cbor_match_with_perm _ _) _; // FIXME: WHY WHY WHY do I need to help Pulse here?
   cbor_match_cases _;
   let CBOR_Case_Array a = xl.v;
+  cbor_with_perm_case_array_match_elem_eq xl a ();
   cbor_match_eq_array xl.p a xh0;
+  assert (pure (Array?.v (Ghost.reveal xh0) == xh));
   Trade.rewrite_with_trade
     (cbor_match xl.p xl.v xh0)
     (cbor_match_array a xl.p xh0 cbor_match);
   Trade.trans (cbor_match_array a xl.p xh0 cbor_match) _ _;
   unfold (cbor_match_array a xl.p xh0 cbor_match);
+  with s. assert (PM.seq_list_match s (Array?.v xh0)
+    (cbor_match (xl.p `perm_mul` a.cbor_array_payload_perm)));
+  rewrite
+    (PM.seq_list_match s (Array?.v xh0)
+      (cbor_match (xl.p `perm_mul` a.cbor_array_payload_perm)))
+    as (PM.seq_list_match s xh
+      (cbor_match
+        (xl.p `perm_mul`
+          (match xl.v with
+            | CBOR_Case_Array a' -> a'.cbor_array_payload_perm
+            | _ -> 1.0R))));
+  rewrite
+    (PM.seq_list_match s xh
+      (cbor_match
+        (xl.p `perm_mul`
+          (match xl.v with
+            | CBOR_Case_Array a' -> a'.cbor_array_payload_perm
+            | _ -> 1.0R))))
+    as (PM.seq_list_match s xh (cbor_with_perm_case_array_match_elem xl));
   // let ar = Some?.v (cbor_with_perm_case_array_get xl);
   let Some ar = cbor_with_perm_case_array_get xl;
   rewrite each a.cbor_array_ptr as ar.v;
@@ -1574,7 +1624,7 @@ ensures
     (U64.v (argument_as_uint64 (get_header_initial_byte xh1)
       (get_header_long_argument xh1)))
     xl xh
-    ar _
+      ar s
   ;
   intro
     (Trade.trade
@@ -1600,6 +1650,23 @@ ensures
     (* ^ There is a single pts_to in the context, rewrite the slice ptr into
        a.cbor_array_ptr and then let maching figure it out. *)
     rewrite S.pts_to s #p v as S.pts_to a.cbor_array_ptr #p v;
+    rewrite
+      (PM.seq_list_match v xh (cbor_with_perm_case_array_match_elem xl))
+      as (PM.seq_list_match v xh
+        (cbor_match
+          (xl.p `perm_mul`
+            (match xl.v with
+              | CBOR_Case_Array a' -> a'.cbor_array_payload_perm
+              | _ -> 1.0R))));
+    rewrite
+      (PM.seq_list_match v xh
+        (cbor_match
+          (xl.p `perm_mul`
+            (match xl.v with
+              | CBOR_Case_Array a' -> a'.cbor_array_payload_perm
+              | _ -> 1.0R))))
+      as (PM.seq_list_match v (Array?.v xh0)
+        (cbor_match (xl.p `perm_mul` a.cbor_array_payload_perm)));
     fold (cbor_match_array a xl.p xh0 cbor_match);
     ()
   };
@@ -1872,6 +1939,20 @@ let cbor_with_perm_case_array_match_elem_d
 = cbor_match_with_depth m
     (perm_mul c.p (match c.v with CBOR_Case_Array a -> a.cbor_array_payload_perm | _ -> 1.0R (* dummy *) ))
 
+let cbor_with_perm_case_array_match_elem_d_eq
+  (m: nat)
+  (c: with_perm cbor_raw)
+  (a: cbor_array)
+  (sq: squash (c.v == CBOR_Case_Array a))
+: Lemma (
+    (match c.v with
+      | CBOR_Case_Array a' -> a'.cbor_array_payload_perm
+      | _ -> 1.0R) == a.cbor_array_payload_perm
+  )
+= match c.v with
+  | CBOR_Case_Array a' -> assert (a' == a)
+  | _ -> assert False
+
 // DELIVERABLE 2: depth-aware element writer / size-computer.
 inline_for_extraction
 let ser_payload_array_array_elem_d
@@ -1944,9 +2025,10 @@ ensures
                           xh1)
                       (get_header_long_argument xh1)))
           raw_data_item) (vmatch_with_cond (match_cbor_payload_d n xh1) cbor_with_perm_case_array) _ _;
-  vmatch_with_cond_elim_trade (match_cbor_payload_d n xh1) _ _ _;
-  Trade.trans (match_cbor_payload_d n xh1 _ _) _ _;
-  let xh0 = match_cbor_payload_elim_trade_d n xh1 _ _;
+  assert (pure (Ghost.reveal xh2 == xh));
+  vmatch_with_cond_elim_trade (match_cbor_payload_d n xh1) _ xl (Ghost.reveal xh2);
+  Trade.trans (match_cbor_payload_d n xh1 xl (Ghost.reveal xh2)) _ _;
+  let xh0 = match_cbor_payload_elim_trade_d n xh1 xl (Ghost.reveal xh2);
   Trade.trans (cbor_match_with_perm_d n xl xh0) _ _;
   Trade.rewrite_with_trade
     (cbor_match_with_perm_d n xl xh0)
@@ -1954,7 +2036,10 @@ ensures
   Trade.trans (cbor_match_with_depth n xl.p xl.v xh0) (cbor_match_with_perm_d n xl xh0) _; // FIXME: WHY WHY WHY do I need to help Pulse here?
   cbor_match_with_depth_cases n xl.p xl.v xh0;
   let CBOR_Case_Array a = xl.v;
+  cbor_with_perm_case_array_match_elem_d_eq (nat_pred n) xl a ();
   cbor_match_with_depth_eq_array n xl.p a xh0;
+  depth_cb_eq n (Ghost.reveal xh0);
+  assert (pure (Array?.v (Ghost.reveal xh0) == xh));
   Trade.rewrite_with_trade
     (cbor_match_with_depth n xl.p xl.v xh0)
     (cbor_match_array a xl.p xh0 (depth_cb n xh0));
@@ -1963,6 +2048,25 @@ ensures
   with s. assert (PM.seq_list_match s (Array?.v xh0)
     ((depth_cb n xh0) (xl.p `perm_mul` a.cbor_array_payload_perm)));
   array_to_unref n xh0 (xl.p `perm_mul` a.cbor_array_payload_perm) s;
+  rewrite
+    (PM.seq_list_match s (Array?.v xh0)
+      (cbor_match_with_depth (nat_pred n)
+        (xl.p `perm_mul` a.cbor_array_payload_perm)))
+    as (PM.seq_list_match s xh
+      (cbor_match_with_depth (nat_pred n)
+        (xl.p `perm_mul`
+          (match xl.v with
+            | CBOR_Case_Array a' -> a'.cbor_array_payload_perm
+            | _ -> 1.0R))));
+  rewrite
+    (PM.seq_list_match s xh
+      (cbor_match_with_depth (nat_pred n)
+        (xl.p `perm_mul`
+          (match xl.v with
+            | CBOR_Case_Array a' -> a'.cbor_array_payload_perm
+            | _ -> 1.0R))))
+    as (PM.seq_list_match s xh
+      (cbor_with_perm_case_array_match_elem_d (nat_pred n) xl));
   let Some ar = cbor_with_perm_case_array_get xl;
   rewrite each a.cbor_array_ptr as ar.v;
   LowParse.Pulse.VCList.nlist_match_slice_intro cbor_with_perm_case_array_get
@@ -1970,7 +2074,7 @@ ensures
     (U64.v (argument_as_uint64 (get_header_initial_byte xh1)
       (get_header_long_argument xh1)))
     xl xh
-    ar _
+      ar s
   ;
   intro
     (Trade.trade
@@ -1996,6 +2100,25 @@ ensures
     (* ^ There is a single pts_to in the context, rewrite the slice ptr into
        a.cbor_array_ptr and then let matching figure it out. *)
     rewrite (S.pts_to sl #p v) as (S.pts_to a.cbor_array_ptr #p v);
+    rewrite
+      (PM.seq_list_match v xh
+        (cbor_with_perm_case_array_match_elem_d (nat_pred n) xl))
+      as (PM.seq_list_match v xh
+        (cbor_match_with_depth (nat_pred n)
+          (xl.p `perm_mul`
+            (match xl.v with
+              | CBOR_Case_Array a' -> a'.cbor_array_payload_perm
+              | _ -> 1.0R))));
+    rewrite
+      (PM.seq_list_match v xh
+        (cbor_match_with_depth (nat_pred n)
+          (xl.p `perm_mul`
+            (match xl.v with
+              | CBOR_Case_Array a' -> a'.cbor_array_payload_perm
+              | _ -> 1.0R))))
+      as (PM.seq_list_match v (Array?.v xh0)
+        (cbor_match_with_depth (nat_pred n)
+          (xl.p `perm_mul` a.cbor_array_payload_perm)));
     array_to_ref n xh0 (xl.p `perm_mul` a.cbor_array_payload_perm) v;
     fold (cbor_match_array a xl.p xh0 (depth_cb n xh0));
     ()
@@ -2260,6 +2383,18 @@ let cbor_with_perm_case_map_match_elem
   Tot slprop
 = cbor_match_map_entry (cbor_with_perm_case_map_match_elem_perm c)
 
+let cbor_with_perm_case_map_match_elem_eq
+  (c: with_perm cbor_raw)
+  (a: cbor_map)
+  (sq: squash (c.v == CBOR_Case_Map a))
+: Lemma (
+    cbor_with_perm_case_map_match_elem_perm c ==
+      c.p `perm_mul` a.cbor_map_payload_perm
+  )
+= match c.v with
+  | CBOR_Case_Map a' -> assert (a' == a)
+  | _ -> assert False
+
 inline_for_extraction
 fn ser_payload_map_map_elem_fst
   (a: with_perm cbor_raw)
@@ -2382,9 +2517,10 @@ ensures
                           xh1)
                       (get_header_long_argument xh1)))
           (raw_data_item & raw_data_item)) (vmatch_with_cond (match_cbor_payload xh1) cbor_with_perm_case_map) _ _;
-  vmatch_with_cond_elim_trade (match_cbor_payload xh1) _ _ _;
-  Trade.trans (match_cbor_payload xh1 _ _) _ _;
-  let xh0 = match_cbor_payload_elim_trade xh1 _ _;
+  assert (pure (Ghost.reveal xh2 == xh));
+  vmatch_with_cond_elim_trade (match_cbor_payload xh1) _ xl (Ghost.reveal xh2);
+  Trade.trans (match_cbor_payload xh1 xl (Ghost.reveal xh2)) _ _;
+  let xh0 = match_cbor_payload_elim_trade xh1 xl (Ghost.reveal xh2);
   Trade.trans (cbor_match_with_perm xl xh0) _ _;
   Trade.rewrite_with_trade
     (cbor_match_with_perm xl xh0)
@@ -2392,7 +2528,9 @@ ensures
   Trade.trans (cbor_match _ _ _) (cbor_match_with_perm xl xh0) _; // FIXME: WHY WHY WHY do I need to help Pulse here?
   cbor_match_cases _;
   let CBOR_Case_Map a = xl.v;
+  cbor_with_perm_case_map_match_elem_eq xl a ();
   cbor_match_eq_map0 xl.p a xh0;
+  assert (pure (Map?.v (Ghost.reveal xh0) == xh));
   Trade.rewrite_with_trade
     (cbor_match xl.p xl.v xh0)
     (cbor_match_map0 a xl.p xh0 cbor_match);
@@ -2400,6 +2538,17 @@ ensures
   cbor_match_map0_map_trade a xl.p xh0;
   Trade.trans (cbor_match_map xl.p a xh0) _ _;
   unfold (cbor_match_map xl.p a xh0);
+  with s. assert (PM.seq_list_match s (Map?.v xh0)
+    (cbor_match_map_entry (xl.p `perm_mul` a.cbor_map_payload_perm)));
+  rewrite
+    (PM.seq_list_match s (Map?.v xh0)
+      (cbor_match_map_entry (xl.p `perm_mul` a.cbor_map_payload_perm)))
+    as (PM.seq_list_match s xh
+      (cbor_match_map_entry (cbor_with_perm_case_map_match_elem_perm xl)));
+  rewrite
+    (PM.seq_list_match s xh
+      (cbor_match_map_entry (cbor_with_perm_case_map_match_elem_perm xl)))
+    as (PM.seq_list_match s xh (cbor_with_perm_case_map_match_elem xl));
   let Some ar = cbor_with_perm_case_map_get xl;
   rewrite each a.cbor_map_ptr as (Mkwith_perm?.v ar);
   LowParse.Pulse.VCList.nlist_match_slice_intro cbor_with_perm_case_map_get
@@ -2407,7 +2556,7 @@ ensures
     (U64.v (argument_as_uint64 (get_header_initial_byte xh1)
       (get_header_long_argument xh1)))
     xl xh
-    ar _
+      ar s
   ;
   intro
     (Trade.trade
@@ -2430,6 +2579,15 @@ ensures
     );
     with ar _p _v. assert (S.pts_to #cbor_map_entry (Mkwith_perm?.v ar) #_p _v);
     rewrite each (Mkwith_perm?.v ar) as a.cbor_map_ptr;
+    rewrite
+      (PM.seq_list_match _v xh (cbor_with_perm_case_map_match_elem xl))
+      as (PM.seq_list_match _v xh
+        (cbor_match_map_entry (cbor_with_perm_case_map_match_elem_perm xl)));
+    rewrite
+      (PM.seq_list_match _v xh
+        (cbor_match_map_entry (cbor_with_perm_case_map_match_elem_perm xl)))
+      as (PM.seq_list_match _v (Map?.v xh0)
+        (cbor_match_map_entry (xl.p `perm_mul` a.cbor_map_payload_perm)));
     fold (cbor_match_map xl.p a xh0);
     ()
   };
@@ -2704,6 +2862,19 @@ let cbor_with_perm_case_map_match_elem_d
   Tot slprop
 = cbor_match_map_entry_with_depth m (cbor_with_perm_case_map_match_elem_perm c)
 
+let cbor_with_perm_case_map_match_elem_d_eq
+  (m: nat)
+  (c: with_perm cbor_raw)
+  (a: cbor_map)
+  (sq: squash (c.v == CBOR_Case_Map a))
+: Lemma (
+    cbor_with_perm_case_map_match_elem_perm c ==
+      c.p `perm_mul` a.cbor_map_payload_perm
+  )
+= match c.v with
+  | CBOR_Case_Map a' -> assert (a' == a)
+  | _ -> assert False
+
 // DELIVERABLE 3 (map): split the depth entry match into key / value halves.
 inline_for_extraction
 fn ser_payload_map_map_elem_fst_d
@@ -2837,9 +3008,10 @@ ensures
                           xh1)
                       (get_header_long_argument xh1)))
           (raw_data_item & raw_data_item)) (vmatch_with_cond (match_cbor_payload_d n xh1) cbor_with_perm_case_map) _ _;
-  vmatch_with_cond_elim_trade (match_cbor_payload_d n xh1) _ _ _;
-  Trade.trans (match_cbor_payload_d n xh1 _ _) _ _;
-  let xh0 = match_cbor_payload_elim_trade_d n xh1 _ _;
+  assert (pure (Ghost.reveal xh2 == xh));
+  vmatch_with_cond_elim_trade (match_cbor_payload_d n xh1) _ xl (Ghost.reveal xh2);
+  Trade.trans (match_cbor_payload_d n xh1 xl (Ghost.reveal xh2)) _ _;
+  let xh0 = match_cbor_payload_elim_trade_d n xh1 xl (Ghost.reveal xh2);
   Trade.trans (cbor_match_with_perm_d n xl xh0) _ _;
   Trade.rewrite_with_trade
     (cbor_match_with_perm_d n xl xh0)
@@ -2847,7 +3019,10 @@ ensures
   Trade.trans (cbor_match_with_depth n xl.p xl.v xh0) (cbor_match_with_perm_d n xl xh0) _;
   cbor_match_with_depth_cases n xl.p xl.v xh0;
   let CBOR_Case_Map a = xl.v;
+  cbor_with_perm_case_map_match_elem_d_eq (nat_pred n) xl a ();
   cbor_match_with_depth_eq_map0 n xl.p a xh0;
+  depth_cb_eq n (Ghost.reveal xh0);
+  assert (pure (Map?.v (Ghost.reveal xh0) == xh));
   Trade.rewrite_with_trade
     (cbor_match_with_depth n xl.p xl.v xh0)
     (cbor_match_map0 a xl.p xh0 (depth_cb n xh0));
@@ -2856,6 +3031,19 @@ ensures
   with s. assert (PM.seq_list_match s (Map?.v xh0)
     (cbor_match_map_entry0 xh0 ((depth_cb n xh0) (xl.p `perm_mul` a.cbor_map_payload_perm))));
   map_to_unref n xh0 (xl.p `perm_mul` a.cbor_map_payload_perm) s;
+  rewrite
+    (PM.seq_list_match s (Map?.v xh0)
+      (cbor_match_map_entry_with_depth (nat_pred n)
+        (xl.p `perm_mul` a.cbor_map_payload_perm)))
+    as (PM.seq_list_match s xh
+      (cbor_match_map_entry_with_depth (nat_pred n)
+        (cbor_with_perm_case_map_match_elem_perm xl)));
+  rewrite
+    (PM.seq_list_match s xh
+      (cbor_match_map_entry_with_depth (nat_pred n)
+        (cbor_with_perm_case_map_match_elem_perm xl)))
+    as (PM.seq_list_match s xh
+      (cbor_with_perm_case_map_match_elem_d (nat_pred n) xl));
   let Some ar = cbor_with_perm_case_map_get xl;
   rewrite each a.cbor_map_ptr as ar.v;
   LowParse.Pulse.VCList.nlist_match_slice_intro cbor_with_perm_case_map_get
@@ -2863,7 +3051,7 @@ ensures
     (U64.v (argument_as_uint64 (get_header_initial_byte xh1)
       (get_header_long_argument xh1)))
     xl xh
-    ar _
+      ar s
   ;
   intro
     (Trade.trade
@@ -2887,6 +3075,19 @@ ensures
     with (sl : S.slice cbor_map_entry) #p v.
       assert (S.pts_to sl #p v);
     rewrite (S.pts_to sl #p v) as (S.pts_to a.cbor_map_ptr #p v);
+    rewrite
+      (PM.seq_list_match v xh
+        (cbor_with_perm_case_map_match_elem_d (nat_pred n) xl))
+      as (PM.seq_list_match v xh
+        (cbor_match_map_entry_with_depth (nat_pred n)
+          (cbor_with_perm_case_map_match_elem_perm xl)));
+    rewrite
+      (PM.seq_list_match v xh
+        (cbor_match_map_entry_with_depth (nat_pred n)
+          (cbor_with_perm_case_map_match_elem_perm xl)))
+      as (PM.seq_list_match v (Map?.v xh0)
+        (cbor_match_map_entry_with_depth (nat_pred n)
+          (xl.p `perm_mul` a.cbor_map_payload_perm)));
     map_to_ref n xh0 (xl.p `perm_mul` a.cbor_map_payload_perm) v;
     fold (cbor_match_map0 a xl.p xh0 (depth_cb n xh0));
     ()
@@ -3147,8 +3348,8 @@ fn ser_payload_tagged_tagged_lens
 {
   vmatch_with_cond_elim_trade (vmatch_ext raw_data_item (match_cbor_payload xh1)) cbor_with_perm_case_tagged _ _;
   let xh2 = vmatch_ext_elim_trade raw_data_item (match_cbor_payload xh1) _ _;
-  Trade.trans (match_cbor_payload xh1 xl xh2) _ _;
-  let xh0 = match_cbor_payload_elim_trade xh1 xl xh2;
+  Trade.trans (match_cbor_payload xh1 xl (Ghost.reveal xh2)) _ _;
+  let xh0 = match_cbor_payload_elim_trade xh1 xl (Ghost.reveal xh2);
   Trade.trans (cbor_match_with_perm xl xh0) _ _;
   Trade.rewrite_with_trade
     (cbor_match_with_perm xl xh0)
@@ -3225,8 +3426,8 @@ fn ser_payload_tagged_not_tagged_lens
 {
   vmatch_with_cond_elim_trade (vmatch_ext raw_data_item (match_cbor_payload xh1)) (pnot cbor_with_perm_case_tagged) _ _;
   let xh2 = vmatch_ext_elim_trade raw_data_item (match_cbor_payload xh1) _ _;
-  Trade.trans (match_cbor_payload xh1 xl xh2) _ _;
-  let xh0 = match_cbor_payload_elim_trade xh1 xl xh2;
+  Trade.trans (match_cbor_payload xh1 xl (Ghost.reveal xh2)) _ _;
+  let xh0 = match_cbor_payload_elim_trade xh1 xl (Ghost.reveal xh2);
   Trade.trans (cbor_match_with_perm xl xh0) _ _;
   Trade.rewrite_with_trade
     (cbor_match_with_perm xl xh0)
@@ -3322,8 +3523,8 @@ fn ser_payload_tagged_tagged_lens_d
 {
   vmatch_with_cond_elim_trade (vmatch_ext raw_data_item (match_cbor_payload_d n xh1)) cbor_with_perm_case_tagged _ _;
   let xh2 = vmatch_ext_elim_trade raw_data_item (match_cbor_payload_d n xh1) _ _;
-  Trade.trans (match_cbor_payload_d n xh1 xl xh2) _ _;
-  let xh0 = match_cbor_payload_elim_trade_d n xh1 xl xh2;
+  Trade.trans (match_cbor_payload_d n xh1 xl (Ghost.reveal xh2)) _ _;
+  let xh0 = match_cbor_payload_elim_trade_d n xh1 xl (Ghost.reveal xh2);
   Trade.trans (cbor_match_with_perm_d n xl xh0) _ _;
   Trade.rewrite_with_trade
     (cbor_match_with_perm_d n xl xh0)
@@ -3372,8 +3573,8 @@ fn ser_payload_tagged_not_tagged_lens_d
 {
   vmatch_with_cond_elim_trade (vmatch_ext raw_data_item (match_cbor_payload_d n xh1)) (pnot cbor_with_perm_case_tagged) _ _;
   let xh2 = vmatch_ext_elim_trade raw_data_item (match_cbor_payload_d n xh1) _ _;
-  Trade.trans (match_cbor_payload_d n xh1 xl xh2) _ _;
-  let xh0 = match_cbor_payload_elim_trade_d n xh1 xl xh2;
+  Trade.trans (match_cbor_payload_d n xh1 xl (Ghost.reveal xh2)) _ _;
+  let xh0 = match_cbor_payload_elim_trade_d n xh1 xl (Ghost.reveal xh2);
   Trade.trans (cbor_match_with_perm_d n xl xh0) _ _;
   Trade.rewrite_with_trade
     (cbor_match_with_perm_d n xl xh0)
@@ -3808,6 +4009,7 @@ ensures
   cbor_match_with_depth_cases 0 xl.p xl.v xh0;
   let CBOR_Case_Array a = xl.v;
   cbor_match_with_depth_eq_array 0 xl.p a xh0;
+  depth_cb_eq 0 (Ghost.reveal xh0);
   Trade.rewrite_with_trade
     (cbor_match_with_depth 0 xl.p xl.v xh0)
     (cbor_match_array a xl.p xh0 (depth_cb 0 xh0));
@@ -3846,6 +4048,7 @@ ensures
   cbor_match_with_depth_cases 0 xl.p xl.v xh0;
   let CBOR_Case_Map a = xl.v;
   cbor_match_with_depth_eq_map0 0 xl.p a xh0;
+  depth_cb_eq 0 (Ghost.reveal xh0);
   Trade.rewrite_with_trade
     (cbor_match_with_depth 0 xl.p xl.v xh0)
     (cbor_match_map0 a xl.p xh0 (depth_cb 0 xh0));
@@ -3943,7 +4146,7 @@ fn ser_payload_tagged_tagged_impossible_d
 {
   vmatch_with_cond_elim_trade (vmatch_ext raw_data_item (match_cbor_payload_d 0 xh1)) cbor_with_perm_case_tagged x' x;
   let xh2 = vmatch_ext_elim_trade raw_data_item (match_cbor_payload_d 0 xh1) x' x;
-  let xh0 = match_cbor_payload_elim_trade_d 0 xh1 x' xh2;
+  let xh0 = match_cbor_payload_elim_trade_d 0 xh1 x' (Ghost.reveal xh2);
   Trade.rewrite_with_trade
     (cbor_match_with_perm_d 0 x' xh0)
     (cbor_match_with_depth 0 x'.p x'.v xh0);
@@ -3969,7 +4172,7 @@ fn size_payload_tagged_tagged_impossible_d
 {
   vmatch_with_cond_elim_trade (vmatch_ext raw_data_item (match_cbor_payload_d 0 xh1)) cbor_with_perm_case_tagged x' x;
   let xh2 = vmatch_ext_elim_trade raw_data_item (match_cbor_payload_d 0 xh1) x' x;
-  let xh0 = match_cbor_payload_elim_trade_d 0 xh1 x' xh2;
+  let xh0 = match_cbor_payload_elim_trade_d 0 xh1 x' (Ghost.reveal xh2);
   Trade.rewrite_with_trade
     (cbor_match_with_perm_d 0 x' xh0)
     (cbor_match_with_depth 0 x'.p x'.v xh0);
@@ -4605,6 +4808,7 @@ ensures
     CBOR_Case_Array a -> {
       rewrite (cbor_match_with_depth n x'.p x'.v x) as (cbor_match_with_depth n x'.p (CBOR_Case_Array a) x);
       cbor_match_with_depth_eq_array n x'.p a x;
+      depth_cb_eq n (Ghost.reveal x);
       rewrite (cbor_match_with_depth n x'.p (CBOR_Case_Array a) x) as (cbor_match_array a x'.p x (depth_cb n x));
       unfold (cbor_match_array a x'.p x (depth_cb n x));
       with s. assert (
@@ -4616,6 +4820,7 @@ ensures
       PM.seq_list_match_nil_intro s (Array?.v x) ((depth_cb 0 x) (x'.p `perm_mul` a.cbor_array_payload_perm));
       fold (cbor_match_array a x'.p x (depth_cb 0 x));
       cbor_match_with_depth_eq_array 0 x'.p a x;
+      depth_cb_eq 0 (Ghost.reveal x);
       rewrite (cbor_match_array a x'.p x (depth_cb 0 x)) as (cbor_match_with_depth 0 x'.p (CBOR_Case_Array a) x);
       rewrite (cbor_match_with_depth 0 x'.p (CBOR_Case_Array a) x) as (cbor_match_with_depth 0 x'.p x'.v x);
       fold (cbor_match_with_perm_d 0 x' x);
@@ -4627,6 +4832,7 @@ ensures
         unfold (cbor_match_with_perm_d 0 x' x);
         rewrite (cbor_match_with_depth 0 x'.p x'.v x) as (cbor_match_with_depth 0 x'.p (CBOR_Case_Array a) x);
         cbor_match_with_depth_eq_array 0 x'.p a x;
+        depth_cb_eq 0 (Ghost.reveal x);
         rewrite (cbor_match_with_depth 0 x'.p (CBOR_Case_Array a) x) as (cbor_match_array a x'.p x (depth_cb 0 x));
         unfold (cbor_match_array a x'.p x (depth_cb 0 x));
         with s2. assert (
@@ -4638,6 +4844,7 @@ ensures
         PM.seq_list_match_nil_intro s2 (Array?.v x) ((depth_cb n x) (x'.p `perm_mul` a.cbor_array_payload_perm));
         fold (cbor_match_array a x'.p x (depth_cb n x));
         cbor_match_with_depth_eq_array n x'.p a x;
+        depth_cb_eq n (Ghost.reveal x);
         rewrite (cbor_match_array a x'.p x (depth_cb n x)) as (cbor_match_with_depth n x'.p (CBOR_Case_Array a) x);
         rewrite (cbor_match_with_depth n x'.p (CBOR_Case_Array a) x) as (cbor_match_with_depth n x'.p x'.v x);
         fold (cbor_match_with_perm_d n x' x);
@@ -4647,6 +4854,7 @@ ensures
     CBOR_Case_Map a -> {
       rewrite (cbor_match_with_depth n x'.p x'.v x) as (cbor_match_with_depth n x'.p (CBOR_Case_Map a) x);
       cbor_match_with_depth_eq_map0 n x'.p a x;
+      depth_cb_eq n (Ghost.reveal x);
       rewrite (cbor_match_with_depth n x'.p (CBOR_Case_Map a) x) as (cbor_match_map0 a x'.p x (depth_cb n x));
       unfold (cbor_match_map0 a x'.p x (depth_cb n x));
       with s. assert (
@@ -4658,6 +4866,7 @@ ensures
       PM.seq_list_match_nil_intro s (Map?.v x) (cbor_match_map_entry0 x ((depth_cb 0 x) (x'.p `perm_mul` a.cbor_map_payload_perm)));
       fold (cbor_match_map0 a x'.p x (depth_cb 0 x));
       cbor_match_with_depth_eq_map0 0 x'.p a x;
+      depth_cb_eq 0 (Ghost.reveal x);
       rewrite (cbor_match_map0 a x'.p x (depth_cb 0 x)) as (cbor_match_with_depth 0 x'.p (CBOR_Case_Map a) x);
       rewrite (cbor_match_with_depth 0 x'.p (CBOR_Case_Map a) x) as (cbor_match_with_depth 0 x'.p x'.v x);
       fold (cbor_match_with_perm_d 0 x' x);
@@ -4669,6 +4878,7 @@ ensures
         unfold (cbor_match_with_perm_d 0 x' x);
         rewrite (cbor_match_with_depth 0 x'.p x'.v x) as (cbor_match_with_depth 0 x'.p (CBOR_Case_Map a) x);
         cbor_match_with_depth_eq_map0 0 x'.p a x;
+        depth_cb_eq 0 (Ghost.reveal x);
         rewrite (cbor_match_with_depth 0 x'.p (CBOR_Case_Map a) x) as (cbor_match_map0 a x'.p x (depth_cb 0 x));
         unfold (cbor_match_map0 a x'.p x (depth_cb 0 x));
         with s2. assert (
@@ -4680,6 +4890,7 @@ ensures
         PM.seq_list_match_nil_intro s2 (Map?.v x) (cbor_match_map_entry0 x ((depth_cb n x) (x'.p `perm_mul` a.cbor_map_payload_perm)));
         fold (cbor_match_map0 a x'.p x (depth_cb n x));
         cbor_match_with_depth_eq_map0 n x'.p a x;
+        depth_cb_eq n (Ghost.reveal x);
         rewrite (cbor_match_map0 a x'.p x (depth_cb n x)) as (cbor_match_with_depth n x'.p (CBOR_Case_Map a) x);
         rewrite (cbor_match_with_depth n x'.p (CBOR_Case_Map a) x) as (cbor_match_with_depth n x'.p x'.v x);
         fold (cbor_match_with_perm_d n x' x);

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Base.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Base.fst
@@ -194,7 +194,7 @@ fn impl_serialize_ext
     ([@@@erasable]sq: squash (
       (Ghost.reveal inj == true \/ Ghost.reveal inj' == true) /\
       typ_equiv t' t /\
-      (forall (x: cbor) . Ghost.reveal t' x ==> ((Ghost.reveal ps'.parser x <: tgt) == Ghost.reveal ps.parser x))
+      (forall (x: cbor) . Ghost.reveal t' x ==> (((Ghost.reveal ps').parser x <: tgt) == (Ghost.reveal ps).parser x))
     ))
 : impl_serialize #(Ghost.reveal t') #tgt #inj' (Ghost.reveal ps') #impl_tgt r
 =
@@ -224,18 +224,15 @@ fn impl_serialize_bij
     (g21: (impl_tgt' -> impl_tgt))
     ([@@@erasable]gprf_21_12: (x: impl_tgt) -> squash (g21 (g12 x) == x))
     ([@@@erasable]gprf_12_21: (x: impl_tgt') -> squash (g12 (g21 x) == x))
-: impl_serialize #t #tgt' #inj (spec_inj ps f12 f21 fprf_21_12 fprf_12_21) #impl_tgt' (rel_fun r g21 f21)
+: impl_serialize #t #tgt' #inj (spec_inj ps f12 f21 fprf_21_12 fprf_12_21) #impl_tgt' (rel_fun r g21 (Ghost.reveal f21))
 =
     (c: _)
     (#v: _)
     (out: _)
 {
-  let c' = g21 c;
-  Trade.rewrite_with_trade
-    (rel_fun r g21 f21 c v)
-    (r c' (Ghost.reveal f21 v));
-  let res = i c' #(Ghost.reveal f21 v) out; // FIXME: WHY WHY WHY the explicit here?
-  Trade.elim _ _;
+  unfold (rel_fun r g21 (Ghost.reveal f21) c (Ghost.reveal v));
+  let res = i (g21 c) #((Ghost.reveal f21) (Ghost.reveal v)) out; // FIXME: WHY WHY WHY the explicit here?
+  fold (rel_fun r g21 (Ghost.reveal f21) c (Ghost.reveal v));
   res
 }
 

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.ArrayGroup.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.ArrayGroup.fst
@@ -562,7 +562,7 @@ fn impl_serialize_array_group_bij
     (g21: (impl_tgt' -> impl_tgt))
     ([@@@erasable]gprf_21_12: (x: impl_tgt) -> squash (g21 (g12 x) == x))
     ([@@@erasable]gprf_12_21: (x: impl_tgt') -> squash (g12 (g21 x) == x))
-: impl_serialize_array_group lmin lmax #(Ghost.reveal t) #tgt' #inj (ag_spec_inj ps f12 f21 fprf_21_12 fprf_12_21) #impl_tgt' (rel_fun r g21 f21)
+: impl_serialize_array_group lmin lmax #(Ghost.reveal t) #tgt' #inj (ag_spec_inj ps f12 f21 fprf_21_12 fprf_12_21) #impl_tgt' (rel_fun r g21 (Ghost.reveal f21))
 =
     (c: _)
     (#v: _)
@@ -573,12 +573,9 @@ fn impl_serialize_array_group_bij
     (#size_before: _)
     (l: _)
 {
-  let c' = g21 c;
-  Trade.rewrite_with_trade
-    (rel_fun r g21 f21 c v)
-    (r c' (Ghost.reveal f21 v));
-  let res = i c' #(Ghost.reveal f21 v) out out_count out_size l;
-  Trade.elim _ _;
+  unfold (rel_fun r g21 (Ghost.reveal f21) c (Ghost.reveal v));
+  let res = i (g21 c) #((Ghost.reveal f21) (Ghost.reveal v)) out out_count out_size l;
+  fold (rel_fun r g21 (Ghost.reveal f21) c (Ghost.reveal v));
   res
 }
 

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.Base.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.Base.fst
@@ -252,7 +252,7 @@ fn impl_serialize_ext
     ([@@@erasable]sq: squash (
       (Ghost.reveal inj == true \/ Ghost.reveal inj' == true) /\
       typ_equiv t' t /\
-      (forall (x: cbor) . Ghost.reveal t' x ==> ((Ghost.reveal ps'.parser x <: tgt) == Ghost.reveal ps.parser x))
+      (forall (x: cbor) . Ghost.reveal t' x ==> (((Ghost.reveal ps').parser x <: tgt) == (Ghost.reveal ps).parser x))
     ))
 : impl_serialize #p overflows_low fits_high #(Ghost.reveal t') #tgt #inj' (Ghost.reveal ps') #impl_tgt r
 =
@@ -285,18 +285,15 @@ fn impl_serialize_bij
     (g21: (impl_tgt' -> impl_tgt))
     ([@@@erasable]gprf_21_12: (x: impl_tgt) -> squash (g21 (g12 x) == x))
     ([@@@erasable]gprf_12_21: (x: impl_tgt') -> squash (g12 (g21 x) == x))
-: impl_serialize #p overflows_low fits_high #t #tgt' #inj (spec_inj ps f12 f21 fprf_21_12 fprf_12_21) #impl_tgt' (rel_fun r g21 f21)
+: impl_serialize #p overflows_low fits_high #t #tgt' #inj (spec_inj ps f12 f21 fprf_21_12 fprf_12_21) #impl_tgt' (rel_fun r g21 (Ghost.reveal f21))
 =
     (c: _)
     (#v: _)
     (out: _)
 {
-  let c' = g21 c;
-  Trade.rewrite_with_trade
-    (rel_fun r g21 f21 c v)
-    (r c' (Ghost.reveal f21 v));
-  let res = i c' #(Ghost.reveal f21 v) out; // FIXME: WHY WHY WHY the explicit here?
-  Trade.elim _ _;
+  unfold (rel_fun r g21 (Ghost.reveal f21) c (Ghost.reveal v));
+  let res = i (g21 c) #((Ghost.reveal f21) (Ghost.reveal v)) out; // FIXME: WHY WHY WHY the explicit here?
+  fold (rel_fun r g21 (Ghost.reveal f21) c (Ghost.reveal v));
   res
 }
 

--- a/src/cddl/tests/dpe/dpe/CDDLTest.DPE.Common.fst
+++ b/src/cddl/tests/dpe/dpe/CDDLTest.DPE.Common.fst
@@ -49,10 +49,10 @@ ensures
           bytes_left
           spect_bytes_left
           x
-          y);
+          (reveal y));
   Trade.Util.elim_hyp_r _ _ _;
   rewrite each
-  (rel_fun rel_bstr bytes_left spect_bytes_left x y)  
+  (rel_fun rel_bstr bytes_left spect_bytes_left x (reveal y))
    as (rel_bytes x y);
   res.s
 }

--- a/src/cose/c/COSE_Format.c
+++ b/src/cose/c/COSE_Format.c
@@ -436,17 +436,20 @@ Serializer for any
 */
 size_t COSE_Format_serialize_any(cbor_det_t c, Pulse_Lib_Slice_slice__uint8_t out)
 {
-  cbor_det_t c_ = any_left(c);
-  size_t len = cbor_det_size(c_, Pulse_Lib_Slice_len__uint8_t(out));
+  size_t slen = Pulse_Lib_Slice_len__uint8_t(out);
+  size_t len = cbor_det_size(any_left(c), slen);
   option__size_t scrut;
   if (len > (size_t)0U)
+  {
+    uint8_t *out1 = Pulse_Lib_Slice_slice_to_arrayptr_intro__uint8_t(out);
     scrut =
       (
         (option__size_t){
           .tag = FStar_Pervasives_Native_Some,
-          .v = cbor_det_serialize(c_, Pulse_Lib_Slice_slice_to_arrayptr_intro__uint8_t(out), len)
+          .v = cbor_det_serialize(any_left(c), out1, len)
         }
       );
+  }
   else
     scrut = ((option__size_t){ .tag = FStar_Pervasives_Native_None });
   if (scrut.tag == FStar_Pervasives_Native_None)
@@ -1217,28 +1220,27 @@ COSE_Format_serialize_tstr(
   Pulse_Lib_Slice_slice__uint8_t out
 )
 {
-  Pulse_Lib_Slice_slice__uint8_t c_ = tstr_left(c);
-  if (sizet_lte_u64(Pulse_Lib_Slice_len__uint8_t(c_), 18446744073709551615ULL))
+  if (sizet_lte_u64(Pulse_Lib_Slice_len__uint8_t(tstr_left(c)), 18446744073709551615ULL))
   {
-    size_t alen = Pulse_Lib_Slice_len__uint8_t(c_);
+    size_t alen = Pulse_Lib_Slice_len__uint8_t(tstr_left(c));
     if
     (
-      cbor_det_impl_utf8_correct_from_array(Pulse_Lib_Slice_slice_to_arrayptr_intro__uint8_t(c_),
+      cbor_det_impl_utf8_correct_from_array(Pulse_Lib_Slice_slice_to_arrayptr_intro__uint8_t(tstr_left(c)),
         alen)
     )
     {
-      uint8_t *a = Pulse_Lib_Slice_slice_to_arrayptr_intro__uint8_t(c_);
+      uint8_t *a = Pulse_Lib_Slice_slice_to_arrayptr_intro__uint8_t(tstr_left(c));
       cbor_det_t pres = dummy_cbor_det_t();
       bool ite;
       if (CBOR_MAJOR_TYPE_TEXT_STRING == CBOR_MAJOR_TYPE_BYTE_STRING)
         ite =
           cbor_det_mk_byte_string_from_arrayptr(a,
-            (uint64_t)Pulse_Lib_Slice_len__uint8_t(c_),
+            (uint64_t)Pulse_Lib_Slice_len__uint8_t(tstr_left(c)),
             &pres);
       else
         ite =
           cbor_det_mk_text_string_from_arrayptr(a,
-            (uint64_t)Pulse_Lib_Slice_len__uint8_t(c_),
+            (uint64_t)Pulse_Lib_Slice_len__uint8_t(tstr_left(c)),
             &pres);
       KRML_MAYBE_UNUSED_VAR(ite);
       cbor_det_t x = pres;
@@ -1386,12 +1388,13 @@ COSE_Format_serialize_bstr(
   Pulse_Lib_Slice_slice__uint8_t out
 )
 {
-  Pulse_Lib_Slice_slice__uint8_t c_ = bstr_left(c);
-  if (sizet_lte_u64(Pulse_Lib_Slice_len__uint8_t(c_), 18446744073709551615ULL))
+  if (sizet_lte_u64(Pulse_Lib_Slice_len__uint8_t(bstr_left(c)), 18446744073709551615ULL))
   {
-    uint8_t *a = Pulse_Lib_Slice_slice_to_arrayptr_intro__uint8_t(c_);
+    uint8_t *a = Pulse_Lib_Slice_slice_to_arrayptr_intro__uint8_t(bstr_left(c));
     cbor_det_t pres = dummy_cbor_det_t();
-    cbor_det_mk_byte_string_from_arrayptr(a, (uint64_t)Pulse_Lib_Slice_len__uint8_t(c_), &pres);
+    cbor_det_mk_byte_string_from_arrayptr(a,
+      (uint64_t)Pulse_Lib_Slice_len__uint8_t(bstr_left(c)),
+      &pres);
     cbor_det_t x = pres;
     size_t len1 = cbor_det_size(x, Pulse_Lib_Slice_len__uint8_t(out));
     option__size_t scrut;
@@ -4115,17 +4118,17 @@ COSE_Format_aux_env29_serialize_1(
   size_t *out_size
 )
 {
-  COSE_Format_aux_env29_type_1_ugly c_ = aux_env29_type_1_left(c);
   uint64_t count = *out_count;
   if (count < 18446744073709551615ULL)
   {
     size_t size = *out_size;
     Pulse_Lib_Slice_slice__uint8_t out1 = split__uint8_t(out, size).snd;
+    COSE_Format_aux_env29_type_1_ugly scrut = aux_env29_type_1_left(c);
     size_t size1;
-    if (c_.tag == COSE_Format_Inl)
-      size1 = COSE_Format_serialize_tstr(c_.case_Inl, out1);
-    else if (c_.tag == COSE_Format_Inr)
-      size1 = COSE_Format_serialize_int(c_.case_Inr, out1);
+    if (scrut.tag == COSE_Format_Inl)
+      size1 = COSE_Format_serialize_tstr(scrut.case_Inl, out1);
+    else if (scrut.tag == COSE_Format_Inr)
+      size1 = COSE_Format_serialize_int(scrut.case_Inr, out1);
     else
       size1 = KRML_EABORT(size_t, "unreachable (pattern matches are exhaustive in F*)");
     if (size1 == (size_t)0U)
@@ -6687,12 +6690,12 @@ COSE_Format_aux_env30_serialize_1(
   size_t *out_size
 )
 {
-  COSE_Format_cose_key_generic c_ = aux_env30_type_1_left(c);
   uint64_t count = *out_count;
   if (count < 18446744073709551615ULL)
   {
     size_t size = *out_size;
-    size_t size1 = COSE_Format_serialize_cose_key_generic(c_, split__uint8_t(out, size).snd);
+    Pulse_Lib_Slice_slice__uint8_t out1 = split__uint8_t(out, size).snd;
+    size_t size1 = COSE_Format_serialize_cose_key_generic(aux_env30_type_1_left(c), out1);
     if (size1 == (size_t)0U)
       return false;
     else
@@ -8878,12 +8881,12 @@ COSE_Format_aux_env34_serialize_1(
   size_t *out_size
 )
 {
-  COSE_Format_evercddl_label c_ = aux_env34_type_1_left(c);
   uint64_t count = *out_count;
   if (count < 18446744073709551615ULL)
   {
     size_t size = *out_size;
-    size_t size1 = COSE_Format_serialize_evercddl_label(c_, split__uint8_t(out, size).snd);
+    Pulse_Lib_Slice_slice__uint8_t out1 = split__uint8_t(out, size).snd;
+    size_t size1 = COSE_Format_serialize_evercddl_label(aux_env34_type_1_left(c), out1);
     if (size1 == (size_t)0U)
       return false;
     else
@@ -14856,12 +14859,12 @@ COSE_Format_aux_env41_serialize_1(
   size_t *out_size
 )
 {
-  COSE_Format_cose_signature c_ = aux_env41_type_1_left(c);
   uint64_t count = *out_count;
   if (count < 18446744073709551615ULL)
   {
     size_t size = *out_size;
-    size_t size1 = COSE_Format_serialize_cose_signature(c_, split__uint8_t(out, size).snd);
+    Pulse_Lib_Slice_slice__uint8_t out1 = split__uint8_t(out, size).snd;
+    size_t size1 = COSE_Format_serialize_cose_signature(aux_env41_type_1_left(c), out1);
     if (size1 == (size_t)0U)
       return false;
     else

--- a/src/cose/generate-rust/CommonPulse.fst
+++ b/src/cose/generate-rust/CommonPulse.fst
@@ -312,11 +312,9 @@ fn mk_phdrs (alg: Int32.t) (rest: A.larray (evercddl_label & values) 0)
   let alg' = mk_int alg;
   A.pts_to_len rest;
   let rest2 = S.from_array rest 0sz;
-  Pulse.Lib.SeqMatch.seq_list_match_nil_intro (Seq.Base.create 0 (dummy_map_val ())) []
+  assert pure ((Ghost.reveal vrest) `Seq.equal` Seq.empty);
+  Pulse.Lib.SeqMatch.seq_list_match_nil_intro (Ghost.reveal vrest) []
       (rel_pair rel_evercddl_label rel_values);
-  assert pure (Seq.Base.create 0 (dummy_map_val ()) `Seq.equal` vrest);
-  rewrite each (FStar.Seq.Base.create 0
-            (dummy_map_val ())) as vrest;
   rw_l (rel_inl_map_eq {s = rest2; p=prest} (CDDL.Spec.Map.empty _ _));
   rw_l (rel_map_sign1_phdrs_eq alg alg' _);
   with res. assert rel_empty_or_serialized_map res (sign1_phdrs_spec alg);
@@ -363,12 +361,10 @@ fn mk_emphdrs (rest: A.larray (evercddl_label & values) 0)
   ensures borrows (rel_header_map res (sign1_emphdrs_spec ())) (pts_to rest #prest vrest)
 {
   A.pts_to_len rest;
-  assert pure (Seq.equal vrest (Seq.create 0 (dummy_map_val ())));
+  assert pure ((Ghost.reveal vrest) `Seq.equal` Seq.empty);
   let rest2 = S.from_array rest 0sz;
-  Pulse.Lib.SeqMatch.seq_list_match_nil_intro (Seq.Base.create 0 (dummy_map_val ())) []
+  Pulse.Lib.SeqMatch.seq_list_match_nil_intro (Ghost.reveal vrest) []
       (rel_pair rel_evercddl_label rel_values);
-  rewrite each (FStar.Seq.Base.create 0
-            (dummy_map_val ())) as vrest;
   rw_l (rel_inl_map_eq {s = rest2; p=prest} (CDDL.Spec.Map.empty _ _));
   rw_l (rel_map_sign1_emphdrs_eq _);
   with res. assert rel_header_map res (sign1_emphdrs_spec ());

--- a/src/cose/rust/src/cbordetveraux.rs
+++ b/src/cose/rust/src/cbordetveraux.rs
@@ -25,17 +25,6 @@ fn set_bitfield_gen8(x: u8, lo: u32, hi: u32, v: u8) -> u8
 
 #[derive(PartialEq, Clone, Copy)] pub struct raw_uint64 { pub size: u8, pub value: u64 }
 
-pub(crate) fn mk_raw_uint64(x: u64) -> raw_uint64
-{
-    let size: u8 =
-        if x <= max_simple_value_additional_info as u64
-        { 0u8 }
-        else if x < 256u64
-        { 1u8 }
-        else if x < 65536u64 { 2u8 } else if x < 4294967296u64 { 3u8 } else { 4u8 };
-    raw_uint64 { size, value: x }
-}
-
 const additional_info_long_argument_8_bits: u8 = 24u8;
 
 const additional_info_unassigned_min: u8 = 28u8;
@@ -169,9 +158,16 @@ fn get_header_major_type(h: header) -> u8
     b.major_type
 }
 
-pub(crate) const simple_value_false: u8 = 20u8;
-
-pub(crate) const simple_value_true: u8 = 21u8;
+pub(crate) fn mk_raw_uint64(x: u64) -> raw_uint64
+{
+    let size: u8 =
+        if x <= max_simple_value_additional_info as u64
+        { 0u8 }
+        else if x < 256u64
+        { 1u8 }
+        else if x < 65536u64 { 2u8 } else if x < 4294967296u64 { 3u8 } else { 4u8 };
+    raw_uint64 { size, value: x }
+}
 
 fn impl_uint8_compare(x1: u8, x2: u8) -> i16
 { if x1 < x2 { -1i16 } else if x1 > x2 { 1i16 } else { 0i16 } }
@@ -373,6 +369,10 @@ fn cbor_match_compare_serialized_array(c1: cbor_serialized, c2: cbor_serialized)
 
 fn cbor_match_compare_serialized_map(c1: cbor_serialized, c2: cbor_serialized) -> i16
 { lex_compare_bytes(c1.cbor_serialized_payload, c2.cbor_serialized_payload) }
+
+pub(crate) const simple_value_false: u8 = 20u8;
+
+pub(crate) const simple_value_true: u8 = 21u8;
 
 pub(crate) fn impl_correct(s: &[u8]) -> bool
 {

--- a/src/cose/rust/src/cbordetveraux.rs
+++ b/src/cose/rust/src/cbordetveraux.rs
@@ -25,6 +25,17 @@ fn set_bitfield_gen8(x: u8, lo: u32, hi: u32, v: u8) -> u8
 
 #[derive(PartialEq, Clone, Copy)] pub struct raw_uint64 { pub size: u8, pub value: u64 }
 
+pub(crate) fn mk_raw_uint64(x: u64) -> raw_uint64
+{
+    let size: u8 =
+        if x <= max_simple_value_additional_info as u64
+        { 0u8 }
+        else if x < 256u64
+        { 1u8 }
+        else if x < 65536u64 { 2u8 } else if x < 4294967296u64 { 3u8 } else { 4u8 };
+    raw_uint64 { size, value: x }
+}
+
 const additional_info_long_argument_8_bits: u8 = 24u8;
 
 const additional_info_unassigned_min: u8 = 28u8;
@@ -158,16 +169,9 @@ fn get_header_major_type(h: header) -> u8
     b.major_type
 }
 
-pub(crate) fn mk_raw_uint64(x: u64) -> raw_uint64
-{
-    let size: u8 =
-        if x <= max_simple_value_additional_info as u64
-        { 0u8 }
-        else if x < 256u64
-        { 1u8 }
-        else if x < 65536u64 { 2u8 } else if x < 4294967296u64 { 3u8 } else { 4u8 };
-    raw_uint64 { size, value: x }
-}
+pub(crate) const simple_value_false: u8 = 20u8;
+
+pub(crate) const simple_value_true: u8 = 21u8;
 
 fn impl_uint8_compare(x1: u8, x2: u8) -> i16
 { if x1 < x2 { -1i16 } else if x1 > x2 { 1i16 } else { 0i16 } }
@@ -369,10 +373,6 @@ fn cbor_match_compare_serialized_array(c1: cbor_serialized, c2: cbor_serialized)
 
 fn cbor_match_compare_serialized_map(c1: cbor_serialized, c2: cbor_serialized) -> i16
 { lex_compare_bytes(c1.cbor_serialized_payload, c2.cbor_serialized_payload) }
-
-pub(crate) const simple_value_false: u8 = 20u8;
-
-pub(crate) const simple_value_true: u8 = 21u8;
 
 pub(crate) fn impl_correct(s: &[u8]) -> bool
 {
@@ -2465,8 +2465,8 @@ pub(crate) fn cbor_array_iterator_next <'b, 'a>(
     cbor_raw
     <'a>
 {
-    let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = pi[0];
-    match i0
+    let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = pi[0];
+    match iter
     {
         cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw::CBOR_Raw_Iterator_Slice { _0: i1 } =>
           {
@@ -2571,8 +2571,8 @@ pub(crate) fn cbor_map_iterator_next <'b, 'a>(
     cbor_map_entry
     <'a>
 {
-    let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry = pi[0];
-    match i0
+    let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry = pi[0];
+    match iter
     {
         cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry::CBOR_Raw_Iterator_Slice { _0: i1 } =>
           {
@@ -4361,9 +4361,9 @@ pub(crate) fn cbor_compare_with_depth(x1: cbor_raw, x2: cbor_raw) -> i16
                         while
                         cond
                         {
-                            let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = (&pi1)[0];
+                            let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = (&pi1)[0];
                             let elt1: cbor_raw =
-                                match i0
+                                match iter
                                 {
                                     cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw::CBOR_Raw_Iterator_Slice
                                     { _0: i }
@@ -4390,9 +4390,9 @@ pub(crate) fn cbor_compare_with_depth(x1: cbor_raw, x2: cbor_raw) -> i16
                                     => cbor_serialized_array_iterator_next_with_depth(&mut pi1, i),
                                     _ => panic!("Incomplete pattern matching")
                                 };
-                            let i00: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = (&pi2)[0];
+                            let iter0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw = (&pi2)[0];
                             let elt2: cbor_raw =
-                                match i00
+                                match iter0
                                 {
                                     cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw::CBOR_Raw_Iterator_Slice
                                     { _0: i }
@@ -4555,10 +4555,10 @@ pub(crate) fn cbor_compare_with_depth(x1: cbor_raw, x2: cbor_raw) -> i16
                         while
                         cond
                         {
-                            let i0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry =
+                            let iter: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry =
                                 (&pi1)[0];
                             let elt1: cbor_map_entry =
-                                match i0
+                                match iter
                                 {
                                     cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry::CBOR_Raw_Iterator_Slice
                                     { _0: i }
@@ -4585,10 +4585,10 @@ pub(crate) fn cbor_compare_with_depth(x1: cbor_raw, x2: cbor_raw) -> i16
                                     => cbor_serialized_map_iterator_next_with_depth(&mut pi1, i),
                                     _ => panic!("Incomplete pattern matching")
                                 };
-                            let i00: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry =
+                            let iter0: cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry =
                                 (&pi2)[0];
                             let elt2: cbor_map_entry =
-                                match i00
+                                match iter0
                                 {
                                     cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry::CBOR_Raw_Iterator_Slice
                                     { _0: i }

--- a/src/cose/rust/src/coseformat.rs
+++ b/src/cose/rust/src/coseformat.rs
@@ -86,8 +86,7 @@ serialize_bool(c: bool, out: &mut [u8]) ->
     usize
 {
     let c·: bool = evercddl_bool_left(c);
-    let c·1: bool = c·;
-    if c·1
+    if c·
     {
         if
         crate::cbordetveraux::simple_value_true
@@ -314,8 +313,8 @@ pub fn
 serialize_any(c: crate::cbordetveraux::cbor_raw, out: &mut [u8]) ->
     usize
 {
-    let c·: crate::cbordetveraux::cbor_raw = any_left(c);
-    let ser: crate::cbordetver::option__size_t = crate::cbordetver::cbor_det_serialize(c·, out);
+    let ser: crate::cbordetver::option__size_t =
+        crate::cbordetver::cbor_det_serialize(any_left(c), out);
     match ser
     {
         crate::cbordetver::option__size_t::None => 0usize,
@@ -610,10 +609,7 @@ Serializer for evercddl_null
 pub fn
 serialize_null(c: nil, out: &mut [u8]) ->
     usize
-{
-    let c·: nil = evercddl_null_left(c);
-    serialize_nil(c·, out)
-}
+{ serialize_nil(evercddl_null_left(c), out) }
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum option__·COSE_Format_evercddl_null···Pulse_Lib_Slice_slice·uint8_t· <'a>
@@ -917,12 +913,11 @@ pub fn
 serialize_tstr(c: &[u8], out: &mut [u8]) ->
     usize
 {
-    let c·: &[u8] = tstr_left(c);
-    let len: usize = c·.len();
+    let len: usize = (tstr_left(c)).len();
     let __anf0: bool = crate::cbordetveraux::sizet_lte_u64(len, 18446744073709551615u64);
     if __anf0
     {
-        let correct: bool = crate::cbordetver::cbor_impl_utf8_correct(c·);
+        let correct: bool = crate::cbordetver::cbor_impl_utf8_correct(tstr_left(c));
         if correct
         {
             let mty: crate::cbordetver::cbor_det_string_kind =
@@ -934,7 +929,7 @@ serialize_tstr(c: &[u8], out: &mut [u8]) ->
                 else
                 { crate::cbordetver::cbor_det_string_kind::TextString };
             let res: crate::cbordetver::option__CBOR_Pulse_Raw_Type_cbor_raw =
-                crate::cbordetver::cbor_det_mk_string(mty, c·);
+                crate::cbordetver::cbor_det_mk_string(mty, tstr_left(c));
             let _letpattern: crate::cbordetver::option__CBOR_Pulse_Raw_Type_cbor_raw = res;
             let x: crate::cbordetveraux::cbor_raw =
                 match _letpattern
@@ -1044,15 +1039,14 @@ pub fn
 serialize_bstr(c: &[u8], out: &mut [u8]) ->
     usize
 {
-    let c·: &[u8] = bstr_left(c);
-    let len: usize = c·.len();
+    let len: usize = (bstr_left(c)).len();
     let __anf0: bool = crate::cbordetveraux::sizet_lte_u64(len, 18446744073709551615u64);
     if __anf0
     {
         let mty: crate::cbordetver::cbor_det_string_kind =
             crate::cbordetver::cbor_det_string_kind::ByteString;
         let res: crate::cbordetver::option__CBOR_Pulse_Raw_Type_cbor_raw =
-            crate::cbordetver::cbor_det_mk_string(mty, c·);
+            crate::cbordetver::cbor_det_mk_string(mty, bstr_left(c));
         let _letpattern: crate::cbordetver::option__CBOR_Pulse_Raw_Type_cbor_raw = res;
         let x: crate::cbordetveraux::cbor_raw =
             match _letpattern
@@ -1145,10 +1139,7 @@ Serializer for bytes
 pub fn
 serialize_bytes(c: &[u8], out: &mut [u8]) ->
     usize
-{
-    let c·: &[u8] = bytes_left(c);
-    serialize_bstr(c·, out)
-}
+{ serialize_bstr(bytes_left(c), out) }
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum option__·COSE_Format_bytes···Pulse_Lib_Slice_slice·uint8_t· <'a>
@@ -1223,10 +1214,7 @@ Serializer for text
 pub fn
 serialize_text(c: &[u8], out: &mut [u8]) ->
     usize
-{
-    let c·: &[u8] = text_left(c);
-    serialize_tstr(c·, out)
-}
+{ serialize_tstr(text_left(c), out) }
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum option__·COSE_Format_text···Pulse_Lib_Slice_slice·uint8_t· <'a>
@@ -1313,7 +1301,6 @@ pub fn
 serialize_nint(c: u64, out: &mut [u8]) ->
     usize
 {
-    let c·: u64 = nint_left(c);
     let mty: crate::cbordetver::cbor_det_int_kind =
         if
         crate::cbordetveraux::cbor_major_type_neg_int64
@@ -1322,7 +1309,8 @@ serialize_nint(c: u64, out: &mut [u8]) ->
         { crate::cbordetver::cbor_det_int_kind::UInt64 }
         else
         { crate::cbordetver::cbor_det_int_kind::NegInt64 };
-    let x: crate::cbordetveraux::cbor_raw = crate::cbordetver::cbor_det_mk_int64(mty, c·);
+    let x: crate::cbordetveraux::cbor_raw =
+        crate::cbordetver::cbor_det_mk_int64(mty, nint_left(c));
     let ser: crate::cbordetver::option__size_t = crate::cbordetver::cbor_det_serialize(x, out);
     match ser
     {
@@ -1417,9 +1405,9 @@ pub fn
 serialize_uint(c: u64, out: &mut [u8]) ->
     usize
 {
-    let c·: u64 = evercddl_uint_left(c);
     let mty: crate::cbordetver::cbor_det_int_kind = crate::cbordetver::cbor_det_int_kind::UInt64;
-    let x: crate::cbordetveraux::cbor_raw = crate::cbordetver::cbor_det_mk_int64(mty, c·);
+    let x: crate::cbordetveraux::cbor_raw =
+        crate::cbordetver::cbor_det_mk_int64(mty, evercddl_uint_left(c));
     let ser: crate::cbordetver::option__size_t = crate::cbordetver::cbor_det_serialize(x, out);
     match ser
     {
@@ -1559,8 +1547,7 @@ pub fn
 serialize_int(c: evercddl_int, out: &mut [u8]) ->
     usize
 {
-    let c·: evercddl_int_ugly = evercddl_int_left(c);
-    match c·
+    match evercddl_int_left(c)
     {
         evercddl_int_ugly::Inl { v: c1 } => serialize_uint(c1, out),
         evercddl_int_ugly::Inr { v: c2 } => serialize_nint(c2, out),
@@ -1687,9 +1674,8 @@ pub fn
 serialize_cborany(c: crate::cbordetveraux::cbor_raw, out: &mut [u8]) ->
     usize
 {
-    let c·: crate::cbordetveraux::cbor_raw = cborany_left(c);
-    let c·1: (u64, crate::cbordetveraux::cbor_raw) = (55799u64,c·);
-    let _letpattern: (u64, crate::cbordetveraux::cbor_raw) = c·1;
+    let c·: (u64, crate::cbordetveraux::cbor_raw) = (55799u64,cborany_left(c));
+    let _letpattern: (u64, crate::cbordetveraux::cbor_raw) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: crate::cbordetveraux::cbor_raw = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -1816,9 +1802,8 @@ pub fn
 serialize_mimemessage(c: &[u8], out: &mut [u8]) ->
     usize
 {
-    let c·: &[u8] = mimemessage_left(c);
-    let c·1: (u64, &[u8]) = (36u64,c·);
-    let _letpattern: (u64, &[u8]) = c·1;
+    let c·: (u64, &[u8]) = (36u64,mimemessage_left(c));
+    let _letpattern: (u64, &[u8]) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: &[u8] = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -1945,9 +1930,8 @@ pub fn
 serialize_regexp(c: &[u8], out: &mut [u8]) ->
     usize
 {
-    let c·: &[u8] = regexp_left(c);
-    let c·1: (u64, &[u8]) = (35u64,c·);
-    let _letpattern: (u64, &[u8]) = c·1;
+    let c·: (u64, &[u8]) = (35u64,regexp_left(c));
+    let _letpattern: (u64, &[u8]) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: &[u8] = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -2074,9 +2058,8 @@ pub fn
 serialize_b64legacy(c: &[u8], out: &mut [u8]) ->
     usize
 {
-    let c·: &[u8] = b64legacy_left(c);
-    let c·1: (u64, &[u8]) = (34u64,c·);
-    let _letpattern: (u64, &[u8]) = c·1;
+    let c·: (u64, &[u8]) = (34u64,b64legacy_left(c));
+    let _letpattern: (u64, &[u8]) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: &[u8] = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -2203,9 +2186,8 @@ pub fn
 serialize_b64url(c: &[u8], out: &mut [u8]) ->
     usize
 {
-    let c·: &[u8] = b64url_left(c);
-    let c·1: (u64, &[u8]) = (33u64,c·);
-    let _letpattern: (u64, &[u8]) = c·1;
+    let c·: (u64, &[u8]) = (33u64,b64url_left(c));
+    let _letpattern: (u64, &[u8]) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: &[u8] = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -2332,9 +2314,8 @@ pub fn
 serialize_uri(c: &[u8], out: &mut [u8]) ->
     usize
 {
-    let c·: &[u8] = uri_left(c);
-    let c·1: (u64, &[u8]) = (32u64,c·);
-    let _letpattern: (u64, &[u8]) = c·1;
+    let c·: (u64, &[u8]) = (32u64,uri_left(c));
+    let _letpattern: (u64, &[u8]) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: &[u8] = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -2461,9 +2442,8 @@ pub fn
 serialize_encodedcbor(c: &[u8], out: &mut [u8]) ->
     usize
 {
-    let c·: &[u8] = encodedcbor_left(c);
-    let c·1: (u64, &[u8]) = (24u64,c·);
-    let _letpattern: (u64, &[u8]) = c·1;
+    let c·: (u64, &[u8]) = (24u64,encodedcbor_left(c));
+    let _letpattern: (u64, &[u8]) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: &[u8] = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -2597,9 +2577,8 @@ pub fn
 serialize_eb16(c: crate::cbordetveraux::cbor_raw, out: &mut [u8]) ->
     usize
 {
-    let c·: crate::cbordetveraux::cbor_raw = eb16_left(c);
-    let c·1: (u64, crate::cbordetveraux::cbor_raw) = (23u64,c·);
-    let _letpattern: (u64, crate::cbordetveraux::cbor_raw) = c·1;
+    let c·: (u64, crate::cbordetveraux::cbor_raw) = (23u64,eb16_left(c));
+    let _letpattern: (u64, crate::cbordetveraux::cbor_raw) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: crate::cbordetveraux::cbor_raw = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -2733,9 +2712,8 @@ pub fn
 serialize_eb64legacy(c: crate::cbordetveraux::cbor_raw, out: &mut [u8]) ->
     usize
 {
-    let c·: crate::cbordetveraux::cbor_raw = eb64legacy_left(c);
-    let c·1: (u64, crate::cbordetveraux::cbor_raw) = (22u64,c·);
-    let _letpattern: (u64, crate::cbordetveraux::cbor_raw) = c·1;
+    let c·: (u64, crate::cbordetveraux::cbor_raw) = (22u64,eb64legacy_left(c));
+    let _letpattern: (u64, crate::cbordetveraux::cbor_raw) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: crate::cbordetveraux::cbor_raw = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -2869,9 +2847,8 @@ pub fn
 serialize_eb64url(c: crate::cbordetveraux::cbor_raw, out: &mut [u8]) ->
     usize
 {
-    let c·: crate::cbordetveraux::cbor_raw = eb64url_left(c);
-    let c·1: (u64, crate::cbordetveraux::cbor_raw) = (21u64,c·);
-    let _letpattern: (u64, crate::cbordetveraux::cbor_raw) = c·1;
+    let c·: (u64, crate::cbordetveraux::cbor_raw) = (21u64,eb64url_left(c));
+    let _letpattern: (u64, crate::cbordetveraux::cbor_raw) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: crate::cbordetveraux::cbor_raw = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -2958,10 +2935,7 @@ Serializer for number
 pub fn
 serialize_number(c: evercddl_int, out: &mut [u8]) ->
     usize
-{
-    let c·: evercddl_int = number_left(c);
-    serialize_int(c·, out)
-}
+{ serialize_int(number_left(c), out) }
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum option__·COSE_Format_number···Pulse_Lib_Slice_slice·uint8_t· <'a>
@@ -3075,9 +3049,8 @@ pub fn
 serialize_tdate(c: &[u8], out: &mut [u8]) ->
     usize
 {
-    let c·: &[u8] = tdate_left(c);
-    let c·1: (u64, &[u8]) = (0u64,c·);
-    let _letpattern: (u64, &[u8]) = c·1;
+    let c·: (u64, &[u8]) = (0u64,tdate_left(c));
+    let _letpattern: (u64, &[u8]) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: &[u8] = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -3172,10 +3145,7 @@ Serializer for values
 pub fn
 serialize_values(c: crate::cbordetveraux::cbor_raw, out: &mut [u8]) ->
     usize
-{
-    let c·: crate::cbordetveraux::cbor_raw = values_left(c);
-    serialize_any(c·, out)
-}
+{ serialize_any(values_left(c), out) }
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum option__·COSE_Format_values···Pulse_Lib_Slice_slice·uint8_t· <'a>
@@ -3302,8 +3272,7 @@ pub fn
 serialize_evercddl_label(c: evercddl_label, out: &mut [u8]) ->
     usize
 {
-    let c·: evercddl_label_ugly = evercddl_label_left(c);
-    match c·
+    match evercddl_label_left(c)
     {
         evercddl_label_ugly::Inl { v: c1 } => serialize_int(c1, out),
         evercddl_label_ugly::Inr { v: c2 } => serialize_tstr(c2, out),
@@ -3456,7 +3425,6 @@ aux_env29_serialize_1(
 ) ->
     bool
 {
-    let c·: aux_env29_type_1_ugly = aux_env29_type_1_left(c);
     let count: u64 = out_count[0];
     if count < 18446744073709551615u64
     {
@@ -3465,7 +3433,7 @@ aux_env29_serialize_1(
         let _out0: &[u8] = _letpattern.0;
         let out1: &mut [u8] = _letpattern.1;
         let size1: usize =
-            match c·
+            match aux_env29_type_1_left(c)
             {
                 aux_env29_type_1_ugly::Inl { v: c1 } => serialize_tstr(c1, out1),
                 aux_env29_type_1_ugly::Inr { v: c2 } => serialize_int(c2, out1),
@@ -5192,15 +5160,6 @@ pub fn
 serialize_cose_key_generic(c: cose_key_generic, out: &mut [u8]) ->
     usize
 {
-    let
-    c·:
-    (((((aux_env29_type_1_ugly, option__COSE_Format_bstr),
-    option__COSE_Format_aux_env29_type_1_ugly),
-    option__FStar_Pervasives_either__CDDL_Pulse_Types_slice__COSE_Format_aux_env29_type_1_CDDL_Pulse_Parse_ArrayGroup_array_iterator_t__CBOR_Pulse_Raw_Iterator_cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw_COSE_Format_aux_env29_type_1),
-    option__COSE_Format_bstr),
-    either__CDDL_Pulse_Types_slice__·COSE_Format_evercddl_label···COSE_Format_values·_CDDL_Pulse_Parse_MapGroup_map_iterator_t__CBOR_Pulse_Raw_Type_cbor_raw_CBOR_Pulse_Raw_Type_cbor_map_entry_CBOR_Pulse_Raw_Iterator_cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry_COSE_Format_evercddl_label_COSE_Format_values)
-    =
-        cose_key_generic_left(c);
     let mut pcount: [u64; 1] = [0u64; 1usize];
     let mut psize: [usize; 1] = [0usize; 1usize];
     let
@@ -5211,7 +5170,7 @@ serialize_cose_key_generic(c: cose_key_generic, out: &mut [u8]) ->
     option__COSE_Format_bstr),
     either__CDDL_Pulse_Types_slice__·COSE_Format_evercddl_label···COSE_Format_values·_CDDL_Pulse_Parse_MapGroup_map_iterator_t__CBOR_Pulse_Raw_Type_cbor_raw_CBOR_Pulse_Raw_Type_cbor_map_entry_CBOR_Pulse_Raw_Iterator_cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry_COSE_Format_evercddl_label_COSE_Format_values)
     =
-        c·;
+        cose_key_generic_left(c);
     let res: bool =
         {
             let
@@ -6923,7 +6882,6 @@ aux_env30_serialize_1(
 ) ->
     bool
 {
-    let c·: cose_key_generic = aux_env30_type_1_left(c);
     let count: u64 = out_count[0];
     if count < 18446744073709551615u64
     {
@@ -6931,7 +6889,7 @@ aux_env30_serialize_1(
         let _letpattern: (&mut [u8], &mut [u8]) = out.split_at_mut(size);
         let _out0: &[u8] = _letpattern.0;
         let out1: &mut [u8] = _letpattern.1;
-        let size1: usize = serialize_cose_key_generic(c·, out1);
+        let size1: usize = serialize_cose_key_generic(aux_env30_type_1_left(c), out1);
         if size1 == 0usize
         { false }
         else
@@ -7136,11 +7094,10 @@ pub fn
 serialize_cose_keyset(c: cose_keyset, out: &mut [u8]) ->
     usize
 {
-    let c·: cose_keyset_ugly = cose_keyset_left(c);
     let mut pcount: [u64; 1] = [0u64; 1usize];
     let mut psize: [usize; 1] = [0usize; 1usize];
     let res: bool =
-        match c·
+        match cose_keyset_left(c)
         {
             cose_keyset_ugly::Inl { v: c1 } =>
               if c1.len() == 0usize
@@ -8313,12 +8270,6 @@ pub fn
 serialize_cose_key_okp(c: cose_key_okp, out: &mut [u8]) ->
     usize
 {
-    let
-    c·:
-    (((((), evercddl_label_ugly), option__COSE_Format_bstr), option__COSE_Format_bstr),
-    either__CDDL_Pulse_Types_slice__·COSE_Format_evercddl_label···COSE_Format_values·_CDDL_Pulse_Parse_MapGroup_map_iterator_t__CBOR_Pulse_Raw_Type_cbor_raw_CBOR_Pulse_Raw_Type_cbor_map_entry_CBOR_Pulse_Raw_Iterator_cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry_COSE_Format_evercddl_label_COSE_Format_values)
-    =
-        cose_key_okp_left(c);
     let mut pcount: [u64; 1] = [0u64; 1usize];
     let mut psize: [usize; 1] = [0usize; 1usize];
     let
@@ -8326,7 +8277,7 @@ serialize_cose_key_okp(c: cose_key_okp, out: &mut [u8]) ->
     (((((), evercddl_label_ugly), option__COSE_Format_bstr), option__COSE_Format_bstr),
     either__CDDL_Pulse_Types_slice__·COSE_Format_evercddl_label···COSE_Format_values·_CDDL_Pulse_Parse_MapGroup_map_iterator_t__CBOR_Pulse_Raw_Type_cbor_raw_CBOR_Pulse_Raw_Type_cbor_map_entry_CBOR_Pulse_Raw_Iterator_cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry_COSE_Format_evercddl_label_COSE_Format_values)
     =
-        c·;
+        cose_key_okp_left(c);
     let res: bool =
         {
             let
@@ -9503,10 +9454,7 @@ Serializer for cose_key
 pub fn
 serialize_cose_key(c: cose_key_okp, out: &mut [u8]) ->
     usize
-{
-    let c·: cose_key_okp = cose_key_left(c);
-    serialize_cose_key_okp(c·, out)
-}
+{ serialize_cose_key_okp(cose_key_left(c), out) }
 
 #[derive(PartialEq, Clone, Copy)]
 pub enum option__·COSE_Format_cose_key···Pulse_Lib_Slice_slice·uint8_t· <'a>
@@ -9606,7 +9554,6 @@ aux_env34_serialize_1(
 ) ->
     bool
 {
-    let c·: evercddl_label = aux_env34_type_1_left(c);
     let count: u64 = out_count[0];
     if count < 18446744073709551615u64
     {
@@ -9614,7 +9561,7 @@ aux_env34_serialize_1(
         let _letpattern: (&mut [u8], &mut [u8]) = out.split_at_mut(size);
         let _out0: &[u8] = _letpattern.0;
         let out1: &mut [u8] = _letpattern.1;
-        let size1: usize = serialize_evercddl_label(c·, out1);
+        let size1: usize = serialize_evercddl_label(aux_env34_type_1_left(c), out1);
         if size1 == 0usize
         { false }
         else
@@ -12277,16 +12224,6 @@ pub fn
 serialize_header_map(c: header_map, out: &mut [u8]) ->
     usize
 {
-    let
-    c·:
-    (((((option__COSE_Format_evercddl_label_ugly,
-    option__FStar_Pervasives_either__CDDL_Pulse_Types_slice__COSE_Format_aux_env34_type_1_CDDL_Pulse_Parse_ArrayGroup_array_iterator_t__CBOR_Pulse_Raw_Iterator_cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw_COSE_Format_aux_env34_type_1),
-    option__COSE_Format_aux_env29_type_1_ugly),
-    option__COSE_Format_bstr),
-    either__·COSE_Format_bstr···FStar_Pervasives_Native_option__COSE_Format_everparsenomatch·_FStar_Pervasives_either__·COSE_Format_bstr···FStar_Pervasives_Native_option__COSE_Format_everparsenomatch·_·FStar_Pervasives_Native_option__COSE_Format_everparsenomatch···FStar_Pervasives_Native_option__COSE_Format_everparsenomatch·),
-    either__CDDL_Pulse_Types_slice__·COSE_Format_evercddl_label···COSE_Format_values·_CDDL_Pulse_Parse_MapGroup_map_iterator_t__CBOR_Pulse_Raw_Type_cbor_raw_CBOR_Pulse_Raw_Type_cbor_map_entry_CBOR_Pulse_Raw_Iterator_cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry_COSE_Format_evercddl_label_COSE_Format_values)
-    =
-        header_map_left(c);
     let mut pcount: [u64; 1] = [0u64; 1usize];
     let mut psize: [usize; 1] = [0usize; 1usize];
     let
@@ -12298,7 +12235,7 @@ serialize_header_map(c: header_map, out: &mut [u8]) ->
     either__·COSE_Format_bstr···FStar_Pervasives_Native_option__COSE_Format_everparsenomatch·_FStar_Pervasives_either__·COSE_Format_bstr···FStar_Pervasives_Native_option__COSE_Format_everparsenomatch·_·FStar_Pervasives_Native_option__COSE_Format_everparsenomatch···FStar_Pervasives_Native_option__COSE_Format_everparsenomatch·),
     either__CDDL_Pulse_Types_slice__·COSE_Format_evercddl_label···COSE_Format_values·_CDDL_Pulse_Parse_MapGroup_map_iterator_t__CBOR_Pulse_Raw_Type_cbor_raw_CBOR_Pulse_Raw_Type_cbor_map_entry_CBOR_Pulse_Raw_Iterator_cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_map_entry_COSE_Format_evercddl_label_COSE_Format_values)
     =
-        c·;
+        header_map_left(c);
     let res: bool =
         {
             let
@@ -14711,8 +14648,7 @@ pub fn
 serialize_empty_or_serialized_map(c: empty_or_serialized_map, out: &mut [u8]) ->
     usize
 {
-    let c·: empty_or_serialized_map_ugly = empty_or_serialized_map_left(c);
-    match c·
+    match empty_or_serialized_map_left(c)
     {
         empty_or_serialized_map_ugly::Inl { v: c1 } =>
           {
@@ -15775,13 +15711,6 @@ pub fn
 serialize_sig_structure(c: sig_structure, out: &mut [u8]) ->
     usize
 {
-    let
-    c·:
-    (evercddl_int_ugly_tags,
-    (empty_or_serialized_map,
-    either__·COSE_Format_empty_or_serialized_map····COSE_Format_bstr···COSE_Format_bstr··_·COSE_Format_bstr···COSE_Format_bstr·))
-    =
-        sig_structure_left(c);
     let mut pcount: [u64; 1] = [0u64; 1usize];
     let mut psize: [usize; 1] = [0usize; 1usize];
     let
@@ -15790,7 +15719,7 @@ serialize_sig_structure(c: sig_structure, out: &mut [u8]) ->
     (empty_or_serialized_map,
     either__·COSE_Format_empty_or_serialized_map····COSE_Format_bstr···COSE_Format_bstr··_·COSE_Format_bstr···COSE_Format_bstr·))
     =
-        c·;
+        sig_structure_left(c);
     let res: bool =
         {
             let c1: evercddl_int_ugly_tags = _letpattern.0;
@@ -16453,17 +16382,13 @@ pub fn
 serialize_cose_sign1(c: cose_sign1, out: &mut [u8]) ->
     usize
 {
-    let
-    c·: ((empty_or_serialized_map, header_map), (either__COSE_Format_bstr_COSE_Format_nil, &[u8]))
-    =
-        cose_sign1_left(c);
     let mut pcount: [u64; 1] = [0u64; 1usize];
     let mut psize: [usize; 1] = [0usize; 1usize];
     let
     _letpattern:
     ((empty_or_serialized_map, header_map), (either__COSE_Format_bstr_COSE_Format_nil, &[u8]))
     =
-        c·;
+        cose_sign1_left(c);
     let res: bool =
         {
             let c1: (empty_or_serialized_map, header_map) = _letpattern.0;
@@ -16702,9 +16627,8 @@ pub fn
 serialize_cose_sign1_tagged(c: cose_sign1, out: &mut [u8]) ->
     usize
 {
-    let c·: cose_sign1 = cose_sign1_tagged_left(c);
-    let c·1: (u64, cose_sign1) = (18u64,c·);
-    let _letpattern: (u64, cose_sign1) = c·1;
+    let c·: (u64, cose_sign1) = (18u64,cose_sign1_tagged_left(c));
+    let _letpattern: (u64, cose_sign1) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: cose_sign1 = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);
@@ -16966,10 +16890,9 @@ pub fn
 serialize_cose_signature(c: cose_signature, out: &mut [u8]) ->
     usize
 {
-    let c·: ((empty_or_serialized_map, header_map), &[u8]) = cose_signature_left(c);
     let mut pcount: [u64; 1] = [0u64; 1usize];
     let mut psize: [usize; 1] = [0usize; 1usize];
-    let _letpattern: ((empty_or_serialized_map, header_map), &[u8]) = c·;
+    let _letpattern: ((empty_or_serialized_map, header_map), &[u8]) = cose_signature_left(c);
     let res: bool =
         {
             let c1: (empty_or_serialized_map, header_map) = _letpattern.0;
@@ -17157,7 +17080,6 @@ aux_env41_serialize_1(
 ) ->
     bool
 {
-    let c·: cose_signature = aux_env41_type_1_left(c);
     let count: u64 = out_count[0];
     if count < 18446744073709551615u64
     {
@@ -17165,7 +17087,7 @@ aux_env41_serialize_1(
         let _letpattern: (&mut [u8], &mut [u8]) = out.split_at_mut(size);
         let _out0: &[u8] = _letpattern.0;
         let out1: &mut [u8] = _letpattern.1;
-        let size1: usize = serialize_cose_signature(c·, out1);
+        let size1: usize = serialize_cose_signature(aux_env41_type_1_left(c), out1);
         if size1 == 0usize
         { false }
         else
@@ -17626,13 +17548,6 @@ pub fn
 serialize_cose_sign(c: cose_sign, out: &mut [u8]) ->
     usize
 {
-    let
-    c·:
-    ((empty_or_serialized_map, header_map),
-    (either__COSE_Format_bstr_COSE_Format_nil,
-    either__CDDL_Pulse_Types_slice__COSE_Format_aux_env41_type_1_CDDL_Pulse_Parse_ArrayGroup_array_iterator_t__CBOR_Pulse_Raw_Iterator_cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw_COSE_Format_aux_env41_type_1))
-    =
-        cose_sign_left(c);
     let mut pcount: [u64; 1] = [0u64; 1usize];
     let mut psize: [usize; 1] = [0usize; 1usize];
     let
@@ -17641,7 +17556,7 @@ serialize_cose_sign(c: cose_sign, out: &mut [u8]) ->
     (either__COSE_Format_bstr_COSE_Format_nil,
     either__CDDL_Pulse_Types_slice__COSE_Format_aux_env41_type_1_CDDL_Pulse_Parse_ArrayGroup_array_iterator_t__CBOR_Pulse_Raw_Iterator_cbor_raw_iterator__CBOR_Pulse_Raw_Type_cbor_raw_COSE_Format_aux_env41_type_1))
     =
-        c·;
+        cose_sign_left(c);
     let res: bool =
         {
             let c1: (empty_or_serialized_map, header_map) = _letpattern.0;
@@ -18104,9 +18019,8 @@ pub fn
 serialize_cose_sign_tagged(c: cose_sign, out: &mut [u8]) ->
     usize
 {
-    let c·: cose_sign = cose_sign_tagged_left(c);
-    let c·1: (u64, cose_sign) = (98u64,c·);
-    let _letpattern: (u64, cose_sign) = c·1;
+    let c·: (u64, cose_sign) = (98u64,cose_sign_tagged_left(c));
+    let _letpattern: (u64, cose_sign) = c·;
     let ctag: u64 = _letpattern.0;
     let cpayload: cose_sign = _letpattern.1;
     let tsz: usize = crate::cbordetver::cbor_det_serialize_tag(ctag, out);

--- a/src/cose/verifiedinterop/COSE.EverCrypt.fst
+++ b/src/cose/verifiedinterop/COSE.EverCrypt.fst
@@ -316,11 +316,9 @@ fn mk_phdrs (alg: Int32.t) (rest: A.larray (evercddl_label & values) 0)
   let alg' = mk_int alg;
   A.pts_to_len rest;
   let rest2 = S.from_array rest 0sz;
-  Pulse.Lib.SeqMatch.seq_list_match_nil_intro (Seq.Base.create 0 (dummy_map_val ())) []
+  assert pure ((Ghost.reveal vrest) `Seq.equal` Seq.empty);
+  Pulse.Lib.SeqMatch.seq_list_match_nil_intro (Ghost.reveal vrest) []
       (rel_pair rel_evercddl_label rel_values);
-  assert pure (Seq.Base.create 0 (dummy_map_val ()) `Seq.equal` vrest);
-  rewrite each (FStar.Seq.Base.create 0
-            (dummy_map_val ())) as vrest;
   rw_l (rel_inl_map_eq {s = rest2; p=prest} (CDDL.Spec.Map.empty _ _));
   rw_l (rel_map_sign1_phdrs_eq alg alg' _);
   with res. assert rel_empty_or_serialized_map res (sign1_phdrs_spec alg);
@@ -364,12 +362,10 @@ fn mk_emphdrs (rest: A.larray (evercddl_label & values) 0)
   ensures borrows (rel_header_map res (sign1_emphdrs_spec ())) (pts_to rest #prest vrest)
 {
   A.pts_to_len rest;
-  assert pure (Seq.equal vrest (Seq.create 0 (dummy_map_val ())));
+  assert pure ((Ghost.reveal vrest) `Seq.equal` Seq.empty);
   let rest2 = S.from_array rest 0sz;
-  Pulse.Lib.SeqMatch.seq_list_match_nil_intro (Seq.Base.create 0 (dummy_map_val ())) []
+  Pulse.Lib.SeqMatch.seq_list_match_nil_intro (Ghost.reveal vrest) []
       (rel_pair rel_evercddl_label rel_values);
-  rewrite each (FStar.Seq.Base.create 0
-            (dummy_map_val ())) as vrest;
   rw_l (rel_inl_map_eq {s = rest2; p=prest} (CDDL.Spec.Map.empty _ _));
   rw_l (rel_map_sign1_emphdrs_eq _);
   with res. assert rel_header_map res (sign1_emphdrs_spec ());

--- a/src/lowparse/pulse/LowParse.Pulse.Combinators.fst
+++ b/src/lowparse/pulse/LowParse.Pulse.Combinators.fst
@@ -2767,9 +2767,9 @@ fn l2r_write_filter
   (offset: _)
   (#v: _)
 {
-  unfold (vmatch_filter vmatch f x' x);
+  unfold (vmatch_filter vmatch f x' (Ghost.reveal x));
   let res = w x' #(Ghost.hide #t1 (Ghost.reveal x)) out offset;
-  fold (vmatch_filter vmatch f x' x);
+  fold (vmatch_filter vmatch f x' (Ghost.reveal x));
   res
 }
 
@@ -2785,9 +2785,9 @@ fn compute_remaining_size_filter
   (out: _)
   (#v: _)
 {
-  unfold (vmatch_filter vmatch f x' x);
+  unfold (vmatch_filter vmatch f x' (Ghost.reveal x));
   let res = w x' #(Ghost.hide #t1 (Ghost.reveal x)) out;
-  fold (vmatch_filter vmatch f x' x);
+  fold (vmatch_filter vmatch f x' (Ghost.reveal x));
   res
 }
 
@@ -2808,7 +2808,7 @@ fn zero_copy_parse_filter
   Trade.trans (vmatch res v') _ _;
   Trade.rewrite_with_trade
     (vmatch res v')
-    (vmatch_filter vmatch f res v);
+    (vmatch_filter vmatch f res (Ghost.reveal v));
   Trade.trans _ (vmatch res v') _;
   res
 }

--- a/src/lowparse/pulse/LowParse.PulseParse.Combinators.fst
+++ b/src/lowparse/pulse/LowParse.PulseParse.Combinators.fst
@@ -972,7 +972,7 @@ fn zero_copy_parse_filter
   Trade.trans (vmatch res v') _ _;
   Trade.rewrite_with_trade
     (vmatch res v')
-    (LPC.vmatch_filter vmatch f res v);
+    (LPC.vmatch_filter vmatch f res (Ghost.reveal v));
   Trade.trans _ (vmatch res v') _;
   res
 }
@@ -1107,8 +1107,8 @@ fn zero_copy_parse_fst
   Trade.elim_hyp_r (vmatch1 res _) (PPB.pts_to_parsed p2 input2 #(pm /. 2.0R) gv2) (PPB.pts_to_parsed (nondep_then p1 p2) input #pm v);
   Trade.rewrite_with_trade
     (vmatch1 res _)
-    (LPC.vmatch_synth vmatch1 fst res v);
-  Trade.trans (LPC.vmatch_synth vmatch1 fst res v) _ _;
+    (LPC.vmatch_synth vmatch1 fst res (Ghost.reveal v));
+  Trade.trans (LPC.vmatch_synth vmatch1 fst res (Ghost.reveal v)) _ _;
   res
 }
 
@@ -1149,8 +1149,8 @@ fn zero_copy_parse_snd
   Trade.elim_hyp_l (PPB.pts_to_parsed p1 input1 #(pm /. 2.0R) gv1) _ (PPB.pts_to_parsed (nondep_then p1 p2) input #pm v);
   Trade.rewrite_with_trade
     (vmatch2 res _)
-    (LPC.vmatch_synth vmatch2 snd res v);
-  Trade.trans (LPC.vmatch_synth vmatch2 snd res v) _ _;
+    (LPC.vmatch_synth vmatch2 snd res (Ghost.reveal v));
+  Trade.trans (LPC.vmatch_synth vmatch2 snd res (Ghost.reveal v)) _ _;
   res
 }
 
@@ -1192,8 +1192,8 @@ fn zero_copy_parse_dtuple2_fst
   Trade.elim_hyp_r (vmatch1 res _) (PPB.pts_to_parsed (p2 gdv1) input2 #(pm /. 2.0R) gdv2) (PPB.pts_to_parsed (parse_dtuple2 p1 p2) input #pm v);
   Trade.rewrite_with_trade
     (vmatch1 res _)
-    (LPC.vmatch_synth vmatch1 dfst res v);
-  Trade.trans (LPC.vmatch_synth vmatch1 dfst res v) _ _;
+    (LPC.vmatch_synth vmatch1 dfst res (Ghost.reveal v));
+  Trade.trans (LPC.vmatch_synth vmatch1 dfst res (Ghost.reveal v)) _ _;
   res
 }
 


### PR DESCRIPTION
An AI agent tried to fix the proofs to adapt EverParse `fstar2` (7fd65f18f27ce5b6d1cc73d939bc71eed66334b5) to FStarLang/FStar@316df75b1306199193b3d454b938b8f39b09bc96 . It turns out that those fixes are not specific to that F* commit, so this PR replicates them to EverParse `master`, to keep the two branches as close as possible.
