### PR TITLE
Bump to latest F*

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update \
       tmux \
       rustup \
       dotnet-sdk-8.0 \
+      python3-venv \
+      clang \
+      cmake \
     && apt-get clean -y
 # FIXME: libgmp-dev should be installed automatically by opam,
 # but it is not working, so just adding it above.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,44 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu24.04
+
+# Base dependencies: opam
+# CI dependencies: jq (to identify F* branch)
+# python3 (for interactive tests)
+# libicu (for .NET, cf. https://aka.ms/dotnet-missing-libicu )
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      wget \
+      git \
+      gnupg \
+      sudo \
+      python3 \
+      python-is-python3 \
+      libgmp-dev \
+      opam \
+      vim \
+      pkg-config \
+      time \
+      libffi-dev \
+      tmux \
+      rustup \
+      dotnet-sdk-8.0 \
+    && apt-get clean -y
+# FIXME: libgmp-dev should be installed automatically by opam,
+# but it is not working, so just adding it above.
+# Same for pkg-config. OPAM prompts even if we're giving --yes
+# and setting OPAMYES.
+
+USER vscode
+ENV HOME=/home/vscode
+WORKDIR /home/vscode
+
+# Make sure ~/bin is in the PATH
+RUN mkdir -p $HOME/bin
+RUN echo 'export PATH=$HOME/bin:$PATH' | tee --append $HOME/.profile $HOME/.bashrc $HOME/.bash_profile
+
+# Install Rust
+RUN rustup install stable
+
+# Install copilot-cli
+RUN curl -fsSL https://gh.io/copilot-install | bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "EverParse devcontainer",
+  "build": {
+    "context": "..",
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "FStarLang.fstar-vscode-assistant"
+      ]
+    }
+  },
+  "remoteEnv": {
+  },
+  // Runs only once when container is prepared
+  "onCreateCommand": {
+  },
+  // Runs periodically and/or when content of repo changes
+  "updateContentCommand": {
+  },
+  // These run only when the container is assigned to a user
+  "postCreateCommand": {
+  }
+}

--- a/opt/hashes.Makefile
+++ b/opt/hashes.Makefile
@@ -1,2 +1,2 @@
-FStar_hash := 316df75b1306199193b3d454b938b8f39b09bc96
+FStar_hash := 8b389ec15fe0e831a93bd4e330ba860f6d967350
 karamel_hash := 6c5e3d20ddcb78ac089f624dca8c94df333c53bb

--- a/src/3d/InterpreterTarget.fst
+++ b/src/3d/InterpreterTarget.fst
@@ -14,6 +14,7 @@
    limitations under the License.
 *)
 module InterpreterTarget
+open Binding
 (* The abstract syntax for the code produced by 3d, targeting prelude/Interpreter.fst *)
 open FStar.All
 open FStar.List.Tot

--- a/src/3d/prelude/EverParse3d.Actions.Base.fst
+++ b/src/3d/prelude/EverParse3d.Actions.Base.fst
@@ -1,6 +1,10 @@
 module EverParse3d.Actions.Base
 friend EverParse3d.Kinds
 friend EverParse3d.Prelude
+module Cast = FStar.Int.Cast
+open EverParse3d.Prelude
+module U32 = FStar.UInt32
+module U64 = FStar.UInt64
 open FStar.HyperStack.ST
 open LowStar.Buffer
 open LowStar.BufferOps
@@ -101,14 +105,14 @@ let index_equations ()
          i0 `inv_implies` i2) ==>
         (i0 `inv_implies` (i1 `conj_inv` i2))
     with introduce _ ==> _
-    with _ . inv_implies_conj i0 i1 i2 () ();
+    with inv_implies_conj i0 i1 i2 () ();
     introduce forall l. _
     with eloc_includes_none l;
     introduce forall l0 l1 l2. (l0 `eloc_includes` l1 /\
          l0 `eloc_includes` l2) ==>
         (l0 `eloc_includes` (l1 `eloc_union` l2))
     with introduce _ ==> _
-    with _ . eloc_includes_union l0 l1 l2 () ();
+    with eloc_includes_union l0 l1 l2 () ();
     introduce forall l. _
     with eloc_includes_refl l
 

--- a/src/3d/prelude/EverParse3d.Prelude.fst
+++ b/src/3d/prelude/EverParse3d.Prelude.fst
@@ -15,6 +15,9 @@
 *)
 module EverParse3d.Prelude
 friend EverParse3d.Kinds
+include EverParse3d.Prelude.StaticHeader
+include EverParse3d.Kinds
+open FStar.Range
 module BF = LowParse.BitFields
 module LP = LowParse.Spec.Base
 module LPC = LowParse.Spec.Combinators

--- a/src/3d/prelude/buffer/EverParse3d.Actions.All.fst
+++ b/src/3d/prelude/buffer/EverParse3d.Actions.All.fst
@@ -3,6 +3,7 @@ friend EverParse3d.Actions.Base
 friend EverParse3d.InputStream.All
 friend EverParse3d.InputStream.Buffer
 
+include EverParse3d.Actions.Base
 let _ = EverParse3d.Actions.BackendFlagValue.backend_flag_value
 
 module IB = EverParse3d.InputBuffer

--- a/src/3d/prelude/buffer/EverParse3d.InputBuffer.fst
+++ b/src/3d/prelude/buffer/EverParse3d.InputBuffer.fst
@@ -1,5 +1,6 @@
 module EverParse3d.InputBuffer
 
+include LowParse.Low.Base
 module B = LowStar.Buffer
 module HS = FStar.HyperStack
 module HST = FStar.HyperStack.ST

--- a/src/3d/prelude/buffer/EverParse3d.InputStream.All.fst
+++ b/src/3d/prelude/buffer/EverParse3d.InputStream.All.fst
@@ -1,4 +1,5 @@
 module EverParse3d.InputStream.All
+include EverParse3d.InputStream.Base
 open EverParse3d.InputStream.Buffer
 
 let t = t

--- a/src/3d/prelude/buffer/EverParse3d.InputStream.Buffer.fst
+++ b/src/3d/prelude/buffer/EverParse3d.InputStream.Buffer.fst
@@ -1,4 +1,10 @@
 module EverParse3d.InputStream.Buffer
+module U8 = FStar.UInt8
+module U32 = FStar.UInt32
+module HS = FStar.HyperStack
+module HST = FStar.HyperStack.ST
+module B = LowStar.Buffer
+open EverParse3d.InputStream.Base
 open EverParse3d.InputStream.Buffer.Aux
 
 (* Implementation for single buffers *)

--- a/src/3d/prelude/buffer/EverParse3d.Readable.fst
+++ b/src/3d/prelude/buffer/EverParse3d.Readable.fst
@@ -1,5 +1,7 @@
 module EverParse3d.Readable
 
+module B = LowStar.Buffer
+module U32 = FStar.UInt32
 let perm0 t = B.pointer (Ghost.erased (Seq.seq bool))
 
 let perm_prop p b = B.loc_disjoint (B.loc_buffer b) (B.loc_buffer p) /\ True

--- a/src/3d/prelude/extern/EverParse3d.Actions.All.fst
+++ b/src/3d/prelude/extern/EverParse3d.Actions.All.fst
@@ -2,6 +2,7 @@ module EverParse3d.Actions.All
 friend EverParse3d.Actions.Base
 friend EverParse3d.InputStream.All
 
+include EverParse3d.Actions.Base
 let _ = EverParse3d.Actions.BackendFlagValue.backend_flag_value
 
 let ___PUINT8 = (b:LowStar.Buffer.buffer FStar.UInt8.t { ~ (LowStar.Buffer.g_is_null b) })

--- a/src/3d/prelude/extern/EverParse3d.InputStream.All.fst
+++ b/src/3d/prelude/extern/EverParse3d.InputStream.All.fst
@@ -1,5 +1,6 @@
 module EverParse3d.InputStream.All
 
+include EverParse3d.InputStream.Base
 open EverParse3d.InputStream.Extern
 
 module Aux = EverParse3d.InputStream.Extern.Base

--- a/src/cbor/pulse/raw/CBOR.Pulse.API.Det.C.Copy.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.API.Det.C.Copy.fst
@@ -3,6 +3,8 @@ friend CBOR.Pulse.API.Det.Type
 friend CBOR.Spec.API.Format
 friend CBOR.Pulse.API.Det.Common
 friend CBOR.Pulse.API.Det.C
+include CBOR.Pulse.API.Det.C
+open Pulse.Lib.Pervasives
 #lang-pulse
 
 module SpecRaw = CBOR.Spec.Raw

--- a/src/cbor/pulse/raw/CBOR.Pulse.API.Det.C.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.API.Det.C.fst
@@ -1,4 +1,18 @@
 module CBOR.Pulse.API.Det.C
+include CBOR.Pulse.API.Det.Type
+include CBOR.Pulse.API.Det.Dummy
+include CBOR.Pulse.API.Base
+open Pulse.Lib.Pervasives
+open CBOR.Spec.Constants
+module Spec = CBOR.Spec.API.Format
+module S = Pulse.Lib.Slice
+module A = Pulse.Lib.Array
+module PM = Pulse.Lib.SeqMatch
+module Trade = Pulse.Lib.Trade.Util
+module SZ = FStar.SizeT
+module U8 = FStar.UInt8
+module SU = Pulse.Lib.Slice.Util
+module AP = Pulse.Lib.ArrayPtr
 #lang-pulse
 
 (* NOTE: this .fst file does not need anything from the Raw namespace,

--- a/src/cbor/pulse/raw/CBOR.Pulse.API.Det.Common.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.API.Det.Common.fst
@@ -1,6 +1,17 @@
 module CBOR.Pulse.API.Det.Common
 friend CBOR.Pulse.API.Det.Type
 friend CBOR.Spec.API.Format
+include CBOR.Pulse.API.Det.Type
+include CBOR.Pulse.API.Det.Dummy
+include CBOR.Pulse.API.Base
+open Pulse.Lib.Pervasives
+module Spec = CBOR.Spec.API.Format
+module S = Pulse.Lib.Slice
+module Trade = Pulse.Lib.Trade.Util
+module SZ = FStar.SizeT
+module U64 = FStar.UInt64
+module U8 = FStar.UInt8
+module PM = Pulse.Lib.SeqMatch
 #lang-pulse
 
 module SpecRaw = CBOR.Spec.Raw

--- a/src/cbor/pulse/raw/CBOR.Pulse.API.Det.Rust.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.API.Det.Rust.fst
@@ -1,4 +1,14 @@
 module CBOR.Pulse.API.Det.Rust
+open CBOR.Spec.Constants
+open Pulse.Lib.Pervasives
+module Spec = CBOR.Spec.API.Format
+module Trade = Pulse.Lib.Trade.Util
+module U8 = FStar.UInt8
+module U64 = FStar.UInt64
+module S = Pulse.Lib.Slice
+module SZ = FStar.SizeT
+module Base = CBOR.Pulse.API.Base
+module PM = Pulse.Lib.SeqMatch
 #lang-pulse
 
 (* NOTE: this .fst file does not need anything from the Raw namespace,

--- a/src/cbor/pulse/raw/CBOR.Pulse.API.Nondet.C.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.API.Nondet.C.fst
@@ -1,4 +1,10 @@
 module CBOR.Pulse.API.Nondet.C
+include CBOR.Pulse.API.Nondet.Type
+open CBOR.Spec.Constants
+open CBOR.Pulse.API.Base
+open Pulse.Lib.Pervasives
+module Spec = CBOR.Spec.API.Format
+module Trade = Pulse.Lib.Trade.Util
 #lang-pulse
 module Rust = CBOR.Pulse.Raw.Nondet
 

--- a/src/cbor/pulse/raw/CBOR.Pulse.API.Nondet.Rust.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.API.Nondet.Rust.fst
@@ -1,4 +1,14 @@
 module CBOR.Pulse.API.Nondet.Rust
+open CBOR.Spec.Constants
+open Pulse.Lib.Pervasives
+module Spec = CBOR.Spec.API.Format
+module Trade = Pulse.Lib.Trade.Util
+module U8 = FStar.UInt8
+module U64 = FStar.UInt64
+module S = Pulse.Lib.Slice
+module SZ = FStar.SizeT
+module Base = CBOR.Pulse.API.Base
+module PM = Pulse.Lib.SeqMatch
 #lang-pulse
 
 (* NOTE: this .fst file does not need anything from the Raw namespace,
@@ -21,7 +31,7 @@ let cbor_nondet_share () = Nondet.cbor_nondet_share ()
 
 let cbor_nondet_gather () = Nondet.cbor_nondet_gather ()
 
-let cbor_nondet_parse () map_key_bound strict_check input #pm #v = Nondet.cbor_nondet_parse () map_key_bound strict_check input #pm #v
+let cbor_nondet_parse () : Base.cbor_nondet_parse_t cbor_nondet_match = Nondet.cbor_nondet_parse ()
 
 let cbor_nondet_match_with_size = Nondet.cbor_nondet_match_with_size
 

--- a/src/cbor/pulse/raw/CBOR.Pulse.API.Nondet.Rust.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.API.Nondet.Rust.fst
@@ -31,7 +31,10 @@ let cbor_nondet_share () = Nondet.cbor_nondet_share ()
 
 let cbor_nondet_gather () = Nondet.cbor_nondet_gather ()
 
-let cbor_nondet_parse () : Base.cbor_nondet_parse_t cbor_nondet_match = Nondet.cbor_nondet_parse ()
+inline_for_extraction noextract [@@noextract_to "krml"]
+let cbor_nondet_parse_aux : Base.cbor_nondet_parse_t cbor_nondet_match = Nondet.cbor_nondet_parse ()
+
+let cbor_nondet_parse () map_key_bound strict_check input #pm #v = cbor_nondet_parse_aux map_key_bound strict_check input #pm #v
 
 let cbor_nondet_match_with_size = Nondet.cbor_nondet_match_with_size
 

--- a/src/cbor/pulse/raw/CBOR.Pulse.Raw.Match.Perm.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.Raw.Match.Perm.fst
@@ -1,4 +1,11 @@
 module CBOR.Pulse.Raw.Match.Perm
+include CBOR.Pulse.Raw.Match
+open CBOR.Spec.Raw.Base
+open Pulse.Lib.Pervasives
+open Pulse.Lib.Trade
+module PM = Pulse.Lib.SeqMatch
+module S = Pulse.Lib.Slice
+module R = Pulse.Lib.Reference
 #lang-pulse
 open CBOR.Pulse.Raw.Util
 

--- a/src/cbor/pulse/raw/CBOR.Pulse.Raw.Nondet.fst
+++ b/src/cbor/pulse/raw/CBOR.Pulse.Raw.Nondet.fst
@@ -1,6 +1,15 @@
 module CBOR.Pulse.Raw.Nondet
 friend CBOR.Pulse.API.Nondet.Type
 friend CBOR.Spec.API.Format
+include CBOR.Pulse.API.Nondet.Type
+open CBOR.Pulse.API.Base
+open Pulse.Lib.Pervasives
+module Spec = CBOR.Spec.API.Format
+module SZ = FStar.SizeT
+module U8 = FStar.UInt8
+module S = Pulse.Lib.Slice.Util
+module Trade = Pulse.Lib.Trade.Util
+module SM = Pulse.Lib.SeqMatch.Util
 #lang-pulse
 open CBOR.Pulse.Raw.Match
 

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.API.UTF8.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.API.UTF8.fst
@@ -1,3 +1,5 @@
 module CBOR.Pulse.API.UTF8
 
+include CBOR.Spec.API.UTF8
+open Pulse.Lib.Pervasives
 let impl_utf8_correct = CBOR.Pulse.Raw.EverParse.UTF8.impl_correct

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Format.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Format.fst
@@ -1,4 +1,16 @@
 module CBOR.Pulse.Raw.EverParse.Format
+open Pulse.Lib.Slice
+open Pulse.Lib.Pervasives
+open Pulse.Lib.Trade
+open CBOR.Spec.Raw.EverParse
+open LowParse.Pulse.Combinators
+open LowParse.Pulse.Recursive
+module Trade = Pulse.Lib.Trade.Util
+module U64 = FStar.UInt64
+module L = LowParse.Spec.VCList
+module SZ = FStar.SizeT
+module R = Pulse.Lib.Reference
+module S = Pulse.Lib.Slice
 #lang-pulse
 open LowParse.Pulse.Int
 open LowParse.Pulse.BitSum

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Format.fsti
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Format.fsti
@@ -1,6 +1,8 @@
 module CBOR.Pulse.Raw.EverParse.Format
 open CBOR.Spec.Raw.EverParse
-open Pulse.Lib.Slice open Pulse.Lib.Pervasives open Pulse.Lib.Trade
+open Pulse.Lib.Slice
+open Pulse.Lib.Pervasives
+open Pulse.Lib.Trade
 open LowParse.Pulse.Combinators
 open LowParse.Pulse.Recursive
 

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Nondet.Gen.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Nondet.Gen.fst
@@ -1,4 +1,14 @@
 module CBOR.Pulse.Raw.EverParse.Nondet.Gen
+include CBOR.Spec.Raw.Nondet
+open CBOR.Spec.Util
+open CBOR.Spec.Raw.EverParse
+include CBOR.Pulse.Raw.EverParse.Format
+open LowParse.Spec.VCList
+open LowParse.Pulse.VCList
+open Pulse.Lib.Pervasives
+module S = Pulse.Lib.Slice.Util
+module SZ = FStar.SizeT
+module Trade = Pulse.Lib.Trade.Util
 #lang-pulse
 
 inline_for_extraction

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Serialized.Base.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Serialized.Base.fst
@@ -1,5 +1,15 @@
 module CBOR.Pulse.Raw.EverParse.Serialized.Base
 friend CBOR.Pulse.Raw.Format.Match
+open Pulse.Lib.Slice
+open Pulse.Lib.Trade
+open LowParse.Spec.Base
+open LowParse.Pulse.Base
+include CBOR.Pulse.Raw.Match
+open CBOR.Spec.Raw.Base
+open Pulse.Lib.Pervasives
+open CBOR.Spec.Raw.EverParse
+module S = Pulse.Lib.Slice
+module U64 = FStar.UInt64
 #lang-pulse
 
 open CBOR.Pulse.Raw.EverParse.Format

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Serialized.Base.fsti
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.Serialized.Base.fsti
@@ -3,9 +3,12 @@ include CBOR.Pulse.Raw.Match
 open CBOR.Spec.Raw.Base
 open Pulse.Lib.Pervasives
 
-open Pulse.Lib.Slice open Pulse.Lib.Pervasives open Pulse.Lib.Trade
+open Pulse.Lib.Slice
+open Pulse.Lib.Pervasives
+open Pulse.Lib.Trade
 open CBOR.Spec.Raw.EverParse
-open LowParse.Spec.Base open LowParse.Pulse.Base
+open LowParse.Spec.Base
+open LowParse.Pulse.Base
 
 module PM = Pulse.Lib.SeqMatch
 module A = Pulse.Lib.Array

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.UTF8.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.EverParse.UTF8.fst
@@ -1,6 +1,15 @@
 module CBOR.Pulse.Raw.EverParse.UTF8
 friend CBOR.Spec.Raw.Format.UTF8
 friend CBOR.Spec.API.UTF8
+include CBOR.Spec.API.UTF8
+open Pulse.Lib.Pervasives
+open CBOR.Spec.Constants
+open CBOR.Spec.Raw.EverParse
+open LowParse.Pulse.Combinators
+open LowParse.Pulse.SeqBytes
+module U8 = FStar.UInt8
+module S = Pulse.Lib.Slice
+module SZ = FStar.SizeT
 #lang-pulse
 
 open CBOR.Spec.Raw.Format.UTF8

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Compare.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Compare.fst
@@ -1,6 +1,11 @@
 module CBOR.Pulse.Raw.Format.Compare
 friend CBOR.Pulse.Raw.Format.Match
 friend CBOR.Spec.Raw.Format
+include CBOR.Spec.Raw.Format
+include CBOR.Pulse.Raw.Compare.Base
+include CBOR.Pulse.Raw.Match
+open Pulse.Lib.Pervasives
+module I16 = FStar.Int16
 #lang-pulse
 module Bytes = CBOR.Pulse.Raw.Compare.Bytes
 module F = CBOR.Spec.Raw.EverParse

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Match.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Match.fst
@@ -1,4 +1,10 @@
 module CBOR.Pulse.Raw.Format.Match
+include CBOR.Pulse.Raw.Type
+open CBOR.Spec.Raw.Base
+open Pulse.Lib.Pervasives
+open Pulse.Lib.Slice
+module U8 = FStar.UInt8
+module Trade = Pulse.Lib.Trade
 #lang-pulse
 open CBOR.Spec.Raw.EverParse
 open LowParse.Spec.VCList

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Nondet.Compare.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Nondet.Compare.fst
@@ -1,5 +1,9 @@
 module CBOR.Pulse.Raw.Format.Nondet.Compare
 friend CBOR.Pulse.Raw.Format.Match
+include CBOR.Spec.Raw.Format
+include CBOR.Spec.Raw.Valid
+include CBOR.Pulse.Raw.Match
+open Pulse.Lib.Pervasives
 #lang-pulse
 
 module EP = CBOR.Pulse.Raw.EverParse.Nondet.Basic

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Nondet.Validate.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Nondet.Validate.fst
@@ -1,5 +1,13 @@
 module CBOR.Pulse.Raw.Format.Nondet.Validate
 friend CBOR.Spec.Raw.Format
+open CBOR.Spec.Raw.Format
+open CBOR.Spec.Raw.Nondet
+open Pulse.Lib.Pervasives
+open Pulse.Lib.Trade
+open Pulse.Lib.Slice
+module U8 = FStar.UInt8
+module SZ = FStar.SizeT
+module Trade = Pulse.Lib.Trade.Util
 #lang-pulse
 module EP = CBOR.Pulse.Raw.EverParse.Format
 module EPND = CBOR.Pulse.Raw.EverParse.Nondet.Basic

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Parse.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Parse.fst
@@ -1,5 +1,14 @@
 module CBOR.Pulse.Raw.Format.Parse
 friend CBOR.Spec.Raw.Format
+include CBOR.Pulse.Raw.Match
+open CBOR.Spec.Raw.Format
+open Pulse.Lib.Pervasives
+open Pulse.Lib.Trade
+open Pulse.Lib.Slice
+module U8 = FStar.UInt8
+module SZ = FStar.SizeT
+module Trade = Pulse.Lib.Trade.Util
+module R = CBOR.Spec.Raw.Optimal
 #lang-pulse
 open CBOR.Pulse.Raw.EverParse.Serialized.Base
 open CBOR.Spec.Raw.EverParse
@@ -19,7 +28,7 @@ let parse_fail_no_serialize
 = introduce forall v1 v2.
     (v == serialize_cbor v1 `Seq.append` v2) ==> False
   with introduce _ ==> _
-  with _ . (
+  with (
     parse_strong_prefix #parse_raw_data_item_kind #raw_data_item parse_raw_data_item (serialize_cbor v1) v
   )
 #pop-options
@@ -96,14 +105,12 @@ let cbor_parse_aux
     Classical.forall_intro_2 (fun v1 v2 -> Classical.move_requires (prf v1) v2);
     ()
 
-module Trade = Pulse.Lib.Trade.Util
 
 #push-options "--z3rlimit 16"
 
 #restart-solver
 
 module U64 = FStar.UInt64
-module U8 = FStar.UInt8
 
 #restart-solver
 #push-options "--fuel 1"

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Parse.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Parse.fst
@@ -15,6 +15,7 @@ open CBOR.Spec.Raw.EverParse
 open CBOR.Pulse.Raw.EverParse.Format
 open LowParse.Spec.Base
 open LowParse.Pulse.Base
+open CBOR.Spec.Raw.Format // must come last, to match the interface's resolution
 
 module CompareBytes = CBOR.Pulse.Raw.Compare.Bytes
 

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialize.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialize.fst
@@ -1,6 +1,11 @@
 module CBOR.Pulse.Raw.Format.Serialize
 friend CBOR.Spec.Raw.Format
 friend CBOR.Pulse.Raw.Format.Match
+include CBOR.Pulse.Raw.Match
+open CBOR.Spec.Raw.Format
+open Pulse.Lib.Trade
+module U8 = FStar.UInt8
+module S = Pulse.Lib.Slice
 #lang-pulse
 open Pulse.Lib.Pervasives
 open CBOR.Spec.Raw.EverParse

--- a/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialized.fst
+++ b/src/cbor/pulse/raw/everparse/CBOR.Pulse.Raw.Format.Serialized.fst
@@ -1,5 +1,11 @@
 module CBOR.Pulse.Raw.Format.Serialized
 friend CBOR.Pulse.Raw.Format.Match
+open CBOR.Pulse.Raw.Iterator.Base
+include CBOR.Pulse.Raw.Match
+open Pulse.Lib.Pervasives
+open Pulse.Lib.Trade
+module SZ = FStar.SizeT
+module U64 = FStar.UInt64
 #lang-pulse
 open CBOR.Spec.Raw.Base
 open CBOR.Pulse.Raw.Iterator

--- a/src/cbor/spec/raw/CBOR.Spec.API.Format.fst
+++ b/src/cbor/spec/raw/CBOR.Spec.API.Format.fst
@@ -1,4 +1,7 @@
 module CBOR.Spec.API.Format
+include CBOR.Spec.API.Type
+module U8 = FStar.UInt8
+module U64 = FStar.UInt64
 module RV = CBOR.Spec.Raw.Optimal
 module RF = CBOR.Spec.Raw.Format
 module RS = CBOR.Spec.Raw.Sort

--- a/src/cbor/spec/raw/CBOR.Spec.API.MapPairSet.fst
+++ b/src/cbor/spec/raw/CBOR.Spec.API.MapPairSet.fst
@@ -1,4 +1,6 @@
 module CBOR.Spec.API.MapPairSet
+open CBOR.Spec.API.Type
+open CBOR.Spec.Util
 module S = CBOR.Spec.Raw.Set
 
 let f : S.order elt = CBOR.Spec.Raw.Format.MapPair.map_pair_order

--- a/src/cbor/spec/raw/CBOR.Spec.API.Type.fst
+++ b/src/cbor/spec/raw/CBOR.Spec.API.Type.fst
@@ -1,5 +1,6 @@
 module CBOR.Spec.API.Type
 
+include CBOR.Spec.Constants
 module RF = CBOR.Spec.Raw.Format
 module R = CBOR.Spec.Raw.Sort
 module DM = CBOR.Spec.Raw.DataModel

--- a/src/cbor/spec/raw/CBOR.Spec.Raw.Base.fst
+++ b/src/cbor/spec/raw/CBOR.Spec.Raw.Base.fst
@@ -1,5 +1,7 @@
 module CBOR.Spec.Raw.Base
 
+include CBOR.Spec.Constants
+open CBOR.Spec.Util
 let rec holds_on_raw_data_item
   (p: (raw_data_item -> bool))
   (x: raw_data_item)

--- a/src/cbor/spec/raw/CBOR.Spec.Raw.DataModel.fst
+++ b/src/cbor/spec/raw/CBOR.Spec.Raw.DataModel.fst
@@ -1,5 +1,10 @@
 module CBOR.Spec.Raw.DataModel
 
+include CBOR.Spec.Constants
+module U64 = FStar.UInt64
+module FS = FStar.FiniteSet.Base
+module U = CBOR.Spec.Util
+open CBOR.Spec.Raw.Base
 module R = CBOR.Spec.Raw.Sort
 
 let cbor_bool

--- a/src/cbor/spec/raw/CBOR.Spec.Raw.Sort.fst
+++ b/src/cbor/spec/raw/CBOR.Spec.Raw.Sort.fst
@@ -1,4 +1,6 @@
 module CBOR.Spec.Raw.Sort
+include CBOR.Spec.Raw.Optimal
+open CBOR.Spec.Util
 open CBOR.Spec.Raw.Map
 
 let cbor_map_sort order = map_sort order

--- a/src/cbor/spec/raw/CBOR.Spec.Raw.Valid.fst
+++ b/src/cbor/spec/raw/CBOR.Spec.Raw.Valid.fst
@@ -1,5 +1,7 @@
 module CBOR.Spec.Raw.Valid
 
+include CBOR.Spec.Raw.Base
+open CBOR.Spec.Util
 let raw_data_item_size_eq_pat
   (x: raw_data_item)
 : Lemma

--- a/src/cbor/spec/raw/CBOR.Spec.Raw.fst
+++ b/src/cbor/spec/raw/CBOR.Spec.Raw.fst
@@ -2,6 +2,12 @@ module CBOR.Spec.Raw
 friend CBOR.Spec.Raw.DataModel
 friend CBOR.Spec.API.Type
 
+include CBOR.Spec.Raw.Sort
+include CBOR.Spec.API.Type
+module RF = CBOR.Spec.Raw.Format
+module R = CBOR.Spec.Raw.Sort
+module RS = CBOR.Spec.Raw.Sort
+module U = CBOR.Spec.Util
 module DM = CBOR.Spec.Raw.DataModel
 
 let mk_cbor r =

--- a/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.Format.MapPair.fst
+++ b/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.Format.MapPair.fst
@@ -1,6 +1,7 @@
 module CBOR.Spec.Raw.Format.MapPair
 friend CBOR.Spec.Raw.DataModel
 friend CBOR.Spec.API.Type
+open CBOR.Spec.API.Type
 open LowParse.Spec.Combinators
 open LowParse.Spec.VCList
 open CBOR.Spec.Raw.EverParse

--- a/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.Format.fst
+++ b/src/cbor/spec/raw/everparse/CBOR.Spec.Raw.Format.fst
@@ -1,4 +1,7 @@
 module CBOR.Spec.Raw.Format
+include CBOR.Spec.Raw.Valid
+module U8 = FStar.UInt8
+module U64 = FStar.UInt64
 module F = CBOR.Spec.Raw.EverParse
 module M = CBOR.Spec.Raw.Map
 module LP = LowParse.Spec.Combinators

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.ArrayGroup.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.ArrayGroup.fst
@@ -1,4 +1,17 @@
 module CDDL.Pulse.Serialize.Gen.ArrayGroup
+include CDDL.Pulse.Serialize.Gen.Base
+include CDDL.Pulse.Parse.ArrayGroup
+open Pulse.Lib.Pervasives
+open CBOR.Spec.API.Type
+open CBOR.Pulse.API.Base
+module Trade = Pulse.Lib.Trade.Util
+module R = Pulse.Lib.Reference
+module S = Pulse.Lib.Slice
+module U8 = FStar.UInt8
+module SZ = FStar.SizeT
+module Cbor = CBOR.Spec.API.Format
+module U64 = FStar.UInt64
+module Iterator = CDDL.Pulse.Iterator.Base
 #lang-pulse
 module SM = Pulse.Lib.SeqMatch.Util
 module GR = Pulse.Lib.GhostReference

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.Choice.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.Choice.fst
@@ -1,4 +1,10 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.Choice
+include CDDL.Pulse.Serialize.Gen.MapGroup.Base
+open Pulse.Lib.Pervasives
+open CBOR.Spec.API.Type
+open CBOR.Pulse.API.Base
+module Trade = Pulse.Lib.Trade.Util
+module U64 = FStar.UInt64
 open CDDL.Pulse.Serialize.Gen.MapGroup.Aux
 #lang-pulse
 

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.Concat.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.Concat.fst
@@ -1,4 +1,13 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.Concat
+include CDDL.Pulse.Serialize.Gen.MapGroup.Base
+open Pulse.Lib.Pervasives
+open CBOR.Spec.API.Type
+open CBOR.Pulse.API.Base
+module Trade = Pulse.Lib.Trade.Util
+module S = Pulse.Lib.Slice
+module U8 = FStar.UInt8
+module SZ = FStar.SizeT
+module U64 = FStar.UInt64
 open CDDL.Pulse.Serialize.Gen.MapGroup.Aux
 #lang-pulse
 

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.Ext.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.Ext.fst
@@ -1,4 +1,8 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.Ext
+include CDDL.Pulse.Serialize.Gen.MapGroup.Base
+open Pulse.Lib.Pervasives
+open CBOR.Spec.API.Type
+open CBOR.Pulse.API.Base
 #lang-pulse
 
 module GR = Pulse.Lib.GhostReference

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.Map.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.Map.fst
@@ -1,4 +1,12 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.Map
+include CDDL.Pulse.Serialize.Gen.MapGroup.Base
+open Pulse.Lib.Pervasives
+open CBOR.Spec.API.Type
+open CBOR.Pulse.API.Base
+module U8 = FStar.UInt8
+module SZ = FStar.SizeT
+module Cbor = CBOR.Spec.API.Format
+module U64 = FStar.UInt64
 #lang-pulse
 
 module GR = Pulse.Lib.GhostReference

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.MatchItemFor.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.MatchItemFor.fst
@@ -1,4 +1,12 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.MatchItemFor
+include CDDL.Pulse.Serialize.Gen.MapGroup.Base
+open Pulse.Lib.Pervasives
+open CBOR.Spec.API.Type
+open CBOR.Pulse.API.Base
+module S = Pulse.Lib.Slice
+module U8 = FStar.UInt8
+module SZ = FStar.SizeT
+module U64 = FStar.UInt64
 open CDDL.Pulse.Serialize.Gen.MapGroup.Aux
 #lang-pulse
 

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux1.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux1.fst
@@ -1,4 +1,15 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux1
+include CDDL.Pulse.Serialize.Gen.MapGroup.Base
+include Pulse.Lib.Pervasives
+include CBOR.Spec.API.Type
+include CBOR.Pulse.API.Base
+include CDDL.Pulse.Serialize.Gen.MapGroup.Aux
+include CDDL.Pulse.Serialize.Gen.MapGroup.Choice
+module S = Pulse.Lib.Slice
+module U8 = FStar.UInt8
+module SZ = FStar.SizeT
+module EqTest = CDDL.Spec.EqTest
+module Map = CDDL.Spec.Map
 #lang-pulse
 
 #push-options "--z3rlimit 32 --split_queries always"

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant.fst
@@ -1,5 +1,11 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux1
+module S = Pulse.Lib.Slice
+module U8 = FStar.UInt8
+module SZ = FStar.SizeT
+module U64 = FStar.UInt64
+module Map = CDDL.Spec.Map
 let impl_serialize_map_zero_or_more_iterator_gen_invariant
   (#pe: cbor_parser)
   (#minl: (cbor_min_length pe))

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma10.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma10.fst
@@ -1,5 +1,6 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma10
 
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 module Map = CDDL.Spec.Map
 module S = Pulse.Lib.Slice
 module U8 = FStar.UInt8

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma11.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma11.fst
@@ -1,5 +1,6 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma11
 
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 module Map = CDDL.Spec.Map
 module S = Pulse.Lib.Slice
 module U8 = FStar.UInt8

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma12.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma12.fst
@@ -1,5 +1,6 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma12
 
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 module Map = CDDL.Spec.Map
 module S = Pulse.Lib.Slice
 module U8 = FStar.UInt8

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma13.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma13.fst
@@ -1,5 +1,6 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma13
 
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 module Map = CDDL.Spec.Map
 module S = Pulse.Lib.Slice
 module U8 = FStar.UInt8

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma14.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma14.fst
@@ -1,5 +1,6 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma14
 
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 module Map = CDDL.Spec.Map
 module Set = CDDL.Spec.Set
 module S = Pulse.Lib.Slice

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma5.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma5.fst
@@ -1,4 +1,5 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma5
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux1
 open CDDL.Pulse.Serialize.Gen.MapGroup.Aux

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma6.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma6.fst
@@ -1,4 +1,5 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma6
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux1
 open CDDL.Pulse.Serialize.Gen.MapGroup.Aux

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma7.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma7.fst
@@ -1,5 +1,6 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma7
 
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 #push-options "--z3rlimit 64"
 
 let invariant_init

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma8.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma8.fst
@@ -1,5 +1,6 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma8
 
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 module Map = CDDL.Spec.Map
 module Set = CDDL.Spec.Set
 module S = Pulse.Lib.Slice

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma9.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma9.fst
@@ -1,5 +1,6 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma9
 
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 module Map = CDDL.Spec.Map
 module S = Pulse.Lib.Slice
 module U8 = FStar.UInt8

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.LoopBody.InsertBranch.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.LoopBody.InsertBranch.fst
@@ -1,4 +1,5 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.LoopBody.InsertBranch
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 #lang-pulse
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Proof0
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma1

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.LoopBody.ParseBranch.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.LoopBody.ParseBranch.fst
@@ -1,4 +1,5 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.LoopBody.ParseBranch
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 #lang-pulse
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Proof0
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma1

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.LoopBody.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.LoopBody.fst
@@ -1,4 +1,8 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.LoopBody
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
+open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma11
+open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma12
+open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma13
 #lang-pulse
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Proof0
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma1

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Proof0.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Proof0.fst
@@ -1,5 +1,6 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Proof0
 
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Invariant
 let impl_serialize_map_zero_or_more_iterator_gen_invariant_implies_invariant1
   #pe #minl #maxl p #key #tkey sp1 #value #tvalue #inj sp2 except em out vout size count m v0 v min max res l
 = impl_serialize_map_zero_or_more_iterator_gen_invariant_reveal p sp1 sp2 except em out vout size count m v0 v min max res l

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.fst
@@ -1,4 +1,11 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2
+include CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux1
+module Trade = Pulse.Lib.Trade.Util
+module SZ = FStar.SizeT
+module U64 = FStar.UInt64
+module Iterator = CDDL.Pulse.Iterator.Base
+module EqTest = CDDL.Spec.EqTest
+module Map = CDDL.Spec.Map
 #lang-pulse
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Proof0
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2.Lemma1

--- a/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.fst
+++ b/src/cddl/pulse/CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.fst
@@ -1,4 +1,12 @@
 module CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore
+include CDDL.Pulse.Serialize.Gen.MapGroup.Base
+open Pulse.Lib.Pervasives
+open CBOR.Spec.API.Type
+open CBOR.Pulse.API.Base
+module Trade = Pulse.Lib.Trade.Util
+module S = Pulse.Lib.Slice
+module Iterator = CDDL.Pulse.Iterator.Base
+module EqTest = CDDL.Spec.EqTest
 open CDDL.Pulse.Serialize.Gen.MapGroup.ZeroOrMore.Aux2
 #lang-pulse
 

--- a/src/cddl/spec/CDDL.Spec.AST.Print.fst
+++ b/src/cddl/spec/CDDL.Spec.AST.Print.fst
@@ -1,5 +1,6 @@
 module CDDL.Spec.AST.Print
 
+include CDDL.Spec.AST.Base
 (* Print an AST value as a string of valid F* syntax. Reparsing the
    output (in a scope where [CDDL.Spec.AST.Base] is in scope) should
    yield a value equal to the original. *)

--- a/src/cddl/spec/CDDL.Spec.ArrayGroup.fst
+++ b/src/cddl/spec/CDDL.Spec.ArrayGroup.fst
@@ -1,5 +1,7 @@
 module CDDL.Spec.ArrayGroup
 
+include CDDL.Spec.Base
+module Cbor = CBOR.Spec.API.Type
 let array_group_concat_assoc
   (#b: _)
   (a1 a2 a3: array_group b)

--- a/src/cddl/spec/CDDL.Spec.Map.fst
+++ b/src/cddl/spec/CDDL.Spec.Map.fst
@@ -1,4 +1,6 @@
 module CDDL.Spec.Map
+open CDDL.Spec.Base
+module S = CDDL.Spec.Set
 module F = FStar.FunctionalExtensionality
 module Util = CBOR.Spec.Util
 module NE = FStar.Nonempty

--- a/src/cddl/spec/CDDL.Spec.MapGroup.Base.fst
+++ b/src/cddl/spec/CDDL.Spec.MapGroup.Base.fst
@@ -1,4 +1,6 @@
 module CDDL.Spec.MapGroup.Base
+include CDDL.Spec.Base
+module Cbor = CBOR.Spec.API.Type
 open CBOR.Spec.API.Type
 
 module FE = FStar.FunctionalExtensionality

--- a/src/cddl/spec/CDDL.Spec.MapGroup.fst
+++ b/src/cddl/spec/CDDL.Spec.MapGroup.fst
@@ -1,4 +1,8 @@
 module CDDL.Spec.MapGroup
+include CDDL.Spec.MapGroup.Base
+module Map = CDDL.Spec.Map
+open CBOR.Spec.API.Type
+module Util = CBOR.Spec.Util
 module U = CBOR.Spec.Util
 
 #push-options "--z3rlimit 64"

--- a/src/cddl/spec/CDDL.Spec.Set.fst
+++ b/src/cddl/spec/CDDL.Spec.Set.fst
@@ -1,4 +1,6 @@
 module CDDL.Spec.Set
+open CDDL.Spec.Base
+module U = CBOR.Spec.Util
 module Cbor = CBOR.Spec.API.Type
 
 let dummy_cbor : Cbor.cbor = Cbor.pack (Cbor.CSimple 0uy)

--- a/src/cose/generate-rust/EverCrypt.Ed25519.fst
+++ b/src/cose/generate-rust/EverCrypt.Ed25519.fst
@@ -1,4 +1,7 @@
 module EverCrypt.Ed25519
+open Pulse.Lib.Pervasives
+module S = Pulse.Lib.Slice
+module U8 = FStar.UInt8
 open Pulse
 #lang-pulse
 

--- a/src/cose/rust/src/cbordetveraux.rs
+++ b/src/cose/rust/src/cbordetveraux.rs
@@ -25,6 +25,17 @@ fn set_bitfield_gen8(x: u8, lo: u32, hi: u32, v: u8) -> u8
 
 #[derive(PartialEq, Clone, Copy)] pub struct raw_uint64 { pub size: u8, pub value: u64 }
 
+pub(crate) fn mk_raw_uint64(x: u64) -> raw_uint64
+{
+    let size: u8 =
+        if x <= max_simple_value_additional_info as u64
+        { 0u8 }
+        else if x < 256u64
+        { 1u8 }
+        else if x < 65536u64 { 2u8 } else if x < 4294967296u64 { 3u8 } else { 4u8 };
+    raw_uint64 { size, value: x }
+}
+
 const additional_info_long_argument_8_bits: u8 = 24u8;
 
 const additional_info_unassigned_min: u8 = 28u8;
@@ -158,16 +169,9 @@ fn get_header_major_type(h: header) -> u8
     b.major_type
 }
 
-pub(crate) fn mk_raw_uint64(x: u64) -> raw_uint64
-{
-    let size: u8 =
-        if x <= max_simple_value_additional_info as u64
-        { 0u8 }
-        else if x < 256u64
-        { 1u8 }
-        else if x < 65536u64 { 2u8 } else if x < 4294967296u64 { 3u8 } else { 4u8 };
-    raw_uint64 { size, value: x }
-}
+pub(crate) const simple_value_false: u8 = 20u8;
+
+pub(crate) const simple_value_true: u8 = 21u8;
 
 fn impl_uint8_compare(x1: u8, x2: u8) -> i16
 { if x1 < x2 { -1i16 } else if x1 > x2 { 1i16 } else { 0i16 } }
@@ -369,10 +373,6 @@ fn cbor_match_compare_serialized_array(c1: cbor_serialized, c2: cbor_serialized)
 
 fn cbor_match_compare_serialized_map(c1: cbor_serialized, c2: cbor_serialized) -> i16
 { lex_compare_bytes(c1.cbor_serialized_payload, c2.cbor_serialized_payload) }
-
-pub(crate) const simple_value_false: u8 = 20u8;
-
-pub(crate) const simple_value_true: u8 = 21u8;
 
 pub(crate) fn impl_correct(s: &[u8]) -> bool
 {

--- a/src/lowparse/LowParse.Endianness.fst
+++ b/src/lowparse/LowParse.Endianness.fst
@@ -1,5 +1,8 @@
 module LowParse.Endianness
 
+include FStar.Endianness
+module S = FStar.Seq
+module U8 = FStar.UInt8
 let rec index_be_to_n'
   (b: bytes)
   (i: nat)

--- a/src/lowparse/LowParse.Low.Base.Spec.fst
+++ b/src/lowparse/LowParse.Low.Base.Spec.fst
@@ -1,5 +1,9 @@
 module LowParse.Low.Base.Spec
 
+include LowParse.Spec.Base
+include LowParse.Slice
+include LowParse.CLens
+module L = FStar.List.Tot
 module M = LowParse.Math
 module B = LowStar.Monotonic.Buffer
 module U32 = FStar.UInt32

--- a/src/lowparse/LowParse.Low.BoundedInt.fst
+++ b/src/lowparse/LowParse.Low.BoundedInt.fst
@@ -14,6 +14,8 @@ module Cast = FStar.Int.Cast
 
 friend LowParse.Spec.BoundedInt
 
+include LowParse.Spec.BoundedInt
+include LowParse.Low.Base
 inline_for_extraction
 let mul256 (x: U16.t) : Tot (y: U32.t { U32.v y == 256 `op_Star` U16.v x }) =
   assert_norm (pow2 8 == 256);

--- a/src/lowparse/LowParse.Low.Int.fst
+++ b/src/lowparse/LowParse.Low.Int.fst
@@ -14,6 +14,8 @@ module LE = LowParse.Low.Endianness
 
 friend LowParse.Spec.Int
 
+include LowParse.Spec.Int
+include LowParse.Low.Base
 let read_u8 : leaf_reader parse_u8 =
   decode_u8_injective ();
   leaf_reader_ext

--- a/src/lowparse/LowParse.SLow.BoundedInt.fst
+++ b/src/lowparse/LowParse.SLow.BoundedInt.fst
@@ -15,6 +15,8 @@ module Cast = FStar.Int.Cast
 
 friend LowParse.Spec.BoundedInt
 
+include LowParse.Spec.BoundedInt
+include LowParse.SLow.Base
 inline_for_extraction
 noextract
 let be_to_n_1 = norm [delta_attr [`%E.must_reduce]; iota; zeta; primops] (E.mk_be_to_n (EI.bounded_integer 1) 1)

--- a/src/lowparse/LowParse.SLow.Int.fst
+++ b/src/lowparse/LowParse.SLow.Int.fst
@@ -10,6 +10,8 @@ module B32 = LowParse.Bytes32
 
 friend LowParse.Spec.Int
 
+include LowParse.Spec.Int
+include LowParse.SLow.Base
 let parse32_u8 =
   decode_u8_injective ();
   make_total_constant_size_parser32 1 1ul

--- a/src/lowparse/LowParse.Spec.BCVLI.fst
+++ b/src/lowparse/LowParse.Spec.BCVLI.fst
@@ -1,4 +1,5 @@
 module LowParse.Spec.BCVLI
+include LowParse.Spec.BoundedInt // for bounded_integer
 open LowParse.Spec.Combinators // for parse_ret
 
 module U32 = FStar.UInt32

--- a/src/lowparse/LowParse.Spec.Base.fst
+++ b/src/lowparse/LowParse.Spec.Base.fst
@@ -1,4 +1,5 @@
 module LowParse.Spec.Base
+include LowParse.Norm
 include LowParse.Bytes
 
 module Seq = FStar.Seq

--- a/src/lowparse/LowParse.Spec.BoundedInt.fst
+++ b/src/lowparse/LowParse.Spec.BoundedInt.fst
@@ -1,5 +1,7 @@
 module LowParse.Spec.BoundedInt
 
+include LowParse.Spec.Base
+include LowParse.Spec.Int // for parse_u16_kind
 open LowParse.Spec.Combinators // for make_total_constant_size_parser_precond
 
 module Seq = FStar.Seq

--- a/src/lowparse/LowParse.Spec.DER.fst
+++ b/src/lowparse/LowParse.Spec.DER.fst
@@ -1,4 +1,7 @@
 module LowParse.Spec.DER
+include LowParse.Spec.Int
+include LowParse.Spec.BoundedInt
+module Cast = FStar.Int.Cast
 open LowParse.Spec.Combinators
 open LowParse.Spec.SeqBytes.Base
 // include LowParse.Spec.VLData // for in_bounds

--- a/src/lowparse/LowParse.Spec.Int.fst
+++ b/src/lowparse/LowParse.Spec.Int.fst
@@ -1,4 +1,11 @@
 module LowParse.Spec.Int
+include LowParse.Spec.Base
+module Seq = FStar.Seq
+module E = FStar.Endianness
+module U8  = FStar.UInt8
+module U16 = FStar.UInt16
+module U32 = FStar.UInt32
+module U64 = FStar.UInt64
 open LowParse.Spec.Combinators
 
 let decode_u8

--- a/src/lowparse/LowParse.Spec.ListUpTo.fst
+++ b/src/lowparse/LowParse.Spec.ListUpTo.fst
@@ -1,4 +1,7 @@
 module LowParse.Spec.ListUpTo
+include LowParse.Spec.Base
+module L = FStar.List.Tot
+module Seq = FStar.Seq
 open LowParse.Spec.Base
 open LowParse.Spec.Fuel
 open LowParse.Spec.Combinators

--- a/src/lowparse/LowParse.Spec.Recursive.fst
+++ b/src/lowparse/LowParse.Spec.Recursive.fst
@@ -1,5 +1,8 @@
 module LowParse.Spec.Recursive
 
+open LowParse.Spec.Combinators
+open LowParse.Spec.VCList
+open LowParse.WellFounded
 open LowParse.Spec.Fuel
 
 module Seq = FStar.Seq

--- a/src/lowparse/pulse/LowParse.PulseParse.IfThenElse.fst
+++ b/src/lowparse/pulse/LowParse.PulseParse.IfThenElse.fst
@@ -271,7 +271,7 @@ let seqbytes_cond_prop_lseq_bytes
        (fst (Some?.v (parse (LSB.parse_lseq_bytes clen) (Seq.slice v (SZ.v offset) (Seq.length v))))))
        == (Seq.slice v (SZ.v offset) (SZ.v off) = cst))
   with introduce _ ==> _
-  with _. (
+  with (
     let s = Seq.slice v (SZ.v offset) (Seq.length v) in
     Seq.lemma_eq_intro (Seq.slice s 0 clen) (Seq.slice v (SZ.v offset) (SZ.v off))
   )

--- a/src/qd/rfc_fstar_compiler.ml
+++ b/src/qd/rfc_fstar_compiler.ml
@@ -5481,6 +5481,10 @@ and compile tch o i (tn:typ) (p:gemstone_t) =
      if friends <> [] then (List.iter (fun f -> w o "friend %s\n" f) friends; w o "\n")
    | _ -> ());
   write_autogen o;
+  (* The implementation no longer inherits the interface's scoping declarations,
+     so it must repeat them itself. *)
+  if !types_from <> "" then w o "include %s\n\n" !types_from;
+  if !types_to <> "" then w o "include %s\n\n" (module_of_filename !types_to);
   if needs_fstar_bytes then w o "open %s\n" !bytes;
   w o "module U8 = FStar.UInt8\n";
   w o "module U16 = FStar.UInt16\n";
@@ -5527,9 +5531,10 @@ and compile tch o i (tn:typ) (p:gemstone_t) =
   let depl = List.filter (fun x -> not (basic_type x)) depl in
   let depl = List.map module_name depl in
   (List.iter (fun dep ->
-    if BatString.starts_with dep (mn^"_") then w i "include %s\n" dep
-    else w i "open %s\n" dep) depl);
+    if BatString.starts_with dep (mn^"_") then (w i "include %s\n" dep; w o "include %s\n" dep)
+    else (w i "open %s\n" dep; w o "open %s\n" dep)) depl);
   w i "\n";
+  w o "\n";
 
   let rlimit = 16 in
 	w o "#reset-options \"--using_facts_from '* -FStar.Tactics -FStar.Reflection -Pulse -PulseCore' --z3rlimit %d --z3cliopt smt.arith.nl=false --max_fuel 2 --max_ifuel 2\"\n\n" rlimit;


### PR DESCRIPTION
This adds a devcontainer for everparse, sorry if I missed an existing one.

This might also be the end of the road for F* 1/2 source file compatibility.  The new introduce/eliminate syntax doesn't work in F* 1 (neither does the interleaving probably).